### PR TITLE
Chown pod dirs correctly

### DIFF
--- a/bin/p2-preparer/main.go
+++ b/bin/p2-preparer/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/preparer"
 	"gopkg.in/yaml.v2"
 )
@@ -74,6 +75,12 @@ func main() {
 	prep, err := preparer.New(preparerConfig.NodeName, preparerConfig.ConsulAddress, preparerConfig.HooksDirectory, logger)
 	if err != nil {
 		logger.WithField("inner_err", err).Errorln("Could not initialize preparer")
+		os.Exit(1)
+	}
+
+	err = os.MkdirAll(pods.DEFAULT_PATH, 0755)
+	if err != nil {
+		logger.WithField("inner_err", err).Errorln("Could not create preparer pod directory")
 		os.Exit(1)
 	}
 

--- a/pkg/pods/hoist_launchable.go
+++ b/pkg/pods/hoist_launchable.go
@@ -306,7 +306,7 @@ func (hoistLaunchable *HoistLaunchable) extractTarGz(fp *os.File, dest string) (
 		return err
 	}
 
-	err = os.MkdirAll(dest, 0755)
+	err = util.MkdirChownAll(dest, uid, gid, 0755)
 	if err != nil {
 		return util.Errorf("Unable to create root directory %s when unpacking %s: %s", dest, fp.Name(), err)
 	}

--- a/pkg/pods/hoist_launchable.go
+++ b/pkg/pods/hoist_launchable.go
@@ -285,6 +285,16 @@ func (hoistLaunchable *HoistLaunchable) MakeCurrent() error {
 	if err != nil {
 		return util.Errorf("Couldn't create symlink for hoist launchable %s: %s", hoistLaunchable.Id, err)
 	}
+
+	uid, gid, err := user.IDs(hoistLaunchable.RunAs)
+	if err != nil {
+		return util.Errorf("Couldn't retrieve UID/GID for hoist launchable %s user %s: %s", hoistLaunchable.Id, hoistLaunchable.RunAs, err)
+	}
+	err = os.Lchown(tempLinkPath, uid, gid)
+	if err != nil {
+		return util.Errorf("Couldn't lchown symlink for hoist launchable %s: %s", hoistLaunchable.Id, err)
+	}
+
 	return os.Rename(tempLinkPath, hoistLaunchable.CurrentDir())
 }
 

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -371,11 +371,11 @@ func (pod *Pod) setupConfig(podManifest *PodManifest) error {
 	if err != nil {
 		return util.Errorf("Could not create the environment dir for pod %s: %s", podManifest.ID(), err)
 	}
-	err = writeEnvFile(pod.EnvDir(), "CONFIG_PATH", configPath)
+	err = writeEnvFile(pod.EnvDir(), "CONFIG_PATH", configPath, uid, gid)
 	if err != nil {
 		return err
 	}
-	err = writeEnvFile(pod.EnvDir(), "POD_HOME", pod.Path())
+	err = writeEnvFile(pod.EnvDir(), "POD_HOME", pod.Path(), uid, gid)
 	if err != nil {
 		return err
 	}
@@ -385,7 +385,7 @@ func (pod *Pod) setupConfig(podManifest *PodManifest) error {
 
 // writeEnvFile takes an environment directory (as described in http://smarden.org/runit/chpst.8.html, with the -e option)
 // and writes a new file with the given value.
-func writeEnvFile(envDir, name, value string) error {
+func writeEnvFile(envDir, name, value string, uid, gid int) error {
 	fpath := path.Join(envDir, name)
 
 	buf := bytes.NewBufferString(value)
@@ -393,6 +393,11 @@ func writeEnvFile(envDir, name, value string) error {
 	err := ioutil.WriteFile(fpath, buf.Bytes(), 0644)
 	if err != nil {
 		return util.Errorf("Could not write environment config file at %s: %s", fpath, err)
+	}
+
+	err = os.Chown(fpath, uid, gid)
+	if err != nil {
+		return util.Errorf("Could not chown environment config file at %s: %s", fpath, err)
 	}
 	return nil
 }

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -366,6 +366,10 @@ func (pod *Pod) setupConfig(podManifest *PodManifest) error {
 	if err != nil {
 		return err
 	}
+	err = file.Chown(uid, gid)
+	if err != nil {
+		return err
+	}
 
 	err = util.MkdirChownAll(pod.EnvDir(), uid, gid, 0755)
 	if err != nil {

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -8,6 +8,7 @@ import (
 	"os/user"
 	"path"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -54,7 +55,14 @@ func TestPodCanWriteEnvFile(t *testing.T) {
 	Assert(t).IsNil(err, "Should not have been an error writing the env dir")
 	defer os.RemoveAll(envDir)
 
-	err = writeEnvFile(envDir, "ENVIRONMENT", "staging")
+	curUser, err := user.Current()
+	Assert(t).IsNil(err, "There should not have been an error finding the current user")
+	uid, err := strconv.ParseInt(curUser.Uid, 10, 0)
+	Assert(t).IsNil(err, "There should not have been an error converting the UID to an int")
+	gid, err := strconv.ParseInt(curUser.Gid, 10, 0)
+	Assert(t).IsNil(err, "There should not have been an error converting the UID to an int")
+
+	err = writeEnvFile(envDir, "ENVIRONMENT", "staging", int(uid), int(gid))
 	Assert(t).IsNil(err, "There should not have been an error writing the config file")
 
 	expectedWritten := path.Join(envDir, "ENVIRONMENT")

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -203,6 +203,7 @@ func TestBuildRunitServices(t *testing.T) {
 		Chpst:          FakeChpst(),
 	}
 	hoistLaunchable := fakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
+	hoistLaunchable.RunAs = "testPod"
 	executables, err := hoistLaunchable.Executables(serviceBuilder)
 	outFilePath := path.Join(serviceBuilder.ConfigRoot, "testPod.yaml")
 

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -159,7 +159,13 @@ func TestWriteManifestWillReturnOldManifestTempPath(t *testing.T) {
 	updated := getUpdatedManifest(t)
 	poddir, err := ioutil.TempDir("", "poddir")
 	Assert(t).IsNil(err, "couldn't create tempdir")
+
 	pod := NewPod("testPod", poddir)
+	curUser, err := user.Current()
+	if err == nil {
+		pod.RunAs = curUser.Username
+	}
+
 	manifestContent, err := existing.Bytes()
 	Assert(t).IsNil(err, "couldn't get manifest bytes")
 	err = ioutil.WriteFile(pod.CurrentPodManifestPath(), manifestContent, 0744)

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path"
 	"runtime"
 	"strings"
@@ -80,6 +81,11 @@ config:
 
 	pod := PodFromManifestId(manifest.ID())
 	pod.path = os.TempDir()
+
+	curUser, err := user.Current()
+	if err == nil {
+		pod.RunAs = curUser.Username
+	}
 
 	err = pod.setupConfig(manifest)
 	Assert(t).IsNil(err, "There shouldn't have been an error setting up config")

--- a/pkg/pods/test_helper.go
+++ b/pkg/pods/test_helper.go
@@ -3,6 +3,7 @@ package pods
 import (
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path"
 	"runtime"
 
@@ -40,6 +41,12 @@ func fakeHoistLaunchableForDir(dirName string) *HoistLaunchable {
 		RootDir:     launchableInstallDir,
 		Chpst:       FakeChpst(),
 	}
+
+	curUser, err := user.Current()
+	if err == nil {
+		launchable.RunAs = curUser.Username
+	}
+
 	return launchable
 }
 

--- a/pkg/util/mkdir.go
+++ b/pkg/util/mkdir.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"os"
+	"syscall"
+)
+
+func MkdirChownAll(path string, uid, gid int, perm os.FileMode) error {
+	// Fast path: if we can tell whether path is a directory or file, stop with success or error.
+	dir, err := os.Stat(path)
+	if err == nil {
+		if dir.IsDir() {
+			return nil
+		}
+		return &os.PathError{"mkdir", path, syscall.ENOTDIR}
+	}
+
+	// Slow path: make sure parent exists and then call Mkdir for path.
+	i := len(path)
+	for i > 0 && os.IsPathSeparator(path[i-1]) { // Skip trailing path separator.
+		i--
+	}
+
+	j := i
+	for j > 0 && !os.IsPathSeparator(path[j-1]) { // Scan backward over element.
+		j--
+	}
+
+	if j > 1 {
+		// Create parent
+		err = MkdirChownAll(path[0:j-1], uid, gid, perm)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Parent now exists; invoke Mkdir and use its result.
+	err = os.Mkdir(path, perm)
+	if err != nil {
+		// Handle arguments like "foo/." by
+		// double-checking that directory doesn't exist.
+		dir, err1 := os.Lstat(path)
+		if err1 == nil && dir.IsDir() {
+			return nil
+		}
+		return err
+	}
+	return os.Chown(path, uid, gid)
+}

--- a/pkg/util/mkdir_test.go
+++ b/pkg/util/mkdir_test.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"strconv"
+	"testing"
+
+	. "github.com/anthonybishopric/gotcha"
+)
+
+func TestMkdirAll(t *testing.T) {
+	temp, err := ioutil.TempDir("", "mkdirall")
+	Assert(t).IsNil(err, "There should not have been an error creating a temp dir")
+
+	dirPath := fmt.Sprintf("%s/foo/bar/baz", temp)
+
+	curUser, err := user.Current()
+	Assert(t).IsNil(err, "There should not have been an error checking the current user")
+	uid, err := strconv.ParseInt(curUser.Uid, 10, 0)
+	Assert(t).IsNil(err, "There should not have been an error converting uid to int")
+	gid, err := strconv.ParseInt(curUser.Gid, 10, 0)
+	Assert(t).IsNil(err, "There should not have been an error converting gid to int")
+
+	err = MkdirChownAll(dirPath, int(uid), int(gid), 0777)
+	Assert(t).IsNil(err, "There should not have been an error creating the directory")
+
+	_, err = os.Stat(dirPath)
+	Assert(t).IsNil(err, "There should not have been an error statting the directory")
+}

--- a/pkg/util/mkdir_test.go
+++ b/pkg/util/mkdir_test.go
@@ -29,4 +29,7 @@ func TestMkdirAll(t *testing.T) {
 
 	_, err = os.Stat(dirPath)
 	Assert(t).IsNil(err, "There should not have been an error statting the directory")
+
+	err = os.RemoveAll(temp)
+	Assert(t).IsNil(err, "There should not have been an error cleaning up the temp directory")
 }


### PR DESCRIPTION
This addresses three of the four main tasks I mentioned on the trello card:

- create /data/pods explicitly
- add mkdirchownall
- use mkdirchownall in all pod-related contexts.

The missing first task (parameterizing /data/pods) will probably need a bit more work. Implicit use of pods.DEFAULT_PATH is threaded through our code and refactoring that might get messy, but for now this functionality is all we really care about, and it simplifies deploys of some existing applications.