### PR TITLE
version bump

### DIFF
--- a/bin/p2-bin2pod/main.go
+++ b/bin/p2-bin2pod/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/uri"
+	"github.com/square/p2/pkg/version"
 	"gopkg.in/alecthomas/kingpin.v1"
 )
 
@@ -69,6 +70,7 @@ func activeDir() string {
 }
 
 func main() {
+	bin2pod.Version(version.VERSION)
 	bin2pod.Parse(os.Args[1:])
 
 	res := Result{}

--- a/bin/p2-bootstrap/bootstrap.go
+++ b/bin/p2-bootstrap/bootstrap.go
@@ -8,6 +8,7 @@ import (
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/util"
+	"github.com/square/p2/pkg/version"
 	"gopkg.in/alecthomas/kingpin.v1"
 )
 
@@ -19,7 +20,7 @@ var (
 )
 
 func main() {
-	kingpin.Version("0.0.1")
+	kingpin.Version(version.VERSION)
 	kingpin.Parse()
 	log.Println("Starting bootstrap")
 	agentManifest, err := pods.PodManifestFromPath(*agentManifestPath)

--- a/bin/p2-inspect/main.go
+++ b/bin/p2-inspect/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/armon/consul-api"
 	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/version"
 	"gopkg.in/alecthomas/kingpin.v1"
 )
 
@@ -37,7 +38,7 @@ type NodeHealth struct {
 }
 
 func main() {
-	kingpin.Version("0.0.1")
+	kingpin.Version(version.VERSION)
 	kingpin.Parse()
 
 	store := kp.NewStore(kp.Options{Address: *consulUrl})

--- a/bin/p2-launch/main.go
+++ b/bin/p2-launch/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/uri"
+	"github.com/square/p2/pkg/version"
 	"gopkg.in/alecthomas/kingpin.v1"
 )
 
@@ -16,7 +17,7 @@ var (
 )
 
 func main() {
-	kingpin.Version("0.0.1")
+	kingpin.Version(version.VERSION)
 	kingpin.Parse()
 	localMan, err := ioutil.TempFile("", "tempmanifest")
 	defer os.Remove(localMan.Name())

--- a/bin/p2-schedule/main.go
+++ b/bin/p2-schedule/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/version"
 	"gopkg.in/alecthomas/kingpin.v1"
 )
 
@@ -17,7 +18,7 @@ var (
 )
 
 func main() {
-	kingpin.Version("0.0.1")
+	kingpin.Version(version.VERSION)
 	kingpin.Parse()
 
 	store := kp.NewStore(kp.Options{})

--- a/bin/p2-watch/main.go
+++ b/bin/p2-watch/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/version"
 	"gopkg.in/alecthomas/kingpin.v1"
 )
 
@@ -16,7 +17,7 @@ var (
 )
 
 func main() {
-	kingpin.Version("0.0.1")
+	kingpin.Version(version.VERSION)
 	kingpin.Parse()
 
 	store := kp.NewStore(kp.Options{})

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+const VERSION string = "0.0.2"


### PR DESCRIPTION
Now that we tagged 0.0.1, we should probably bump to 0.0.2.