### PR TITLE
Inspect

### DIFF
--- a/bin/p2-inspect/README.md
+++ b/bin/p2-inspect/README.md
@@ -1,0 +1,67 @@
+# p2-inspect
+
+`p2-inspect` is a tool for examining the state of a p2 cluster. Given the address of any consul agent, it will pull the manifest SHAs and health checks for all the pods running in the cluster, across all its nodes. Example:
+
+```bash
+$ p2-inspect | python -mjson.tool
+```
+
+```json
+{
+    "isup": {
+        "aws1.example.com": {
+            "health_check": {
+                "output": "[/data/pods/isup/isup/installs/isup_vsjlzlxvnkizuxmkutqmkqhwukyryztuxhusnkpm/bin/launch]\n[PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin TERM=linux RUNLEVEL=3 PREVLEVEL=N UPSTART_EVENTS=runlevel UPSTART_JOB=runit UPSTART_INSTANCE= CONFIG_PATH=/data/pods/isup/config/isup_717cc0d58df240e2668c865cdc063d715446e6db.yaml]\n",
+                "status": "passing"
+            },
+            "intent_manifest_sha": "717cc0d58df240e2668c865cdc063d715446e6db",
+            "reality_manifest_sha": "717cc0d58df240e2668c865cdc063d715446e6db"
+        },
+        "aws2.example.com": {
+            "health_check": {
+                "output": "[/data/pods/isup/isup/installs/isup_tkkhnurngovsomvzikznymgmluohzjvniwzrtpxq/bin/launch]\n[PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin TERM=linux RUNLEVEL=3 PREVLEVEL=N UPSTART_EVENTS=runlevel UPSTART_JOB=runit UPSTART_INSTANCE= CONFIG_PATH=/data/pods/isup/config/isup_b56d3c3fd3c264841c8aad6a9ce6f06271a62dc6.yaml]\n",
+                "status": "passing"
+            },
+            "intent_manifest_sha": "b56d3c3fd3c264841c8aad6a9ce6f06271a62dc6",
+            "reality_manifest_sha": "b56d3c3fd3c264841c8aad6a9ce6f06271a62dc6"
+        }
+    },
+    "p2-preparer": {
+        "aws1.example.com": {
+            "intent_manifest_sha": "9b9c7cb38b9a68564d6d582c05298cd3dab02e9d",
+            "reality_manifest_sha": "9b9c7cb38b9a68564d6d582c05298cd3dab02e9d"
+        },
+        "aws2.example.com": {
+            "intent_manifest_sha": "9b9c7cb38b9a68564d6d582c05298cd3dab02e9d",
+            "reality_manifest_sha": "9b9c7cb38b9a68564d6d582c05298cd3dab02e9d"
+        },
+        "aws3.example.com": {
+            "intent_manifest_sha": "9b9c7cb38b9a68564d6d582c05298cd3dab02e9d",
+            "reality_manifest_sha": "9b9c7cb38b9a68564d6d582c05298cd3dab02e9d"
+        }
+    }
+}
+```
+
+This indicates that there are three nodes running the `p2-preparer` pod. This pod has no health check; hence there is no `health_check` object in the JSON. Meanwhile, there are also two instances of the `isup` pod. These pods both have passing health checks, and their health check scripts produced some output that you can see in the JSON above.
+
+You can filter by pod ID, by node name, or by both:
+
+```bash
+$ p2-inspect --node aws1.example.com --pod isup | python -m json.tool
+```
+
+```json
+{
+    "isup": {
+        "aws1.example.com": {
+            "health_check": {
+                "output": "[/data/pods/isup/isup/installs/isup_vsjlzlxvnkizuxmkutqmkqhwukyryztuxhusnkpm/bin/launch]\n[PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin TERM=linux RUNLEVEL=3 PREVLEVEL=N UPSTART_EVENTS=runlevel UPSTART_JOB=runit UPSTART_INSTANCE= CONFIG_PATH=/data/pods/isup/config/isup_717cc0d58df240e2668c865cdc063d715446e6db.yaml]\n",
+                "status": "passing"
+            },
+            "intent_manifest_sha": "717cc0d58df240e2668c865cdc063d715446e6db",
+            "reality_manifest_sha": "717cc0d58df240e2668c865cdc063d715446e6db"
+        }
+    }
+}
+```

