### PR TITLE
Allow degraded health checks in replication rollouts

### DIFF
--- a/pkg/health/health_state.go
+++ b/pkg/health/health_state.go
@@ -1,0 +1,63 @@
+package health
+
+import (
+	"fmt"
+)
+
+type HealthState string
+
+var (
+	Passing  = HealthState("passing")
+	Unknown  = HealthState("unknown")
+	Warning  = HealthState("warning")
+	Critical = HealthState("critical")
+
+	NoStatusGiven = fmt.Errorf("No status given")
+)
+
+func ToHealthState(v string) HealthState {
+	if v == "passing" {
+		return Passing
+	}
+	if v == "unknown" {
+		return Unknown
+	}
+	if v == "warning" {
+		return Warning
+	}
+	if v == "critical" {
+		return Critical
+	}
+	return Unknown
+}
+
+// Compare two HealthStates. Return 0 if equal, -1 if a<b and +1 if a>b.
+// The ordering is Passing>Warning>Unknown>Critical.
+func Compare(a, b HealthState) int {
+	if a == b {
+		return 0
+	}
+
+	if a == Passing {
+		return 1
+	}
+	if b == Passing {
+		return -1
+	}
+
+	if a == Warning {
+		return 1
+	}
+	if b == Warning {
+		return -1
+	}
+
+	if a == Unknown {
+		return 1
+	}
+	if b == Unknown {
+		return -1
+	}
+
+	return 0
+}

--- a/pkg/replication/replication.go
+++ b/pkg/replication/replication.go
@@ -141,7 +141,7 @@ func (repl *Replicator) isHealthyAndCurrent(status *health.ServiceNodeStatus, er
 	} else if err == nil {
 		sha, _ := repl.Manifest.SHA()
 		repl.Logger.WithField("status", status).Debugln("Comparing")
-		return status.Healthy, status.IsCurrentVersion(sha)
+		return status.Health == health.Passing, status.IsCurrentVersion(sha)
 	} else {
 		repl.Logger.WithFields(logrus.Fields{
 			"err":  err,

--- a/pkg/replication/replication_test.go
+++ b/pkg/replication/replication_test.go
@@ -108,15 +108,15 @@ statuses:
   host1.domain:
     node: host1.domain
     version: abc123
-    healthy: true
+    health: passing
   host2.domain:
     node: host2.domain
     version: abc123
-    healthy: true
+    health: passing
   host3.domain:
     node: host3.domain
     version: abc123
-    healthy: true
+    health: passing
 `)
 	allocated := fakeAllocation("host1.domain", "host2.domain", "host3.domain")
 	manifest := podManifest(t, "foo", "def345")
@@ -131,7 +131,7 @@ statuses:
 		checker.resp.Statuses[node] = &health.ServiceNodeStatus{
 			Version: newManSha,
 			Node:    node,
-			Healthy: true,
+			Health:  health.Passing,
 		}
 	}
 

--- a/pkg/replication/rollout_order.go
+++ b/pkg/replication/rollout_order.go
@@ -23,14 +23,6 @@ func (c compare) less() bool {
 	return c == lessThan
 }
 
-func compareFromBool(b bool) compare {
-	if b {
-		return lessThan
-	} else {
-		return greaterThan
-	}
-}
-
 type rolloutOrder struct {
 	nodes           []allocation.Node
 	referenceStatus *health.ServiceStatus
@@ -88,19 +80,19 @@ func (r *rolloutOrder) compareErrors(iErr, jErr error) compare {
 }
 
 func (r *rolloutOrder) compareHealth(iNode, jNode allocation.Node, iHealth, jHealth *health.ServiceNodeStatus) compare {
-	if iHealth.Healthy && !jHealth.Healthy {
-		return greaterThan
+	comp := health.Compare(iHealth.Health, jHealth.Health)
+	if comp == 0 {
+		if iNode.Name < jNode.Name {
+			return lessThan
+		} else {
+			if iNode.Name == jNode.Name {
+				return equal
+			} else {
+				return greaterThan
+			}
+		}
 	}
-	if iHealth.Healthy && jHealth.Healthy {
-		return compareFromBool(iNode.Name < jNode.Name)
-	}
-	if !iHealth.Healthy && jHealth.Healthy {
-		return lessThan
-	}
-	if !iHealth.Healthy && !jHealth.Healthy {
-		return compareFromBool(iNode.Name < jNode.Name)
-	}
-	return equal
+	return compare(comp)
 }
 
 func (r *rolloutOrder) Swap(i, j int) {


### PR DESCRIPTION
Verified in universe - I set the wrong status port so all the health checks would be critical, then I set the replicate threshold to critical, and the rollout completed successfully.