### PR TITLE
Allow zero launchables or zero executables

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -182,7 +182,9 @@ func (hl *Launchable) Executables(serviceBuilder *runit.ServiceBuilder) ([]Execu
 	binLaunchPath := filepath.Join(hl.InstallDir(), "bin", "launch")
 
 	binLaunchInfo, err := os.Stat(binLaunchPath)
-	if err != nil {
+	if os.IsNotExist(err) {
+		return []Executable{}, nil
+	} else if err != nil {
 		return nil, util.Errorf("%s", err)
 	}
 

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -507,20 +507,14 @@ func writeEnvFile(envDir, name, value string, uid, gid int) error {
 
 func (pod *Pod) Launchables(manifest *Manifest) ([]hoist.Launchable, error) {
 	launchableStanzas := manifest.LaunchableStanzas
-	if len(launchableStanzas) == 0 {
-		return nil, util.Errorf("Pod must provide at least one launchable, none found")
-	}
+	launchables := make([]hoist.Launchable, 0, len(launchableStanzas))
 
-	launchables := make([]hoist.Launchable, len(launchableStanzas))
-	var i int = 0
 	for _, launchableStanza := range launchableStanzas {
-
 		launchable, err := pod.getLaunchable(launchableStanza)
 		if err != nil {
 			return nil, err
 		}
-		launchables[i] = *launchable
-		i++
+		launchables = append(launchables, *launchable)
 	}
 
 	return launchables, nil


### PR DESCRIPTION
Note that you can still get some undesired behavior when scheduling an empty manifest (eg the service check will still be created if the status_port is in the manifest), but that's a separate issue