--- a/bin/p2-inspect/main.go
+++ b/bin/p2-inspect/main.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/armon/consul-api"
+	"github.com/square/p2/pkg/intent"
+	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/reality"
+	"gopkg.in/alecthomas/kingpin.v1"
+)
+
+var (
+	consulUrl      = kingpin.Flag("consul", "The hostname and port of a consul agent in the p2 cluster. Defaults to 0.0.0.0:8500.").String()
+	filterNodeName = kingpin.Flag("node", "The node to inspect. By default, all nodes are shown.").String()
+	filterPodId    = kingpin.Flag("pod", "The pod manifest ID to inspect. By default, all pods are shown.").String()
+)
+
+const (
+	INTENT_SOURCE = iota
+	REALITY_SOURCE
+)
+
+type NodePodStatus struct {
+	NodeName           string      `json:"node,omitempty"`
+	PodId              string      `json:"pod,omitempty"`
+	IntentManifestSHA  string      `json:"intent_manifest_sha"`
+	RealityManifestSHA string      `json:"reality_manifest_sha"`
+	Health             *NodeHealth `json:"health_check,omitempty"`
+}
+
+type NodeHealth struct {
+	Status string `json:"status"`
+	Output string `json:"output"`
+}
+
+func main() {
+	kingpin.Version("0.0.1")
+	kingpin.Parse()
+
+	client, err := consulapi.NewClient(&consulapi.Config{
+		Address: *consulUrl,
+	})
+	if err != nil {
+		log.Fatalf("Could not open consul client: %s", err)
+	}
+
+	intents, _, err := client.KV().List(intent.INTENT_TREE, nil)
+	if err != nil {
+		log.Fatalf("Could not list intent kvpairs: %s", err)
+	}
+	realities, _, err := client.KV().List(reality.REALITY_TREE, nil)
+	if err != nil {
+		log.Fatalf("Could not list reality kvpairs: %s", err)
+	}
+
+	statusMap := make(map[string]map[string]NodePodStatus)
+
+	for _, kvp := range intents {
+		if addKVPToMap(kvp, INTENT_SOURCE, *filterNodeName, *filterPodId, statusMap) != nil {
+			log.Fatal(err)
+		}
+	}
+
+	for _, kvp := range realities {
+		if addKVPToMap(kvp, REALITY_SOURCE, *filterNodeName, *filterPodId, statusMap) != nil {
+			log.Fatal(err)
+		}
+	}
+
+	for podId := range statusMap {
+		checks, _, err := client.Health().Checks(podId, nil)
+		if err != nil {
+			log.Fatalf("Could not retrieve health checks for pod %s: %s", podId, err)
+		}
+
+		for _, check := range checks {
+			if *filterNodeName != "" && check.Node != *filterNodeName {
+				continue
+			}
+
+			old := statusMap[podId][check.Node]
+			old.Health = &NodeHealth{
+				Status: check.Status,
+				Output: check.Output,
+			}
+			statusMap[podId][check.Node] = old
+		}
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.Encode(statusMap)
+}
+
+func addKVPToMap(kvp *consulapi.KVPair, source int, filterNode, filterPod string, statuses map[string]map[string]NodePodStatus) error {
+	keySegs := strings.Split(kvp.Key, "/")
+	nodeName := keySegs[1]
+	podId := keySegs[2]
+
+	if filterNode != "" && nodeName != filterNode {
+		return nil
+	}
+	if filterPod != "" && podId != filterPod {
+		return nil
+	}
+
+	if statuses[podId] == nil {
+		statuses[podId] = make(map[string]NodePodStatus)
+	}
+	old := statuses[podId][nodeName]
+
+	manifest, err := pods.PodManifestFromBytes(kvp.Value)
+	if err != nil {
+		return err
+	}
+	manifestSHA, err := manifest.SHA()
+	if err != nil {
+		return err
+	}
+
+	switch source {
+	case INTENT_SOURCE:
+		if old.IntentManifestSHA != "" {
+			return fmt.Errorf("Two intent manifests for node %s pod %s", nodeName, podId)
+		}
+		old.IntentManifestSHA = manifestSHA
+	case REALITY_SOURCE:
+		if old.RealityManifestSHA != "" {
+			return fmt.Errorf("Two reality manifests for node %s pod %s", nodeName, podId)
+		}
+		old.RealityManifestSHA = manifestSHA
+	}
+
+	statuses[podId][nodeName] = old
+	return nil
+}


### PR DESCRIPTION
Capabilities:

- retrieve SHAs from intent and reality stores for all pods on all nodes in the cluster
- filter to a single pod ID or a single node (or both)
- retrieves health check statuses and includes them in the output
- output is unindented json

Pretty printing can be implemented via `p2-inspect | python -mjson.tool`