### PR TITLE
Add service registration in pkg/intent

### DIFF
--- a/pkg/intent/intent.go
+++ b/pkg/intent/intent.go
@@ -120,10 +120,10 @@ func (i *Store) SetPod(node string, manifest pods.PodManifest) (time.Duration, e
 	podService := &consulapi.AgentServiceRegistration{
 		Name: manifest.ID(),
 	}
-	if manifest.Port != 0 {
+	if manifest.StatusPort != 0 {
 		podService.Check = &consulapi.AgentServiceCheck{
 			// prints the HTTP response on stderr, while exiting 0 if the status code is 200
-			Script:   fmt.Sprintf(`if [[ $(curl 0.0.0.0:%v/_status -s -o /dev/stderr -w "%%{http_code}") == "200" ]] ; then exit 0 ; else exit 2; fi`, manifest.Port),
+			Script:   fmt.Sprintf(`if [[ $(curl 0.0.0.0:%v/_status -s -o /dev/stderr -w "%%{http_code}") == "200" ]] ; then exit 0 ; else exit 2; fi`, manifest.StatusPort),
 			Interval: "5s", // magic number alert
 		}
 	}

--- a/pkg/intent/intent.go
+++ b/pkg/intent/intent.go
@@ -18,6 +18,7 @@ const INTENT_TREE string = "/intent"
 
 type ConsulClient interface {
 	KV() *consulapi.KV
+	Agent() *consulapi.Agent
 }
 
 type Options struct {

--- a/pkg/intent/intent.go
+++ b/pkg/intent/intent.go
@@ -116,11 +116,24 @@ func (i *Store) SetPod(node string, manifest pods.PodManifest) (time.Duration, e
 	if err != nil {
 		return 0, err
 	}
+
+	podService := &consulapi.AgentServiceRegistration{
+		Name: manifest.ID(),
+		Check: &consulapi.AgentServiceCheck{
+			// prints the HTTP response on stderr, while exiting 0 if the status code is 200
+			Script:   fmt.Sprintf(`if [[ $(curl 0.0.0.0:%v/_status -s -o /dev/stderr -w "%%{http_code}") == "200" ]] ; then exit 0 ; else exit 2; fi`, manifest.Port),
+			Interval: "5s", // magic number alert
+		},
+	}
+	err = i.client.Agent().ServiceRegister(podService)
+	if err != nil {
+		return 0, err
+	}
+
 	keyPair := &consulapi.KVPair{
 		Key:   i.IntentKey(node, manifest),
 		Value: buf.Bytes(),
 	}
-
 	writeMeta, err := i.client.KV().Put(keyPair, nil)
 	return writeMeta.RequestTime, err
 }

--- a/pkg/intent/intent.go
+++ b/pkg/intent/intent.go
@@ -119,11 +119,13 @@ func (i *Store) SetPod(node string, manifest pods.PodManifest) (time.Duration, e
 
 	podService := &consulapi.AgentServiceRegistration{
 		Name: manifest.ID(),
-		Check: &consulapi.AgentServiceCheck{
+	}
+	if manifest.Port != 0 {
+		podService.Check = &consulapi.AgentServiceCheck{
 			// prints the HTTP response on stderr, while exiting 0 if the status code is 200
 			Script:   fmt.Sprintf(`if [[ $(curl 0.0.0.0:%v/_status -s -o /dev/stderr -w "%%{http_code}") == "200" ]] ; then exit 0 ; else exit 2; fi`, manifest.Port),
 			Interval: "5s", // magic number alert
-		},
+		}
 	}
 	err = i.client.Agent().ServiceRegister(podService)
 	if err != nil {

--- a/pkg/intent/intent_test.go
+++ b/pkg/intent/intent_test.go
@@ -18,6 +18,11 @@ func (f fakeClient) KV() *consulapi.KV {
 	return client.KV()
 }
 
+func (f fakeClient) Agent() *consulapi.Agent {
+	client, _ := consulapi.NewClient(consulapi.DefaultConfig())
+	return client.Agent()
+}
+
 func makePodKv(key string, value string) *consulapi.KVPair {
 	return &consulapi.KVPair{
 		Key:   key,

--- a/pkg/pods/manifest_parser.go
+++ b/pkg/pods/manifest_parser.go
@@ -27,7 +27,7 @@ type PodManifest struct {
 	Id                string                      `yaml:"id"` // public for yaml marshaling access. Use ID() instead.
 	LaunchableStanzas map[string]LaunchableStanza `yaml:"launchables"`
 	Config            map[string]interface{}      `yaml:"config"`
-	Port              int                         `yaml:"port"`
+	StatusPort        int                         `yaml:"status_port"`
 }
 
 func (manifest *PodManifest) ID() string {

--- a/pkg/pods/manifest_parser.go
+++ b/pkg/pods/manifest_parser.go
@@ -27,6 +27,7 @@ type PodManifest struct {
 	Id                string                      `yaml:"id"` // public for yaml marshaling access. Use ID() instead.
 	LaunchableStanzas map[string]LaunchableStanza `yaml:"launchables"`
 	Config            map[string]interface{}      `yaml:"config"`
+	Port              int                         `yaml:"port"`
 }
 
 func (manifest *PodManifest) ID() string {

--- a/pkg/pods/manifest_parser_test.go
+++ b/pkg/pods/manifest_parser_test.go
@@ -34,6 +34,7 @@ launchables:
     location: https://localhost:4444/foo/bar/baz.tar.gz
 config:
   ENVIRONMENT: staging
+port: 8000
 `
 }
 
@@ -50,6 +51,8 @@ func TestPodManifestCanBeWritten(t *testing.T) {
 	}
 	manifest.LaunchableStanzas["my-app"] = launchable
 	manifest.Config["ENVIRONMENT"] = "staging"
+
+	manifest.Port = 8000
 
 	buff := bytes.Buffer{}
 	manifest.Write(&buff)
@@ -76,7 +79,7 @@ func TestPodManifestCanReportItsSHA(t *testing.T) {
 	Assert(t).IsNil(err, "should not have erred when building manifest")
 	val, err := manifest.SHA()
 	Assert(t).IsNil(err, "should not have erred when getting SHA")
-	Assert(t).AreEqual("f176d13fd3ec91e21bc163ec8b2e937df3625ea5", val, "SHA mismatched expectations")
+	Assert(t).AreEqual("20c18072f4170e5feec92b9f83a1774f2e53ac52", val, "SHA mismatched expectations")
 }
 
 func TestNilPodManifestHasEmptySHA(t *testing.T) {

--- a/pkg/pods/manifest_parser_test.go
+++ b/pkg/pods/manifest_parser_test.go
@@ -34,7 +34,7 @@ launchables:
     location: https://localhost:4444/foo/bar/baz.tar.gz
 config:
   ENVIRONMENT: staging
-port: 8000
+status_port: 8000
 `
 }
 
@@ -52,7 +52,7 @@ func TestPodManifestCanBeWritten(t *testing.T) {
 	manifest.LaunchableStanzas["my-app"] = launchable
 	manifest.Config["ENVIRONMENT"] = "staging"
 
-	manifest.Port = 8000
+	manifest.StatusPort = 8000
 
 	buff := bytes.Buffer{}
 	manifest.Write(&buff)
@@ -79,7 +79,7 @@ func TestPodManifestCanReportItsSHA(t *testing.T) {
 	Assert(t).IsNil(err, "should not have erred when building manifest")
 	val, err := manifest.SHA()
 	Assert(t).IsNil(err, "should not have erred when getting SHA")
-	Assert(t).AreEqual("20c18072f4170e5feec92b9f83a1774f2e53ac52", val, "SHA mismatched expectations")
+	Assert(t).AreEqual("5a92dd996feb6c9bd5c451d2b36282cc7804f911", val, "SHA mismatched expectations")
 }
 
 func TestNilPodManifestHasEmptySHA(t *testing.T) {


### PR DESCRIPTION
Now when you intent.SetPod, p2 will also register a Consul service. The ID of the service is that of the manifest itself. p2 also associates a health check with the new service, which is basically a curl on its `/_status` endpoint.

I'm going to do some integration tests by hand because I want to see if this code actually works, but look it over and let me know what's missing.