### PR TITLE
HTTPS health checking

### DIFF
--- a/pkg/kp/service.go
+++ b/pkg/kp/service.go
@@ -19,7 +19,7 @@ func (s *Store) RegisterService(manifest pods.PodManifest) error {
 		podService.Port = manifest.StatusPort
 		podService.Check = &consulapi.AgentServiceCheck{
 			// prints the HTTP response on stderr, while exiting 0 if the status code is 200
-			Script: fmt.Sprintf(`if [[ $(curl 0.0.0.0:%v/_status -s -o /dev/stderr -w "%%{http_code}") == "200" ]] ; then exit 0 ; else exit 2; fi`, manifest.StatusPort),
+			Script: fmt.Sprintf(`if [[ $(curl https://$(hostname):%v/_status -s -o /dev/stderr -w "%%{http_code}" --cacert ${SECRETS_PATH}/service2service.ca.pem) == "200" ]] ; then exit 0 ; else exit 2; fi`, manifest.StatusPort),
 			// magic number alert
 			Interval: "5s",
 		}

--- a/pkg/kp/service.go
+++ b/pkg/kp/service.go
@@ -7,6 +7,12 @@ import (
 	"github.com/square/p2/pkg/pods"
 )
 
+var (
+	// prints the HTTP response on stderr, while exiting 0 if the status code is 200
+	httpStatusCheck  = `if [[ $(curl http://$(hostname):%v/_status -s -o /dev/stderr -w "%%{http_code}") == "200" ]] ; then exit 0 ; else exit 2; fi`
+	httpsStatusCheck = `if [[ $(curl https://$(hostname):%v/_status -s -o /dev/stderr -w "%%{http_code}" --cacert ${SECRETS_PATH}/service2service.ca.pem) == "200" ]] ; then exit 0 ; else exit 2; fi`
+)
+
 // RegisterService creates a consul service for the given pod manifest. If the
 // manifest specifies a status port, the resulting consul service will also
 // include a health check for that port.
@@ -18,10 +24,13 @@ func (s *Store) RegisterService(manifest pods.PodManifest) error {
 	if manifest.StatusPort != 0 {
 		podService.Port = manifest.StatusPort
 		podService.Check = &consulapi.AgentServiceCheck{
-			// prints the HTTP response on stderr, while exiting 0 if the status code is 200
-			Script: fmt.Sprintf(`if [[ $(curl https://$(hostname):%v/_status -s -o /dev/stderr -w "%%{http_code}" --cacert ${SECRETS_PATH}/service2service.ca.pem) == "200" ]] ; then exit 0 ; else exit 2; fi`, manifest.StatusPort),
 			// magic number alert
 			Interval: "5s",
+		}
+		if manifest.StatusHTTP {
+			podService.Check.Script = fmt.Sprintf(httpStatusCheck, manifest.StatusPort)
+		} else {
+			podService.Check.Script = fmt.Sprintf(httpsStatusCheck, manifest.StatusPort)
 		}
 	}
 

--- a/pkg/pods/pod_manifest.go
+++ b/pkg/pods/pod_manifest.go
@@ -30,6 +30,7 @@ type PodManifest struct {
 	LaunchableStanzas map[string]LaunchableStanza `yaml:"launchables"`
 	Config            map[string]interface{}      `yaml:"config"`
 	StatusPort        int                         `yaml:"status_port,omitempty"`
+	StatusHTTP        bool                        `yaml:"status_http,omitempty"`
 	// these fields are required to track the original text if it was signed
 	raw       []byte
 	plaintext []byte

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -30,7 +30,7 @@ type Hooks interface {
 type Store interface {
 	Pod(string) (*pods.PodManifest, time.Duration, error)
 	SetPod(string, pods.PodManifest) (time.Duration, error)
-	RegisterService(pods.PodManifest) error
+	RegisterService(pods.PodManifest, string) error
 	WatchPods(string, <-chan struct{}, chan<- error, chan<- kp.ManifestResult)
 }
 
@@ -43,6 +43,7 @@ type Preparer struct {
 	keyring             openpgp.KeyRing
 	podRoot             string
 	authorizedDeployers []string
+	caPath              string
 }
 
 func (p *Preparer) WatchForHooks(quit chan struct{}) {
@@ -246,7 +247,7 @@ func (p *Preparer) installAndLaunchPod(newManifest *pods.PodManifest, pod Pod, l
 			}).Warnln("Could not run hooks")
 		}
 
-		err = p.store.RegisterService(*newManifest)
+		err = p.store.RegisterService(*newManifest, p.caPath)
 		if err != nil {
 			logger.WithField("err", err).Errorln("Service registration failed")
 			return false

--- a/pkg/preparer/orchestrate_test.go
+++ b/pkg/preparer/orchestrate_test.go
@@ -153,7 +153,7 @@ func (f *FakeStore) SetPod(string, pods.PodManifest) (time.Duration, error) {
 	return 0, nil
 }
 
-func (f *FakeStore) RegisterService(pods.PodManifest) error {
+func (f *FakeStore) RegisterService(pods.PodManifest, string) error {
 	return nil
 }
 

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -30,6 +30,7 @@ type PreparerConfig struct {
 	ConsulTokenPath      string           `yaml:"consul_token_path,omitempty"`
 	HooksDirectory       string           `yaml:"hooks_directory"`
 	KeyringPath          string           `yaml:"keyring,omitempty"`
+	CAPath               string           `yaml:"ca_path,omitempty"`
 	PodRoot              string           `yaml:"pod_root,omitempty"`
 	AuthorizedDeployers  []string         `yaml:"authorized_deployers,omitempty"`
 	ExtraLogDestinations []LogDestination `yaml:"extra_log_destinations,omitempty"`
@@ -148,5 +149,6 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 		keyring:             keyring,
 		podRoot:             preparerConfig.PodRoot,
 		authorizedDeployers: preparerConfig.AuthorizedDeployers,
+		caPath:              preparerConfig.CAPath,
 	}, nil
 }


### PR DESCRIPTION
This commit adds support for https health checks. Pods have to opt into https in their manifests. The CA for the HTTPS endpoint is in consul's `$SECRETS_PATH`.

pretty icky code to be putting in an open source project but we can improve the usability later