### PR TITLE
Restart all executables

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -164,7 +164,7 @@ func (hl *Launchable) start(serviceBuilder *runit.ServiceBuilder, sv *runit.SV) 
 
 	for _, executable := range executables {
 		_, err := sv.Restart(&executable.Service)
-		if err != runit.SuperviseOkMissing {
+		if err != nil && err != runit.SuperviseOkMissing {
 			return err
 		}
 	}


### PR DESCRIPTION
If the error was nil, it would be returned after the first executable, and the others would still be down. (Probably wasn't as obvious of an issue before because we only recently started stopping AND starting)