### PR TITLE
Register consul service during bootstrap

### DIFF
--- a/bin/p2-bootstrap/bootstrap.go
+++ b/bin/p2-bootstrap/bootstrap.go
@@ -177,7 +177,10 @@ func ScheduleForThisHost(manifest *pods.Manifest, alsoReality bool) error {
 
 	if alsoReality {
 		_, err = store.SetPod(kp.RealityPath(hostname, manifest.ID()), *manifest)
-		return err
+		if err != nil {
+			return err
+		}
+		return store.RegisterService(*manifest, "")
 	}
 	return nil
 }


### PR DESCRIPTION
Consul server nodes register a service for themselves automatically. Consul client nodes do not, but we end up registering one for them anyway as part of the reality-updating process. So we should probably do that in bootstrap too.