### PR TITLE
Block on net.Listen in logger socket test

### DIFF
--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -72,13 +72,13 @@ func TestAddSocketHook(t *testing.T) {
 	socket_location := "test_socket.sock"
 	os.Remove(socket_location)
 
+	l, err := net.Listen("unix", socket_location)
+	Assert(t).IsNil(err, "Got an unexpected error when trying to listen to socket")
+	defer l.Close()
+
 	// make goroutine to listen to socket and write what it gets to channel
 	out := make(chan []byte)
 	go func() {
-		l, err := net.Listen("unix", socket_location)
-		Assert(t).IsNil(err, "Got an unexpected error when trying to listen to socket")
-		defer l.Close()
-
 		fd, err := l.Accept()
 		Assert(t).IsNil(err, "Got an unexpected error when trying to call accept() on socket")
 		buf := make([]byte, 1024)
@@ -91,7 +91,7 @@ func TestAddSocketHook(t *testing.T) {
 	time.Sleep(1 * time.Millisecond)
 
 	// Add socket hook and log something
-	err := logger.AddHook(OUT_SOCKET, socket_location)
+	err = logger.AddHook(OUT_SOCKET, socket_location)
 	Assert(t).IsNil(err, "Got an unexpected error when adding a socket logging hook")
 	logger.WithFields(logrus.Fields{}).Error("some message")
 


### PR DESCRIPTION
Sometimes this test fails because the scheduler doesn't execute the
net.Listen right away. Then the logger fires the hook expecting the
socket to be there, and it isn't yet (because nobody is listening).

To eliminate these sporadic errors, we can just move the Listen call
out of the goroutine, so that the test is blocked until the socket is
ready.