### PR TITLE
VERSION should be a variable, not a constant

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,7 +36,7 @@ end
 
 desc 'Install all built binaries'
 task :install => :godep_check do
-  e "godep go install ./..."
+  e "godep go install -a -ldflags \"-X github.com/square/p2/pkg/version.VERSION $(git describe --tags)\" ./..."
 end
 
 desc 'Run the vagrant integration tests. Will attempt to build first to save you some time.'

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const VERSION string = "0.0.2"
+var VERSION string = "0.0.2"


### PR DESCRIPTION
Variables can be set at link time with the -X flag, where as constants are fixed at compile time and therefore cannot be reconfigured later. I plan to put this in my universe script because I usually check out a new branch every time I build a new universe.

Use case:

```bash
$ touch pkg/version/version.go
$ godep go install -ldflags "-X github.com/square/p2/pkg/version.VERSION $(git describe --tags)" ./bin/...
$ p2-inspect --version
0.0.01-47-g123abcd
```