### PR TITLE
fix proto parsing

### DIFF
--- a/pkg/uri/uri.go
+++ b/pkg/uri/uri.go
@@ -10,7 +10,7 @@ import (
 	"github.com/square/p2/pkg/util"
 )
 
-var leadingProto = regexp.MustCompile("^[a-zA-Z\\d\\.]+:.//.*")
+var leadingProto = regexp.MustCompile("^[a-zA-Z\\d\\.]+:.*")
 
 // URICopy Wraps opening and copying content from URIs. Will attempt
 // directly perform file copies if the uri is begins with file://, otherwise

--- a/pkg/uri/uri_test.go
+++ b/pkg/uri/uri_test.go
@@ -3,6 +3,8 @@ package uri
 import (
 	"fmt"
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path"
 	"runtime"
@@ -14,6 +16,7 @@ import (
 
 func TestLeadingProtoRegexMatchesProto(t *testing.T) {
 	Assert(t).IsTrue(leadingProto.MatchString("file:///foo/bar/baz"), "Should have matched")
+	Assert(t).IsTrue(leadingProto.MatchString("http://www.com/foo/bar/baz"), "Should have matched")
 }
 
 func TestLeadingProtoRegexDoesNotMatchPath(t *testing.T) {
@@ -47,4 +50,31 @@ func TestURIWithNoProtocolTreatedLikeLocalPath(t *testing.T) {
 	thisContents, err := ioutil.ReadFile(thisFile)
 	Assert(t).IsNil(err, "The original file could not be read")
 	Assert(t).AreEqual(string(thisContents), string(copiedContents), "The contents of the files do not match")
+}
+
+func TestCorrectlyPullsFilesOverHTTP(t *testing.T) {
+	tempdir, err := ioutil.TempDir("", "cp-dest")
+	Assert(t).IsNil(err, "Couldn't create temp dir")
+	defer os.RemoveAll(tempdir)
+
+	copied := path.Join(tempdir, "copied")
+
+	caller := util.From(runtime.Caller(0))
+
+	ts := httptest.NewServer(http.FileServer(http.Dir(caller.Dirname())))
+	Assert(t).IsTrue(leadingProto.MatchString(ts.URL), fmt.Sprintf("the http test server generated an invalid url (%s)", ts.URL))
+	defer ts.Close()
+
+	// Do not use path.Join for URLs. It will compress consecutive forward slashes.
+	// ie, http:// becomes http:/
+	source := fmt.Sprintf("%s/%s", ts.URL, path.Base(caller.Filename))
+	Assert(t).IsTrue(leadingProto.MatchString(source), fmt.Sprintf("The url %s should have had a proto", source))
+
+	err = URICopy(source, copied)
+	Assert(t).IsNil(err, "the file should have been downloaded")
+
+	copiedContents, err := ioutil.ReadFile(copied)
+	thisContents, err := ioutil.ReadFile(caller.Filename)
+
+	Assert(t).AreEqual(string(thisContents), string(copiedContents), fmt.Sprintf("Should have downloaded the file correctly from (%s)", source))
 }

--- a/pkg/util/stack.go
+++ b/pkg/util/stack.go
@@ -18,10 +18,14 @@ func From(pc uintptr, file string, line int, ok bool) *Caller {
 	return &Caller{file}
 }
 
+func (c *Caller) Dirname() string {
+	return path.Dir(c.Filename)
+}
+
 func (c *Caller) ExpandPath(pathstr string) string {
-	return path.Join(path.Dir(c.Filename), pathstr)
+	return path.Join(c.Dirname(), pathstr)
 }
 
 func (c *Caller) Glob(pattern string) ([]string, error) {
-	return filepath.Glob(path.Join(path.Dir(c.Filename), pattern))
+	return filepath.Glob(path.Join(c.Dirname(), pattern))
 }


### PR DESCRIPTION
@mpuncel dumb regex mistake, then looked at the RFC for URLs (http://www.ietf.org/rfc/rfc1738.txt) and realized the `//` is technically protocol specific. 
