### PR TITLE
POD_HOME exports in p2

### DIFF
--- a/pkg/pods/fake_chpst
+++ b/pkg/pods/fake_chpst
@@ -14,8 +14,12 @@ end.parse!
 
 if options[:env]
   Dir.new(options[:env]).each do |file|
-    if file != "." && file != ".."
-      ENV[file] = File.read(file)
+    if file != "." && file != ".." && !File.directory?(file)
+      begin
+        ENV[file] = File.read(file)
+      rescue
+        # silence errors
+      end
     end
   end
 end

--- a/pkg/pods/hoist_launchable.go
+++ b/pkg/pods/hoist_launchable.go
@@ -104,7 +104,7 @@ func (hoistLaunchable *HoistLaunchable) invokeBinScript(script string) (string, 
 		return "", err
 	}
 
-	cmd := exec.Command(hoistLaunchable.Chpst, "-u", hoistLaunchable.RunAs, cmdPath)
+	cmd := exec.Command(hoistLaunchable.Chpst, "-u", hoistLaunchable.RunAs, "-e", hoistLaunchable.ConfigDir, cmdPath)
 	buffer := bytes.Buffer{}
 	cmd.Stdout = &buffer
 	cmd.Stderr = &buffer

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -79,6 +79,7 @@ config:
 	Assert(t).IsNil(err, "should not have erred reading the manifest")
 
 	pod := PodFromManifestId(manifest.ID())
+	pod.path = os.TempDir()
 
 	err = pod.setupConfig(manifest)
 	Assert(t).IsNil(err, "There shouldn't have been an error setting up config")


### PR DESCRIPTION
The fake_chpst fix was because, for some reason, there were unreadable files in my $TMPDIR. The test was setting ConfigDir to $TMPDIR and fake_chpst was trying to read them, then throwing exceptions.