### PR TITLE
Add AFTER_AUTH_FAIL hook type

### DIFF
--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -33,9 +33,10 @@ func (hookType HookType) String() string {
 }
 
 var (
-	BEFORE_INSTALL = HookType("before_install")
-	AFTER_INSTALL  = HookType("after_install")
-	AFTER_LAUNCH   = HookType("after_launch")
+	BEFORE_INSTALL  = HookType("before_install")
+	AFTER_INSTALL   = HookType("after_install")
+	AFTER_LAUNCH    = HookType("after_launch")
+	AFTER_AUTH_FAIL = HookType("after_auth_fail")
 )
 
 func AsHookType(value string) (HookType, error) {
@@ -46,6 +47,8 @@ func AsHookType(value string) (HookType, error) {
 		return AFTER_INSTALL, nil
 	case AFTER_LAUNCH.String():
 		return AFTER_LAUNCH, nil
+	case AFTER_AUTH_FAIL.String():
+		return AFTER_AUTH_FAIL, nil
 	default:
 		return HookType(""), fmt.Errorf("%s is not a valid hook type", value)
 	}

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -131,6 +131,15 @@ func (p *Preparer) handlePods(podChan <-chan pods.PodManifest, quit <-chan struc
 			manifestLogger.NoFields().Debugln("New manifest received")
 
 			working = p.verifySignature(manifestToLaunch, manifestLogger)
+			if !working {
+				err = p.hooks.RunHookType(hooks.AFTER_AUTH_FAIL, pods.NewPod(manifestToLaunch.ID(), pods.PodPath(p.podRoot, manifestToLaunch.ID())), &manifestToLaunch)
+				if err != nil {
+					manifestLogger.WithFields(logrus.Fields{
+						"err":   err,
+						"hooks": hooks.AFTER_AUTH_FAIL,
+					}).Warnln("Could not run hooks")
+				}
+			}
 		case <-time.After(1 * time.Second):
 			if working {
 				pod := pods.NewPod(manifestToLaunch.ID(), pods.PodPath(p.podRoot, manifestToLaunch.ID()))


### PR DESCRIPTION
as requested. I'm gonna go test it but take a look at the code.

One thought I just had: it would be nice if we could pass more information to hooks of this type, specifically to communicate how the auth failure occurred. We don't really have a mechanism for this right now (the hook basically has to parse the manifest itself and check the signature by somehow reading the preparer's public keyring) but it would be cool.