### PR TITLE
Use full 20-byte GPG fingerprints

### DIFF
--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -1,6 +1,7 @@
 package preparer
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -181,7 +182,7 @@ func (p *Preparer) verifySignature(manifest pods.Manifest, logger logging.Logger
 
 	signer, err := manifest.Signer(p.keyring)
 	if signer != nil {
-		signerId := signer.PrimaryKey.KeyIdShortString()
+		signerId := fmt.Sprintf("%X", signer.PrimaryKey.Fingerprint)
 		logger.WithField("signer_key", signerId).Debugln("Resolved manifest signature")
 
 		// Hmm, some hacks here.

--- a/pkg/preparer/orchestrate_test.go
+++ b/pkg/preparer/orchestrate_test.go
@@ -342,7 +342,7 @@ func TestPreparerWillAcceptAuthorizedSignatureForPreparer(t *testing.T) {
 	sig := ""
 	manifest, fakeSigner := testSignedManifest(t, func(m *pods.Manifest, e *openpgp.Entity) {
 		m.Id = POD_ID
-		sig = e.PrimaryKey.KeyIdShortString()
+		sig = fmt.Sprintf("%X", e.PrimaryKey.Fingerprint)
 	})
 
 	p, _, fakePodRoot := testPreparer(t, &FakeStore{})


### PR DESCRIPTION
GPG short IDs are only 4 bytes long and can risk collisions. Using the entire fingerprint (20 bytes) is more predictable.

http://security.stackexchange.com/questions/74009/what-is-an-openpgp-key-id-collision