### PR TITLE
Add artifact cacher

### DIFF
--- a/pkg/hoist/artifact_cache.go
+++ b/pkg/hoist/artifact_cache.go
@@ -1,0 +1,117 @@
+package hoist
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/uri"
+	"github.com/square/p2/pkg/util"
+)
+
+// ArtifactCacher keeps a directory of Hoist artifacts that can be reused for future downloads.
+// This allows artifacts to be cheaply shared amongst different pods, especially in cases where
+// the artifacts contain base libraries and runtimes. For example, a pod may include a Java 8
+// artifact that is reused across other pods.
+//
+// The cache assumes that Hoist artifact URIs are unique at the basename, ie. comply with the
+// convention of {artifact_name}_{artifact_SHA}.tar.gz pattern. No attempt is made to distinguish
+// artifacts that are named the same but contain different content. (Checksumming is presumed to
+// be done by the Launchable itself)
+//
+// Once a cached copy of an artifact is created, it will be hardlinked into the final destination
+// URI provided by the caller. This allows the ArtifactCacher to safely prune without worrying about
+// whether the artifact is still in use by a particular Launchable (say, as the Last link). However,
+// as a result of this strategy, pruning the cache dir will not be sufficient to free system disk
+// resources as other links to the same tars will also need to be removed.
+type ArtifactCacher struct {
+	cacheDir      string
+	nestedFetcher Fetcher
+	Logger        *logging.Logger
+}
+
+// Complies with the Fetcher interface
+func (a *ArtifactCacher) Fetch(fromURI, toURI string) error {
+	base := filepath.Base(toURI)
+	if base == "." || base == string(filepath.Separator) {
+		return util.Errorf("%s is not a valid toURI", toURI)
+	}
+	cachePath := filepath.Join(a.cacheDir, base)
+	if _, err := os.Stat(cachePath); os.IsNotExist(err) {
+		a.nestedFetcher(fromURI, cachePath)
+	} else if err != nil {
+		return util.Errorf("Error stating the cache path: %s", err)
+	} else {
+		err = a.touch(cachePath)
+		if err != nil {
+			a.Logger.WithField("err", err).Warnln("Error when updating mtime on cached artifact")
+		}
+	}
+	// hardlink so we can safely prune without breaking Last/Current links
+	linkErr := os.Link(cachePath, toURI)
+	if linkErr != nil {
+		// we may be on different mounts, just copy
+		err := uri.URICopy(cachePath, toURI)
+		if err != nil {
+			return util.Errorf("Could not link or copy file from %s to %s: %s - %s", cachePath, toURI, err, linkErr)
+		}
+	}
+	return nil
+}
+
+type byMtime []os.FileInfo
+
+func (b byMtime) Len() int           { return len(b) }
+func (b byMtime) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
+func (b byMtime) Less(i, j int) bool { return b[i].ModTime().Before(b[j].ModTime()) }
+
+// Prune will remove all but `keep` # of artifacts
+// from the cache dir. Prune will favor more recently modified artifacts
+func (a *ArtifactCacher) Prune(keep int) {
+	infos, err := ioutil.ReadDir(a.cacheDir)
+	if err != nil {
+		err = util.Errorf("cache dir unlistable: %s", err)
+		a.Logger.WithField("err", err).Errorln("Pruning failed")
+		return
+	}
+	byMtimeInfos := byMtime(infos)
+	sort.Sort(&byMtimeInfos)
+	for i := len(infos) - 1; i >= keep; i-- {
+		info := infos[i]
+		err = os.Remove(filepath.Join(a.cacheDir, info.Name()))
+		if err != nil {
+			a.Logger.WithFields(logrus.Fields{
+				"path": info.Name(),
+				"err":  err,
+			}).Errorln("Could not prune")
+		}
+	}
+}
+
+func (a *ArtifactCacher) touch(cachePath string) error {
+	err := os.Chtimes(cachePath, time.Now(), time.Now())
+	if err != nil {
+		return util.Errorf("Couldn't update %s mtime: %s", cachePath, err)
+	}
+	return nil
+}
+
+func WithCacher(f Fetcher, cacheDir string) (*ArtifactCacher, error) {
+	if _, err := os.Stat(cacheDir); os.IsNotExist(err) {
+		err = os.MkdirAll(cacheDir, 0644)
+		if err != nil {
+			return nil, util.Errorf("Could not initialize cacheDir %s: %s", cacheDir, err)
+		}
+	}
+	logger := logging.DefaultLogger.SubLogger(logrus.Fields{"source": "artifact_cache"})
+	cacher := &ArtifactCacher{
+		cacheDir:      cacheDir,
+		nestedFetcher: f,
+		Logger:        &logger,
+	}
+	return cacher, nil
+}

