### PR TITLE
standardize runit service names. if bin/launch is an executable, the run...

### DIFF
--- a/pkg/pods/hoist_launchable.go
+++ b/pkg/pods/hoist_launchable.go
@@ -223,7 +223,7 @@ func (hoistLaunchable *HoistLaunchable) Executables(serviceBuilder *runit.Servic
 	// ideally a launchable will have just one launch script someday (can't be
 	// a dir)
 	if !(binLaunchInfo.IsDir()) {
-		serviceName := hoistLaunchable.Id // use the ID of the launchable as its unique Runit service name
+		serviceName := strings.Join([]string{hoistLaunchable.Id, "__", "launch"}, "")
 		servicePath := path.Join(serviceBuilder.RunitRoot, serviceName)
 		runitService := &runit.Service{servicePath, serviceName}
 		executable := &HoistExecutable{*runitService, binLaunchPath}

--- a/pkg/pods/hoist_launchable_test.go
+++ b/pkg/pods/hoist_launchable_test.go
@@ -111,6 +111,17 @@ func TestSingleRunitService(t *testing.T) {
 	Assert(t).AreEqual(executables[0].Path, expectedServicePaths[0], "Runit service paths from launchable did not match expected")
 }
 
+func TestLaunchExecutableOnlyRunitService(t *testing.T) {
+	launchable := FakeHoistLaunchableForDir("launch_script_only_test_hoist_launchable")
+	Assert(t).IsNil(launchable.MakeCurrent(), "Should have been made current")
+	executables, err := launchable.Executables(runit.DefaultBuilder)
+	Assert(t).IsNil(err, "Error occurred when obtaining runit services for launchable")
+
+	expectedServicePaths := []string{"/var/service/testPod__testLaunchable__launch"}
+	Assert(t).AreEqual(len(executables), 1, "Found an unexpected number of runit services")
+	Assert(t).AreEqual(executables[0].Path, expectedServicePaths[0], "Runit service paths from launchable did not match expected")
+}
+
 func TestDisable(t *testing.T) {
 	hoistLaunchable := FakeHoistLaunchableForDir("successful_scripts_test_hoist_launchable")
 


### PR DESCRIPTION
...it service will now be called `<podname>__<launchablename>__launch` whereas it used to be called `<podname>__<launchablename>`

@anthonybishopric @petertseng 