### PR TITLE
Lower log level for "new manifest received"

### DIFF
--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -142,7 +142,7 @@ func (p *Preparer) handlePods(podChan <-chan pods.PodManifest, quit <-chan struc
 				"sha":      sha,
 				"sha_err":  err,
 			})
-			manifestLogger.NoFields().Infoln("New manifest received")
+			manifestLogger.NoFields().Debugln("New manifest received")
 			working = true
 		case <-time.After(1 * time.Second):
 			if working {


### PR DESCRIPTION
This is definitely the least useful and noisiest of our log messages