### PR TITLE
Test hooks in the integration test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,5 +39,13 @@ task :install => :godep_check do
   e "godep go install ./..."
 end
 
+desc 'Run the vagrant integration tests. Will attempt to build first to save you some time.'
+task :integration => :build do
+  root = File.dirname(__FILE__)
+  # suite.rb has a number of options, this one just runs the default one.
+  script = File.expand_path("integration/suite.rb", root)
+  exec "ruby #{script}"
+end
+
 desc 'By default, gather dependencies, build and test'
 task :default => [:deps, :test, :install]

--- a/bin/p2-preparer/main.go
+++ b/bin/p2-preparer/main.go
@@ -29,9 +29,7 @@ type PreparerConfig struct {
 }
 
 func main() {
-	logger := logging.NewLogger(logrus.Fields{
-		"app": "preparer",
-	})
+	logger := logging.NewLogger(logrus.Fields{})
 	configPath := os.Getenv("CONFIG_PATH")
 	if configPath == "" {
 		logger.NoFields().Errorln("No CONFIG_PATH variable was given")

--- a/integration/suite.rb
+++ b/integration/suite.rb
@@ -62,7 +62,7 @@ Dir.glob(File.join(path, '*/')).each do |test_dir|
       end
     end
     begin
-      to_execute = sprintf(options[:test_command], test_dir)
+      to_execute = sprintf(options[:test_command], "integration/#{test_name}")
       puts "Starting test #{test_name}: #{to_execute}".yellow
       unless system("vagrant ssh -c #{Shellwords.escape(to_execute)}")
         puts "#{test_name} #{'FAILED'.red}"

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -64,15 +65,22 @@ func runDirectory(dirpath string, environment []string, logger logging.Logger) e
 			continue
 		}
 		cmd := exec.Command(fullpath)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
+		hookOut := &bytes.Buffer{}
+		cmd.Stdout = hookOut
+		cmd.Stderr = hookOut
 		cmd.Env = environment
 		err := cmd.Run()
 		if err != nil {
 			logger.WithFields(logrus.Fields{
-				"err":  err,
-				"path": fullpath,
+				"err":    err,
+				"path":   fullpath,
+				"output": hookOut.String(),
 			}).Warnln("Could not execute hook")
+		} else {
+			logger.WithFields(logrus.Fields{
+				"path":   fullpath,
+				"output": hookOut.String(),
+			}).Infoln("Executed hook")
 		}
 	}
 

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -1,6 +1,7 @@
 package preparer
 
 import (
+	"path"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -44,7 +45,7 @@ func New(nodeName string, consulAddress string, hooksDirectory string, logger lo
 	listener := HookListener{
 		Intent:         store,
 		HookPrefix:     kp.HOOK_TREE,
-		DestinationDir: pods.DEFAULT_PATH,
+		DestinationDir: path.Join(pods.DEFAULT_PATH, "hooks"),
 		ExecDir:        hooksDirectory,
 		Logger:         logger,
 	}


### PR DESCRIPTION
This commit replaces the use of user.CreateUser with a
simple create_user shell script that is launched as a before_install
hook pod. This has the effect of verifying that the hook is
found in the intent store, installed correctly, and launched at
the correct time during the install / launch.

This commit includes a number of small fixes and changes to facilitate
that goal.