### PR TITLE
Verify reality store during bootstrap

### DIFF
--- a/bin/p2-bootstrap/bootstrap.go
+++ b/bin/p2-bootstrap/bootstrap.go
@@ -129,7 +129,6 @@ func VerifyConsulUp(timeout string) error {
 }
 
 func VerifyReality(waitTime time.Duration, consulID, agentID string) error {
-	satisfied := make(chan struct{})
 	quit := make(chan struct{})
 	defer close(quit)
 	store := kp.NewStore(kp.Options{


### PR DESCRIPTION
Verifies that the Preparer and Consul both make it into the reality store. If ACLs are misconfigured for the preparer, this step will catch such an issue.