### PR TITLE
Cgroup limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ P2 is based on existing deployment tools at Square. The following list reflects 
 * [Consul](https://consul.io/)
 * [Runit](http://smarden.org/runit/), which includes chpst
 * [ServiceBuilder](https://github.com/square/prodeng/tree/master/servicebuilder)
+* [Contain](https://github.com/square/prodeng/tree/master/cgroup-container)
 * Logrotate
 * [Nolimit](https://github.com/square/prodeng/tree/master/nolimit)
 

--- a/bin/p2-bin2pod/main.go
+++ b/bin/p2-bin2pod/main.go
@@ -43,6 +43,7 @@ var (
 	location      = bin2pod.Flag("location", "The location where the outputted tar will live. The characters {} will be replaced with the unique basename of the tar, including its SHA. If not provided, the location will be a file path to the resulting tar from the build, which is included in the output of this script. Users must copy the resultant tar to the new location if it is different from the default output path.").String()
 	workDirectory = bin2pod.Flag("work-dir", "A directory where the results will be written.").ExistingDir()
 	config        = bin2pod.Flag("config", "a list of key=value assignments. Each key will be set in the config section.").Strings()
+	containerSize = bin2pod.Flag("container", "the container size that this manifest should use").Default("small").String()
 )
 
 type Result struct {
@@ -97,6 +98,7 @@ func main() {
 		stanza.Location = tarLocation
 		res.FinalLocation = tarLocation
 	}
+	stanza.ContainerType = *containerSize
 	manifest.LaunchableStanzas[podId()] = stanza
 
 	if err != nil {

--- a/bin/p2-bin2pod/main.go
+++ b/bin/p2-bin2pod/main.go
@@ -43,7 +43,7 @@ var (
 	location      = bin2pod.Flag("location", "The location where the outputted tar will live. The characters {} will be replaced with the unique basename of the tar, including its SHA. If not provided, the location will be a file path to the resulting tar from the build, which is included in the output of this script. Users must copy the resultant tar to the new location if it is different from the default output path.").String()
 	workDirectory = bin2pod.Flag("work-dir", "A directory where the results will be written.").ExistingDir()
 	config        = bin2pod.Flag("config", "a list of key=value assignments. Each key will be set in the config section.").Strings()
-	containerSize = bin2pod.Flag("container", "the container size that this manifest should use").Default("small").String()
+	containerSize = bin2pod.Flag("container", "the container size that this manifest should use").String()
 )
 
 type Result struct {

--- a/pkg/hoist/fake_contain
+++ b/pkg/hoist/fake_contain
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+options = {}
+# accept the same options as contain but fake out
+OptionParser.new do |opts|
+  opts.on('-s size', '--size size', 'size') do |arg|
+  end
+  opts.on('-a app', '--app application', 'application name') do |arg|
+  end
+  opts.on('-d dir', '--dir dir for container defs', 'directory name') do |arg|
+  end
+  opts.on('-n', '--dry-run', 'dry run') do |arg|
+  end
+  opts.on('-v', '--verbose', 'verbose') do |arg|
+  end
+end.parse!
+
+exec ARGV.join(" ")

--- a/pkg/hoist/hoist_executable.go
+++ b/pkg/hoist/hoist_executable.go
@@ -21,22 +21,28 @@ type HoistExecutable struct {
 }
 
 func (e HoistExecutable) SBEntry() []string {
-	return []string{
-		e.Nolimit,
-		e.Contain,
-		"-a",
-		e.ContainerName,
-		"-s",
-		e.Container,
-		"-v",
-		"--",
+	var ret []string
+	ret = append(ret, e.Nolimit)
+	if e.Container != "" {
+		ret = append(ret,
+			e.Contain,
+			"-a",
+			e.ContainerName,
+			"-s",
+			e.Container,
+			"-v",
+			"--",
+		)
+	}
+	ret = append(ret,
 		e.Chpst,
 		"-u",
 		strings.Join([]string{e.RunAs, e.RunAs}, ":"),
 		"-e",
 		e.ConfigDir,
-		e.ExecPath,
-	}
+	)
+	ret = append(ret, e.ExecPath)
+	return ret
 }
 
 func (e HoistExecutable) WriteExecutor(writer io.Writer) error {

--- a/pkg/hoist/hoist_executable.go
+++ b/pkg/hoist/hoist_executable.go
@@ -13,6 +13,7 @@ type HoistExecutable struct {
 	ExecPath      string
 	Chpst         string
 	Contain       string
+	Container     string
 	ContainerName string
 	Nolimit       string
 	RunAs         string
@@ -26,7 +27,7 @@ func (e HoistExecutable) SBEntry() []string {
 		"-a",
 		e.ContainerName,
 		"-s",
-		"mycgroup",
+		e.Container,
 		"-v",
 		"--",
 		e.Chpst,

--- a/pkg/hoist/hoist_executable.go
+++ b/pkg/hoist/hoist_executable.go
@@ -9,17 +9,26 @@ import (
 )
 
 type HoistExecutable struct {
-	Service   runit.Service
-	ExecPath  string
-	Chpst     string
-	Nolimit   string
-	RunAs     string
-	ConfigDir string
+	Service       runit.Service
+	ExecPath      string
+	Chpst         string
+	Contain       string
+	ContainerName string
+	Nolimit       string
+	RunAs         string
+	ConfigDir     string
 }
 
 func (e HoistExecutable) SBEntry() []string {
 	return []string{
 		e.Nolimit,
+		e.Contain,
+		"-a",
+		e.ContainerName,
+		"-s",
+		"mycgroup",
+		"-v",
+		"--",
 		e.Chpst,
 		"-u",
 		strings.Join([]string{e.RunAs, e.RunAs}, ":"),

--- a/pkg/hoist/hoist_executable_test.go
+++ b/pkg/hoist/hoist_executable_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	. "github.com/anthonybishopric/gotcha"
+	"github.com/square/p2/pkg/runit"
 )
 
 func TestExecutableWritesValidScript(t *testing.T) {
@@ -24,11 +25,14 @@ func TestExecutableWritesValidScript(t *testing.T) {
 	err = ioutil.WriteFile(path.Join(envdir, "SPECIALTESTVAR"), []byte("specialvalue"), 0644)
 	Assert(t).IsNil(err, "test setup failure - should not have failed to write an environment var")
 	executable := &HoistExecutable{
-		Chpst:     FakeChpst(),
-		Nolimit:   "",
-		ExecPath:  "/usr/bin/env",
-		RunAs:     user.Username,
-		ConfigDir: envdir,
+		Service:       runit.Service{Name: "foo"},
+		Chpst:         FakeChpst(),
+		Contain:       FakeContain(),
+		ContainerName: "mypod__mylaunchable",
+		Nolimit:       "",
+		ExecPath:      "/usr/bin/env",
+		RunAs:         user.Username,
+		ConfigDir:     envdir,
 	}
 	scriptPath := path.Join(scriptdir, "script")
 	scriptHandle, err := os.OpenFile(scriptPath, os.O_CREATE|os.O_WRONLY, 0744)

--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -29,6 +29,7 @@ type HoistLaunchable struct {
 	FetchToFile Fetcher // Callback that downloads the file from the remote location.
 	RootDir     string  // The root directory of the launchable, containing N:N>=1 installs.
 	Chpst       string  // The path to chpst
+	Contain     string  // The path to contain
 }
 
 func DefaultFetcher() Fetcher {
@@ -171,12 +172,14 @@ func (h *HoistLaunchable) Executables(serviceBuilder *runit.ServiceBuilder) ([]H
 		servicePath := path.Join(serviceBuilder.RunitRoot, serviceName)
 		runitService := &runit.Service{servicePath, serviceName}
 		executable := &HoistExecutable{
-			Service:   *runitService,
-			ExecPath:  binLaunchPath,
-			Chpst:     h.Chpst,
-			Nolimit:   "/usr/bin/nolimit",
-			RunAs:     h.RunAs,
-			ConfigDir: h.ConfigDir,
+			Service:       *runitService,
+			ExecPath:      binLaunchPath,
+			Chpst:         h.Chpst,
+			Contain:       h.Contain,
+			ContainerName: h.Id,
+			Nolimit:       "/usr/bin/nolimit",
+			RunAs:         h.RunAs,
+			ConfigDir:     h.ConfigDir,
 		}
 
 		return []HoistExecutable{*executable}, nil
@@ -194,12 +197,14 @@ func (h *HoistLaunchable) Executables(serviceBuilder *runit.ServiceBuilder) ([]H
 			execPath := path.Join(binLaunchPath, service.Name())
 			runitService := &runit.Service{servicePath, serviceName}
 			executable := &HoistExecutable{
-				Service:   *runitService,
-				ExecPath:  execPath,
-				Chpst:     h.Chpst,
-				Nolimit:   "/usr/bin/nolimit",
-				RunAs:     h.RunAs,
-				ConfigDir: h.ConfigDir,
+				Service:       *runitService,
+				ExecPath:      execPath,
+				Chpst:         h.Chpst,
+				Contain:       h.Contain,
+				ContainerName: h.Id,
+				Nolimit:       "/usr/bin/nolimit",
+				RunAs:         h.RunAs,
+				ConfigDir:     h.ConfigDir,
 			}
 			executables[i] = *executable
 		}

--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -22,14 +22,15 @@ type Fetcher func(string, string) error
 
 // A HoistLaunchable represents a particular install of a hoist artifact.
 type HoistLaunchable struct {
-	Location    string  // A URL where we can download the artifact from.
-	Id          string  // A unique identifier for this launchable, used when creating runit services
-	RunAs       string  // The user to assume when launching the executable
-	ConfigDir   string  // The value for chpst -e. See http://smarden.org/runit/chpst.8.html
-	FetchToFile Fetcher // Callback that downloads the file from the remote location.
-	RootDir     string  // The root directory of the launchable, containing N:N>=1 installs.
-	Chpst       string  // The path to chpst
-	Contain     string  // The path to contain
+	Location      string  // A URL where we can download the artifact from.
+	Id            string  // A unique identifier for this launchable, used when creating runit services
+	RunAs         string  // The user to assume when launching the executable
+	ConfigDir     string  // The value for chpst -e. See http://smarden.org/runit/chpst.8.html
+	FetchToFile   Fetcher // Callback that downloads the file from the remote location.
+	RootDir       string  // The root directory of the launchable, containing N:N>=1 installs.
+	Chpst         string  // The path to chpst
+	Contain       string  // The path to contain
+	ContainerType string  // The container type to pass to contain
 }
 
 func DefaultFetcher() Fetcher {
@@ -176,6 +177,7 @@ func (h *HoistLaunchable) Executables(serviceBuilder *runit.ServiceBuilder) ([]H
 			ExecPath:      binLaunchPath,
 			Chpst:         h.Chpst,
 			Contain:       h.Contain,
+			Container:     h.ContainerType,
 			ContainerName: h.Id,
 			Nolimit:       "/usr/bin/nolimit",
 			RunAs:         h.RunAs,
@@ -201,6 +203,7 @@ func (h *HoistLaunchable) Executables(serviceBuilder *runit.ServiceBuilder) ([]H
 				ExecPath:      execPath,
 				Chpst:         h.Chpst,
 				Contain:       h.Contain,
+				Container:     h.ContainerType,
 				ContainerName: h.Id,
 				Nolimit:       "/usr/bin/nolimit",
 				RunAs:         h.RunAs,

--- a/pkg/hoist/hoist_launchable_test.go
+++ b/pkg/hoist/hoist_launchable_test.go
@@ -27,13 +27,14 @@ func TestInstall(t *testing.T) {
 	defer os.RemoveAll(launchableHome)
 
 	launchable := &HoistLaunchable{
-		testLocation,
-		"hello",
-		currentUser.Username,
-		launchableHome,
-		fc.File,
-		launchableHome,
-		FakeChpst(),
+		Location:    testLocation,
+		Id:          "hello",
+		RunAs:       currentUser.Username,
+		ConfigDir:   launchableHome,
+		FetchToFile: fc.File,
+		RootDir:     launchableHome,
+		Chpst:       FakeChpst(),
+		Contain:     "/usr/bin/contain",
 	}
 
 	err = launchable.Install()
@@ -54,7 +55,16 @@ func TestInstall(t *testing.T) {
 func TestInstallDir(t *testing.T) {
 	tempDir := os.TempDir()
 	testLocation := "http://someserver/test_launchable_abc123.tar.gz"
-	launchable := &HoistLaunchable{testLocation, "testLaunchable", "testuser", tempDir, new(FakeCurl).File, tempDir, ""}
+	launchable := &HoistLaunchable{
+		Location:    testLocation,
+		Id:          "testLaunchable",
+		RunAs:       "testuser",
+		ConfigDir:   tempDir,
+		FetchToFile: new(FakeCurl).File,
+		RootDir:     tempDir,
+		Chpst:       "",
+		Contain:     "",
+	}
 
 	installDir := launchable.InstallDir()
 

--- a/pkg/hoist/test_helper.go
+++ b/pkg/hoist/test_helper.go
@@ -27,6 +27,10 @@ func FakeChpst() string {
 	return util.From(runtime.Caller(0)).ExpandPath("fake_chpst")
 }
 
+func FakeContain() string {
+	return util.From(runtime.Caller(0)).ExpandPath("fake_contain")
+}
+
 func FakeHoistLaunchableForDir(dirName string) *HoistLaunchable {
 	tempDir, _ := ioutil.TempDir("", "fakeenv")
 	_, filename, _, _ := runtime.Caller(0)

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -471,14 +471,15 @@ func (pod *Pod) getLaunchable(launchableStanza LaunchableStanza) (*hoist.HoistLa
 		launchableRootDir := path.Join(pod.path, launchableStanza.LaunchableId)
 		launchableId := strings.Join([]string{pod.Id, "__", launchableStanza.LaunchableId}, "")
 		return &hoist.HoistLaunchable{
-			Location:    launchableStanza.Location,
-			Id:          launchableId,
-			RunAs:       pod.RunAs,
-			ConfigDir:   pod.EnvDir(),
-			FetchToFile: hoist.DefaultFetcher(),
-			RootDir:     launchableRootDir,
-			Chpst:       pod.Chpst,
-			Contain:     pod.Contain,
+			Location:      launchableStanza.Location,
+			Id:            launchableId,
+			RunAs:         pod.RunAs,
+			ConfigDir:     pod.EnvDir(),
+			FetchToFile:   hoist.DefaultFetcher(),
+			RootDir:       launchableRootDir,
+			Chpst:         pod.Chpst,
+			Contain:       pod.Contain,
+			ContainerType: launchableStanza.ContainerType,
 		}, nil
 	} else {
 		err := fmt.Errorf("launchable type '%s' is not supported yet", launchableStanza.LaunchableType)

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -40,6 +40,7 @@ type Pod struct {
 	SV             *runit.SV
 	ServiceBuilder *runit.ServiceBuilder
 	Chpst          string
+	Contain        string
 }
 
 func NewPod(id string, path string) *Pod {
@@ -51,6 +52,7 @@ func NewPod(id string, path string) *Pod {
 		SV:             runit.DefaultSV,
 		ServiceBuilder: runit.DefaultBuilder,
 		Chpst:          runit.DefaultChpst,
+		Contain:        runit.DefaultContain,
 	}
 }
 
@@ -476,6 +478,7 @@ func (pod *Pod) getLaunchable(launchableStanza LaunchableStanza) (*hoist.HoistLa
 			FetchToFile: hoist.DefaultFetcher(),
 			RootDir:     launchableRootDir,
 			Chpst:       pod.Chpst,
+			Contain:     pod.Contain,
 		}, nil
 	} else {
 		err := fmt.Errorf("launchable type '%s' is not supported yet", launchableStanza.LaunchableType)

--- a/pkg/pods/pod_manifest.go
+++ b/pkg/pods/pod_manifest.go
@@ -23,6 +23,7 @@ type LaunchableStanza struct {
 	LaunchableType string `yaml:"launchable_type"`
 	LaunchableId   string `yaml:"launchable_id"`
 	Location       string `yaml:"location"`
+	ContainerType  string `yaml:"container,omitempty"`
 }
 
 type PodManifest struct {

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -208,6 +208,7 @@ func TestBuildRunitServices(t *testing.T) {
 	hoistLaunchable := hoist.FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
 	hoistLaunchable.RunAs = "testPod"
 	hoistLaunchable.Contain = hoist.FakeContain()
+	hoistLaunchable.ContainerType = "mycgroup"
 	executables, err := hoistLaunchable.Executables(serviceBuilder)
 	outFilePath := path.Join(serviceBuilder.ConfigRoot, "testPod.yaml")
 

--- a/pkg/runit/servicebuilder.go
+++ b/pkg/runit/servicebuilder.go
@@ -74,6 +74,7 @@ var DefaultBuilder = &ServiceBuilder{
 }
 
 var DefaultChpst = "/usr/bin/chpst"
+var DefaultContain = "/usr/bin/contain"
 
 func (b *ServiceBuilder) serviceYamlPath(name string) string {
 	return path.Join(b.ConfigRoot, fmt.Sprintf("%s.yaml", name))


### PR DESCRIPTION
Introduces a dependency on our [contain](https://github.com/square/prodeng/tree/master/cgroup-container) script. I was planning to use libcontainer for this, but there are too many moving parts in their top-level API, and their internal packages are clearly not intended for third-party consumption.

I kind of dislike the code surrounding "insert this binary into the runit script for this hoist executable". This has me thinking about a better API for that area, but it can wait for now.