### PR TITLE
log errors in pod package

### DIFF
--- a/bin/bootstrap/bootstrap.go
+++ b/bin/bootstrap/bootstrap.go
@@ -57,8 +57,8 @@ func InstallConsul(consulPod *pods.Pod) error {
 	if err != nil {
 		return util.Errorf("Can't install Consul, aborting: %s", err)
 	}
-	err = consulPod.Launch()
-	if err != nil {
+	ok, err := consulPod.Launch()
+	if err != nil || !ok {
 		return util.Errorf("Can't launch Consul, aborting: %s", err)
 	}
 	time.Sleep(time.Second * 10)
@@ -92,5 +92,6 @@ func InstallBaseAgent(agentManifest *pods.PodManifest) error {
 	if err != nil {
 		return err
 	}
-	return agentPod.Launch()
+	_, err = agentPod.Launch()
+	return err
 }

--- a/bin/preparer/main.go
+++ b/bin/preparer/main.go
@@ -41,5 +41,11 @@ func main() {
 	if preparerConfig.ConsulAddress == "" {
 		preparerConfig.ConsulAddress = "127.0.0.1:8500"
 	}
-	watchForPodManifestsForNode(preparerConfig.NodeName, preparerConfig.ConsulAddress)
+	logFile, err := os.OpenFile("/tmp/platypus", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		os.Exit(1)
+	}
+	defer logFile.Close()
+
+	watchForPodManifestsForNode(preparerConfig.NodeName, preparerConfig.ConsulAddress, logFile)
 }

--- a/pkg/pods/hoist_launchable.go
+++ b/pkg/pods/hoist_launchable.go
@@ -290,7 +290,7 @@ func (*HoistLaunchable) Type() string {
 
 func (hoistLaunchable *HoistLaunchable) InstallDir() string {
 	launchableName := hoistLaunchable.Version()
-	return path.Join(hoistLaunchable.RootDir, "installs", launchableName) // need to generalize this (no /data/pods assumption)
+	return path.Join(hoistLaunchable.RootDir, "installs", launchableName)
 }
 
 func extractTarGz(fp *os.File, dest string) (err error) {


### PR DESCRIPTION
@anthonybishopric 

Does this look like the right thing to do? I'm keeping the logging at the pod package level (we just want to know if big stuff like Install() or Launch() fail, with detailed error messages in the log message).

I also felt that the outer agent loop (preparer) should know whether a halt fully succeeded, even if we don't return an error. Maybe I should instead return a map of errors instead of a bool? LMK what you think
