### PR TITLE
HTTPS in p2 binaries

### DIFF
--- a/bin/p2-inspect/main.go
+++ b/bin/p2-inspect/main.go
@@ -21,6 +21,7 @@ var (
 	filterPodId    = kingpin.Flag("pod", "The pod manifest ID to inspect. By default, all pods are shown.").String()
 	consulToken    = kingpin.Flag("token", "The consul ACL token to use. Empty by default.").String()
 	headers        = kingpin.Flag("header", "An HTTP header to add to requests, in KEY=VALUE form. Can be specified multiple times.").StringMap()
+	https          = kingpin.Flag("https", "Use HTTPS").Bool()
 )
 
 const (
@@ -51,6 +52,7 @@ func main() {
 		Address: *consulUrl,
 		Token:   *consulToken,
 		Client:  net.NewHeaderClient(*headers),
+		HTTPS:   *https,
 	}
 	store := kp.NewStore(opts)
 

--- a/bin/p2-replicate/main.go
+++ b/bin/p2-replicate/main.go
@@ -37,6 +37,7 @@ var (
 	consulToken = replicate.Flag("token", "The ACL token to use for consul").String()
 	threshold   = replicate.Flag("threshold", "The minimum health level to treat as healthy. One of (in order) passing, warning, unknown, critical.").String()
 	headers     = replicate.Flag("header", "An HTTP header to add to requests, in KEY=VALUE form. Can be specified multiple times.").StringMap()
+	https       = replicate.Flag("https", "Use HTTPS").Bool()
 )
 
 func main() {
@@ -47,6 +48,7 @@ func main() {
 		Address: *consulUrl,
 		Token:   *consulToken,
 		Client:  net.NewHeaderClient(*headers),
+		HTTPS:   *https,
 	}
 	store := kp.NewStore(opts)
 

--- a/bin/p2-schedule/main.go
+++ b/bin/p2-schedule/main.go
@@ -20,6 +20,7 @@ var (
 	consulAddress = kingpin.Flag("consul", "The address of the consul node to use. Defaults to 0.0.0.0:8500").String()
 	consulToken   = kingpin.Flag("token", "The ACL to use for accessing consul.").String()
 	headers       = kingpin.Flag("header", "An HTTP header to add to requests, in KEY=VALUE form. Can be specified multiple times.").StringMap()
+	https         = kingpin.Flag("https", "Use HTTPS").Bool()
 )
 
 func main() {
@@ -30,6 +31,7 @@ func main() {
 		Address: *consulAddress,
 		Token:   *consulToken,
 		Client:  net.NewHeaderClient(*headers),
+		HTTPS:   *https,
 	})
 
 	if *nodeName == "" {

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -44,10 +44,11 @@ type ConsulHealthChecker struct {
 	Store  kp.Store
 }
 
-func NewConsulHealthChecker(store kp.Store, consulHealth *api.Health) *ConsulHealthChecker {
+func NewConsulHealthChecker(opts kp.Options) *ConsulHealthChecker {
+	client := kp.NewConsulClient(opts)
 	return &ConsulHealthChecker{
-		Health: consulHealth,
-		Store:  store,
+		Health: client.Health(),
+		Store:  *kp.NewStore(opts),
 	}
 }
 

--- a/pkg/kp/config.go
+++ b/pkg/kp/config.go
@@ -1,0 +1,38 @@
+package kp
+
+import (
+	"net/http"
+
+	"github.com/hashicorp/consul/api"
+)
+
+type Options struct {
+	// The hostname and port of Consul (eg "example.com:8500"), or a unix socket
+	// (eg "unix:///var/run/consul.sock"). The empty string defaults to
+	// "127.0.0.1:8500".
+	Address string
+	// Set to true to use HTTPS.
+	HTTPS bool
+	// The ACL token to pass to Consul.
+	Token string
+	// If non-nil, this http.Client will be used for Consul communication.
+	Client *http.Client
+}
+
+func NewConsulClient(opts Options) *api.Client {
+	conf := api.DefaultConfig()
+	if opts.Address != "" {
+		conf.Address = opts.Address
+	}
+	if opts.Client != nil {
+		conf.HttpClient = opts.Client
+	}
+	if opts.HTTPS {
+		conf.Scheme = "https"
+	}
+	conf.Token = opts.Token
+
+	// error is always nil
+	ret, _ := api.NewClient(conf)
+	return ret
+}

--- a/pkg/kp/kv.go
+++ b/pkg/kp/kv.go
@@ -5,7 +5,6 @@ package kp
 import (
 	"bytes"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/hashicorp/consul/api"
@@ -17,25 +16,13 @@ type ManifestResult struct {
 	Manifest pods.Manifest
 	Path     string
 }
-type Options struct {
-	Token   string
-	Address string
-	Client  *http.Client
-}
 
 type Store struct {
 	client *api.Client
 }
 
 func NewStore(opts Options) *Store {
-	conf := api.DefaultConfig()
-	conf.Address = opts.Address
-	conf.Token = opts.Token
-	conf.HttpClient = opts.Client
-
-	// the error is always nil
-	client, _ := api.NewClient(conf)
-	return &Store{client: client}
+	return &Store{client: NewConsulClient(opts)}
 }
 
 // KVError encapsulates an error in a Store operation. Errors returned from the


### PR DESCRIPTION
I was originally going to add it as a scheme (eg `127.0.0.1:8500` vs `https://127.0.0.1:8500`) but it turns out that doesn't really work. Consul supports unix sockets in the address field (ie instead of `127.0.0.1` you can say `unix:///var/run/consul.sock`), and the unix socket scheme kinda gets in the way of the https part. So you have to pass it as a boolean.

The changes to health.NewConsulHealthChecker will be useful if we refactor the reality-checking out of pkg/health later on.