### PR TITLE
Prevent races when downloading the same artifact

### DIFF
--- a/pkg/pods/hoist_launchable.go
+++ b/pkg/pods/hoist_launchable.go
@@ -220,6 +220,7 @@ func (hoistLaunchable *HoistLaunchable) Install() error {
 	}
 
 	outDir, err := ioutil.TempDir("", hoistLaunchable.Version())
+	defer os.RemoveAll(outDir)
 	if err != nil {
 		return util.Errorf("Could not create temporary directory to install %s: %s", hoistLaunchable.Version(), err)
 	}

--- a/pkg/pods/hoist_launchable.go
+++ b/pkg/pods/hoist_launchable.go
@@ -219,9 +219,14 @@ func (hoistLaunchable *HoistLaunchable) Install() error {
 		return nil
 	}
 
-	outPath := path.Join(os.TempDir(), hoistLaunchable.Version())
+	outDir, err := ioutil.TempDir("", hoistLaunchable.Version())
+	if err != nil {
+		return util.Errorf("Could not create temporary directory to install %s: %s", hoistLaunchable.Version(), err)
+	}
 
-	err := hoistLaunchable.FetchToFile(hoistLaunchable.Location, outPath)
+	outPath := path.Join(outDir, hoistLaunchable.Version())
+
+	err = hoistLaunchable.FetchToFile(hoistLaunchable.Location, outPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This ensures that a new temporary directory serves as the download
destination for Hoist artifacts, even when installing artifacts
of the same name and verison. In practice this won't affect day-to-day
operations of the preparer, but does have a meaningful impact on
test cases.