--- a/pkg/hoist/artifact_cache_test.go
+++ b/pkg/hoist/artifact_cache_test.go
@@ -1,0 +1,108 @@
+package hoist
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	. "github.com/anthonybishopric/gotcha"
+	"github.com/square/p2/pkg/uri"
+	"github.com/square/p2/pkg/util"
+)
+
+func helloTar() string {
+	return util.From(runtime.Caller(0)).ExpandPath("hoisted-hello_def456.tar.gz")
+}
+
+func cleanupCacher(a *ArtifactCacher) {
+	os.RemoveAll(a.cacheDir)
+}
+
+func tempCacher(t *testing.T) *ArtifactCacher {
+	dir, err := ioutil.TempDir("", "cacher-test")
+	Assert(t).IsNil(err, "Should not have erred creating a temp dir")
+	cacher, err := WithCacher(DefaultFetcher(), dir)
+	Assert(t).IsNil(err, "test setup error - could not create cacher")
+	return cacher
+}
+
+func TestArtifactCacheWillCacheNewlyDiscoveredArtifacts(t *testing.T) {
+	dest, err := ioutil.TempDir("", "download-target")
+	Assert(t).IsNil(err, "Should not have erred creating a temp dir")
+	defer os.RemoveAll(dest)
+	cacher := tempCacher(t)
+	defer cleanupCacher(cacher)
+	helloDest := filepath.Join(dest, "hello.tar.gz")
+	err = cacher.Fetch(helloTar(), helloDest)
+
+	Assert(t).IsNil(err, "Cacher returned an error when fetching")
+
+	info, err := os.Stat(filepath.Join(cacher.cacheDir, "hello.tar.gz"))
+	Assert(t).IsNil(err, "should not have erred stating the expected cached tar location")
+	Assert(t).IsTrue(info.Size() > 0, "should have cached something")
+
+	info, err = os.Stat(helloDest)
+	Assert(t).IsNil(err, "should not have erred stating the expected destination")
+	Assert(t).IsTrue(info.Size() > 0, "should have actually fetched to the target")
+}
+
+func TestArtifactCacheWillTouchExistingArtifactsOnAccess(t *testing.T) {
+	cacher := tempCacher(t)
+	defer cleanupCacher(cacher)
+	preCopiedPath := filepath.Join(cacher.cacheDir, filepath.Base(helloTar()))
+	err := uri.URICopy(helloTar(), preCopiedPath)
+	Assert(t).IsNil(err, "test setup - couldn't prewarm cache")
+	aYearAgo := time.Now().Add(-365 * 24 * time.Hour)
+	anHourAgo := time.Now().Add(-time.Hour)
+
+	fmt.Println(aYearAgo)
+	fmt.Println(anHourAgo)
+
+	err = os.Chtimes(preCopiedPath, aYearAgo, aYearAgo)
+	Assert(t).IsNil(err, "test setup - should have been able to change mtime")
+
+	dest, err := ioutil.TempDir("", "download-target")
+	Assert(t).IsNil(err, "test setup - should not have erred creating a temp dir")
+	defer os.RemoveAll(dest)
+
+	err = cacher.Fetch(helloTar(), filepath.Join(dest, filepath.Base(helloTar())))
+	Assert(t).IsNil(err, "cacher erred during copy")
+
+	info, err := os.Stat(preCopiedPath)
+	Assert(t).IsNil(err, "should not have erred stating the cache path")
+
+	fmt.Println(info.ModTime())
+	Assert(t).IsTrue(info.ModTime().After(anHourAgo), "cacher didn't touch the pre-copied path")
+}
+
+func TestArtifactCacheWillPruneAllIfKeepIsZero(t *testing.T) {
+	dest, err := ioutil.TempDir("", "download-target")
+	Assert(t).IsNil(err, "Should not have erred creating a temp dir")
+	defer os.RemoveAll(dest)
+	cacher := tempCacher(t)
+	defer cleanupCacher(cacher)
+	helloDest := filepath.Join(dest, "hello.tar.gz")
+	err = cacher.Fetch(helloTar(), helloDest)
+	helloDest2 := filepath.Join(dest, "hello2.tar.gz")
+	err = cacher.Fetch(helloTar(), helloDest2)
+	helloDest3 := filepath.Join(dest, "hello3.tar.gz")
+	err = cacher.Fetch(helloTar(), helloDest3)
+
+	cacher.Prune(1)
+
+	files, err := ioutil.ReadDir(cacher.cacheDir)
+
+	Assert(t).IsNil(err, "Should not have erred reading dir")
+	Assert(t).AreEqual(1, len(files), "Should have had 1 file left")
+
+	cacher.Prune(0)
+
+	files, err = ioutil.ReadDir(cacher.cacheDir)
+
+	Assert(t).IsNil(err, "Should not have erred reading dir")
+	Assert(t).AreEqual(0, len(files), "Should have had no files left")
+}


### PR DESCRIPTION
To be integrated, this will allow us to reduce unnecessarily download times when deploying shared artifacts.