### PR TITLE
Allow p2-launch to specify user

### DIFF
--- a/bin/p2-launch/main.go
+++ b/bin/p2-launch/main.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	manifestURI = kingpin.Arg("manifest", "a path or url to a pod manifest that will be installed and launched immediately.").String()
+	runUser     = kingpin.Flag("runas", "the user that the pod will execute as. Defaults to the pod's ID.").String()
 )
 
 func main() {
@@ -33,6 +34,9 @@ func main() {
 	}
 
 	pod := pods.NewPod(manifest.ID(), pods.PodPath(manifest.ID()))
+	if runUser != nil && *runUser != "" {
+		pod.RunAs = *runUser
+	}
 	err = pod.Install(manifest)
 	if err != nil {
 		log.Fatalf("Could not install manifest %s: %s", manifest.ID(), err)


### PR DESCRIPTION
Encountered this issue while bootstrapping a new universe cluster, because I use `p2-launch` to start consul as opposed to `p2-bootstrap`. Pretty straightforward fix