### PR TITLE
allow hook in integration test to run as root

### DIFF
--- a/integration/single-node-slug-deploy/check.go
+++ b/integration/single-node-slug-deploy/check.go
@@ -138,6 +138,21 @@ mkdir -p $HOOKED_POD_HOME
 		return err
 	}
 
+	userHookManifest, err := pods.PodManifestFromPath(manifestPath)
+	if err != nil {
+		return err
+	}
+
+	userHookManifest.Config["hook"] = map[interface{}]interface{}{
+		"run_as": "root",
+	}
+	contents, err := userHookManifest.Bytes()
+	if err != nil {
+		return err
+	}
+
+	ioutil.WriteFile(manifestPath, contents, 0644)
+
 	manifestPath, err = signManifest(manifestPath, tmpdir)
 	if err != nil {
 		return err


### PR DESCRIPTION
since we now default hooks to run as the pod ID, we need to allow this user creation hook to run as root