### PR TITLE
Intent key/value path

### DIFF
--- a/bin/p2-watch/main.go
+++ b/bin/p2-watch/main.go
@@ -29,7 +29,7 @@ func main() {
 			log.Fatalf("Could not get the hostname to do scheduling: %s", err)
 		}
 	}
-	path := fmt.Sprintf("nodes/%s", node)
+	path := fmt.Sprintf("intent/%s", node)
 
 	log.Printf("Watching manifests at %s\n", path)
 

--- a/bin/p2-watch/main.go
+++ b/bin/p2-watch/main.go
@@ -29,7 +29,7 @@ func main() {
 			log.Fatalf("Could not get the hostname to do scheduling: %s", err)
 		}
 	}
-	path := fmt.Sprintf("intent/%s", node)
+	path := fmt.Sprintf("%s/%s", intent.INTENT_TREE, node)
 
 	log.Printf("Watching manifests at %s\n", path)
 

--- a/pkg/intent/intent.go
+++ b/pkg/intent/intent.go
@@ -104,7 +104,7 @@ func (i *Store) WatchPods(path string, quit <-chan struct{}, errChan chan<- erro
 }
 
 func (i *Store) IntentKey(node string, manifest pods.PodManifest) string {
-	return fmt.Sprintf("nodes/%s/%s", node, manifest.ID())
+	return fmt.Sprintf("intent/%s/%s", node, manifest.ID())
 }
 
 func (i *Store) SetPod(node string, manifest pods.PodManifest) (time.Duration, error) {

--- a/pkg/intent/intent.go
+++ b/pkg/intent/intent.go
@@ -14,6 +14,8 @@ import (
 	"github.com/square/p2/pkg/util"
 )
 
+const INTENT_TREE string = "/intent"
+
 type ConsulClient interface {
 	KV() *consulapi.KV
 }
@@ -104,7 +106,7 @@ func (i *Store) WatchPods(path string, quit <-chan struct{}, errChan chan<- erro
 }
 
 func (i *Store) IntentKey(node string, manifest pods.PodManifest) string {
-	return fmt.Sprintf("intent/%s/%s", node, manifest.ID())
+	return fmt.Sprintf("%s/%s/%s", INTENT_TREE, node, manifest.ID())
 }
 
 func (i *Store) SetPod(node string, manifest pods.PodManifest) (time.Duration, error) {

--- a/pkg/intent/intent_test.go
+++ b/pkg/intent/intent_test.go
@@ -2,6 +2,7 @@ package intent
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	. "github.com/anthonybishopric/gotcha"
@@ -80,7 +81,7 @@ func errorWatch(kv ppkv.KV, prefix string, opts consulapi.QueryOptions, kvCh cha
 func TestHappyPathPodWatch(t *testing.T) {
 	i := Store{Options{}, consulapi.DefaultConfig(), happyWatch, fakeClient{}}
 
-	path := "/intent/ama1.dfw.square"
+	path := fmt.Sprintf("%s/ama1.dfw.square", INTENT_TREE)
 	quit := make(chan struct{})
 	defer close(quit)
 	errChan := make(chan error)
@@ -97,7 +98,7 @@ func TestHappyPathPodWatch(t *testing.T) {
 func TestErrorPath(t *testing.T) {
 	i := Store{Options{}, consulapi.DefaultConfig(), errorWatch, fakeClient{}}
 
-	path := "/intent/ama1.dfw.square"
+	path := fmt.Sprintf("%s/ama1.dfw.square", INTENT_TREE)
 	quit := make(chan struct{})
 	defer close(quit)
 	errChan := make(chan error)
@@ -115,7 +116,7 @@ func TestErrorPath(t *testing.T) {
 func TestErrorsAndPodsReturned(t *testing.T) {
 	i := Store{Options{}, consulapi.DefaultConfig(), partiallyHappyWatch, fakeClient{}}
 
-	path := "/intent/ama1.dfw.square"
+	path := fmt.Sprintf("%s/ama1.dfw.square", INTENT_TREE)
 	quit := make(chan struct{})
 	defer close(quit)
 	errChan := make(chan error)

--- a/pkg/intent/intent_test.go
+++ b/pkg/intent/intent_test.go
@@ -80,7 +80,7 @@ func errorWatch(kv ppkv.KV, prefix string, opts consulapi.QueryOptions, kvCh cha
 func TestHappyPathPodWatch(t *testing.T) {
 	i := Store{Options{}, consulapi.DefaultConfig(), happyWatch, fakeClient{}}
 
-	path := "/nodes/ama1.dfw.square"
+	path := "/intent/ama1.dfw.square"
 	quit := make(chan struct{})
 	defer close(quit)
 	errChan := make(chan error)
@@ -97,7 +97,7 @@ func TestHappyPathPodWatch(t *testing.T) {
 func TestErrorPath(t *testing.T) {
 	i := Store{Options{}, consulapi.DefaultConfig(), errorWatch, fakeClient{}}
 
-	path := "/nodes/ama1.dfw.square"
+	path := "/intent/ama1.dfw.square"
 	quit := make(chan struct{})
 	defer close(quit)
 	errChan := make(chan error)
@@ -115,7 +115,7 @@ func TestErrorPath(t *testing.T) {
 func TestErrorsAndPodsReturned(t *testing.T) {
 	i := Store{Options{}, consulapi.DefaultConfig(), partiallyHappyWatch, fakeClient{}}
 
-	path := "/nodes/ama1.dfw.square"
+	path := "/intent/ama1.dfw.square"
 	quit := make(chan struct{})
 	defer close(quit)
 	errChan := make(chan error)

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -32,7 +32,7 @@ func WatchForPodManifestsForNode(nodeName string, consulAddress string, hooksDir
 		return
 	}
 
-	path := fmt.Sprintf("nodes/%s", nodeName)
+	path := fmt.Sprintf("intent/%s", nodeName)
 
 	// This allows us to signal the goroutine watching consul to quit
 	watcherQuit := make(<-chan struct{})

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -32,7 +32,7 @@ func WatchForPodManifestsForNode(nodeName string, consulAddress string, hooksDir
 		return
 	}
 
-	path := fmt.Sprintf("intent/%s", nodeName)
+	path := fmt.Sprintf("%s/%s", intent.INTENT_TREE, nodeName)
 
 	// This allows us to signal the goroutine watching consul to quit
 	watcherQuit := make(<-chan struct{})


### PR DESCRIPTION
This PR changes the path for keys in the intent store to `/intent/<node>/<manifestid>` as we discussed on Friday.