### PR TITLE
Remove leading slash on intent path

### DIFF
--- a/pkg/intent/intent.go
+++ b/pkg/intent/intent.go
@@ -14,7 +14,7 @@ import (
 	"github.com/square/p2/pkg/util"
 )
 
-const INTENT_TREE string = "/intent"
+const INTENT_TREE string = "intent"
 
 type ConsulClient interface {
 	KV() *consulapi.KV


### PR DESCRIPTION
moral of the story: path.Join is correct, string concatenation is incorrect https://github.com/armon/consul-api/blob/master/kv.go#L171

I looked at all the references to INTENT_TREE and they all look safe to me with the leading slash removed, but I've already screwed up twice on this change, so some extra eyes would be welcome.