### PR TITLE
Allowed deployers

### DIFF
--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -157,7 +157,23 @@ func (p *Preparer) verifySignature(manifest pods.PodManifest, logger logging.Log
 
 	signer, err := manifest.Signer(p.keyring)
 	if signer != nil {
-		logger.WithField("signer_key", signer.PrimaryKey.KeyIdShortString()).Debugln("Resolved manifest signature")
+		signerId := signer.PrimaryKey.KeyIdShortString()
+		logger.WithField("signer_key", signerId).Debugln("Resolved manifest signature")
+
+		// Hmm, some hacks here.
+		if manifest.Id == "p2-preparer" {
+			foundAuthorized := false
+			for _, authorized := range p.authorizedDeployers {
+				if authorized == signerId {
+					foundAuthorized = true
+				}
+			}
+			if !foundAuthorized {
+				logger.WithField("signer_key", signerId).Errorln("Not an authorized deployer of the preparer")
+				return false
+			}
+		}
+
 		return true
 	}
 

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -31,13 +31,14 @@ type Store interface {
 }
 
 type Preparer struct {
-	node         string
-	store        Store
-	hooks        Hooks
-	hookListener HookListener
-	Logger       logging.Logger
-	keyring      openpgp.KeyRing
-	podRoot      string
+	node                string
+	store               Store
+	hooks               Hooks
+	hookListener        HookListener
+	Logger              logging.Logger
+	keyring             openpgp.KeyRing
+	podRoot             string
+	authorizedDeployers []string
 }
 
 func (p *Preparer) WatchForHooks(quit chan struct{}) {

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -11,6 +11,10 @@ import (
 	"golang.org/x/crypto/openpgp"
 )
 
+// The Pod ID of the preparer.
+// Used because the preparer special-cases itself in a few places.
+const POD_ID = "p2-preparer"
+
 type Pod interface {
 	hooks.Pod
 	Launch(*pods.PodManifest) (bool, error)
@@ -133,7 +137,7 @@ func (p *Preparer) handlePods(podChan <-chan pods.PodManifest, quit <-chan struc
 				// HACK ZONE. When we have better authz, rewrite.
 				// Still need to ensure that preparer launches correctly
 				// as root
-				if pod.Id == "p2-preparer" {
+				if pod.Id == POD_ID {
 					pod.RunAs = "root"
 				}
 
@@ -161,7 +165,7 @@ func (p *Preparer) verifySignature(manifest pods.PodManifest, logger logging.Log
 		logger.WithField("signer_key", signerId).Debugln("Resolved manifest signature")
 
 		// Hmm, some hacks here.
-		if manifest.Id == "p2-preparer" {
+		if manifest.Id == POD_ID {
 			foundAuthorized := false
 			for _, authorized := range p.authorizedDeployers {
 				if authorized == signerId {

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -165,7 +165,7 @@ func (p *Preparer) verifySignature(manifest pods.PodManifest, logger logging.Log
 		logger.WithField("signer_key", signerId).Debugln("Resolved manifest signature")
 
 		// Hmm, some hacks here.
-		if manifest.Id == POD_ID {
+		if manifest.Id == POD_ID && len(p.authorizedDeployers) > 0 {
 			foundAuthorized := false
 			for _, authorized := range p.authorizedDeployers {
 				if authorized == signerId {

--- a/pkg/preparer/orchestrate_test.go
+++ b/pkg/preparer/orchestrate_test.go
@@ -291,7 +291,7 @@ func TestPreparerWillAcceptSignatureFromKeyring(t *testing.T) {
 	Assert(t).IsTrue(p.verifySignature(*manifest, logging.DefaultLogger), "should have accepted signed manifest")
 }
 
-func TestPreparerWillRejectSignatureForPreparerWithoutAuthorizedDeployers(t *testing.T) {
+func TestPreparerWillAcceptSignatureForPreparerWithoutAuthorizedDeployers(t *testing.T) {
 	manifest, fakeSigner := testSignedManifest(t, func(m *pods.PodManifest, _ *openpgp.Entity) {
 		m.Id = POD_ID
 	})
@@ -300,7 +300,7 @@ func TestPreparerWillRejectSignatureForPreparerWithoutAuthorizedDeployers(t *tes
 	defer os.RemoveAll(fakePodRoot)
 	p.keyring = openpgp.EntityList{fakeSigner}
 
-	Assert(t).IsFalse(p.verifySignature(*manifest, logging.DefaultLogger), "expected preparer to reject manifest (no authorized deployer)")
+	Assert(t).IsTrue(p.verifySignature(*manifest, logging.DefaultLogger), "expected preparer to accept manifest (empty authorized deployers)")
 }
 
 func TestPreparerWillRejectUnauthorizedSignatureForPreparer(t *testing.T) {

--- a/pkg/preparer/orchestrate_test.go
+++ b/pkg/preparer/orchestrate_test.go
@@ -285,7 +285,7 @@ func TestPreparerWillAcceptSignatureFromKeyring(t *testing.T) {
 
 func TestPreparerWillRejectSignatureForPreparerWithoutAuthorizedDeployers(t *testing.T) {
 	manifest, fakeSigner := testSignedManifest(t, func(m *pods.PodManifest, _ *openpgp.Entity) {
-		m.Id = "p2-preparer"
+		m.Id = POD_ID
 	})
 
 	p, _, fakePodRoot := testPreparer(t, &FakeStore{})
@@ -297,7 +297,7 @@ func TestPreparerWillRejectSignatureForPreparerWithoutAuthorizedDeployers(t *tes
 
 func TestPreparerWillRejectUnauthorizedSignatureForPreparer(t *testing.T) {
 	manifest, fakeSigner := testSignedManifest(t, func(m *pods.PodManifest, _ *openpgp.Entity) {
-		m.Id = "p2-preparer"
+		m.Id = POD_ID
 	})
 
 	p, _, fakePodRoot := testPreparer(t, &FakeStore{})
@@ -311,7 +311,7 @@ func TestPreparerWillRejectUnauthorizedSignatureForPreparer(t *testing.T) {
 func TestPreparerWillAcceptAuthorizedSignatureForPreparer(t *testing.T) {
 	sig := ""
 	manifest, fakeSigner := testSignedManifest(t, func(m *pods.PodManifest, e *openpgp.Entity) {
-		m.Id = "p2-preparer"
+		m.Id = POD_ID
 		sig = e.PrimaryKey.KeyIdShortString()
 	})
 

--- a/pkg/preparer/orchestrate_test.go
+++ b/pkg/preparer/orchestrate_test.go
@@ -100,11 +100,19 @@ func testManifest(t *testing.T) *pods.PodManifest {
 	return manifest
 }
 
+// Use the same signer for all SignedManifests.
+// Otherwise, Travis may time out waiting for entropy.
+var cachedSigner *openpgp.Entity
+
 func testSignedManifest(t *testing.T, modify func(*pods.PodManifest, *openpgp.Entity)) (*pods.PodManifest, *openpgp.Entity) {
 	testManifest := testManifest(t)
 
-	fakeSigner, err := openpgp.NewEntity("p2", "p2-test", "p2@squareup.com", nil)
-	Assert(t).IsNil(err, "NewEntity error should have been nil")
+	if cachedSigner == nil {
+		var err error
+		cachedSigner, err = openpgp.NewEntity("p2", "p2-test", "p2@squareup.com", nil)
+		Assert(t).IsNil(err, "NewEntity error should have been nil")
+	}
+	fakeSigner := cachedSigner
 
 	if modify != nil {
 		modify(testManifest, fakeSigner)

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -31,6 +31,7 @@ type PreparerConfig struct {
 	HooksDirectory       string           `yaml:"hooks_directory"`
 	KeyringPath          string           `yaml:"keyring,omitempty"`
 	PodRoot              string           `yaml:"pod_root,omitempty"`
+	AuthorizedDeployers  []string         `yaml:"authorized_deployers,omitempty"`
 	ExtraLogDestinations []LogDestination `yaml:"extra_log_destinations,omitempty"`
 }
 
@@ -139,12 +140,13 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 	}
 
 	return &Preparer{
-		node:         preparerConfig.NodeName,
-		store:        store,
-		hooks:        hooks.Hooks(preparerConfig.HooksDirectory, &logger),
-		hookListener: listener,
-		Logger:       logger,
-		keyring:      keyring,
-		podRoot:      preparerConfig.PodRoot,
+		node:                preparerConfig.NodeName,
+		store:               store,
+		hooks:               hooks.Hooks(preparerConfig.HooksDirectory, &logger),
+		hookListener:        listener,
+		Logger:              logger,
+		keyring:             keyring,
+		podRoot:             preparerConfig.PodRoot,
+		authorizedDeployers: preparerConfig.AuthorizedDeployers,
 	}, nil
 }


### PR DESCRIPTION
Original:

OK, this has the replicator check the intent store for allowed_deployers before writing to the intent store.

This works, but we also need to do this for p2-schedule, don't we?

I've a mind to write tests for this, if I hear that this is the direction we want to take.

Now it's the simplified version for preparer only.