### PR TITLE
make expanded files owned by RunAs

### DIFF
--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/runit"
-	"github.com/square/p2/pkg/user"
+	"github.com/square/p2/pkg/uri"
 	"github.com/square/p2/pkg/util"
 
 	"github.com/Sirupsen/logrus"
@@ -124,7 +124,7 @@ func (pod *Pod) writeCurrentManifest(manifest *PodManifest) (string, error) {
 	lastManifest := path.Join(tmpDir, "last_manifest.yaml")
 
 	if _, err := os.Stat(pod.CurrentPodManifestPath()); err == nil {
-		err = os.Rename(pod.CurrentPodManifestPath(), lastManifest)
+		err = uri.URICopy(pod.CurrentPodManifestPath(), lastManifest)
 		if err != nil && !os.IsNotExist(err) {
 			return "", err
 		}
@@ -213,10 +213,6 @@ func (pod *Pod) Install(manifest *PodManifest) error {
 	err := os.MkdirAll(podHome, 0755) // this dir needs to be owned by different user at some point
 	if err != nil {
 		return util.Errorf("Could not create pod home: %s", err)
-	}
-	_, err = user.CreateUser(manifest.ID(), podHome)
-	if err != nil && err != user.AlreadyExists {
-		return err
 	}
 
 	// we may need to write config files to a unique directory per pod version, depending on restart semantics. Need

--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os/exec"
 	osuser "os/user"
+	"strconv"
 
 	"github.com/square/p2/pkg/util"
 )
@@ -28,4 +29,20 @@ func CreateUser(username string, homedir string) (*osuser.User, error) {
 		return nil, util.Errorf("Couldn't add new user %s: %s: %s", username, err, errout.String())
 	}
 	return osuser.Lookup(username)
+}
+
+func IDs(username string) (int, int, error) {
+	user, err := osuser.Lookup(username)
+	if err != nil {
+		return 0, 0, err
+	}
+	uid, err := strconv.ParseInt(user.Uid, 10, 0)
+	if err != nil {
+		return 0, 0, err
+	}
+	gid, err := strconv.ParseInt(user.Gid, 10, 0)
+	if err != nil {
+		return 0, 0, err
+	}
+	return int(uid), int(gid), nil
 }


### PR DESCRIPTION
This also fixes two bugs where `os.Rename` failed due to moving across drives. @mpuncel  @petertseng 
