### PR TITLE
Refactor URI fetcher to support streaming

### DIFF
--- a/pkg/hoist/test_helper.go
+++ b/pkg/hoist/test_helper.go
@@ -6,33 +6,22 @@ import (
 	"os/user"
 	"runtime"
 
+	"github.com/square/p2/pkg/uri"
 	"github.com/square/p2/pkg/util"
 )
-
-type FakeCurl struct {
-	url     string
-	outPath string
-}
-
-func (fc *FakeCurl) File(url string, outPath string) error {
-	fc.url = url
-	fc.outPath = outPath
-
-	return DefaultFetcher()(url, outPath)
-}
 
 func FakeHoistLaunchableForDir(dirName string) *Launchable {
 	tempDir, _ := ioutil.TempDir("", "fakeenv")
 	launchableInstallDir := util.From(runtime.Caller(0)).ExpandPath(dirName)
 
 	launchable := &Launchable{
-		Location:    "testLaunchable.tar.gz",
-		Id:          "testPod__testLaunchable",
-		RunAs:       "testPod",
-		ConfigDir:   tempDir,
-		FetchToFile: new(FakeCurl).File,
-		RootDir:     launchableInstallDir,
-		P2exec:      util.From(runtime.Caller(0)).ExpandPath("fake_p2-exec"),
+		Location:  "testLaunchable.tar.gz",
+		Id:        "testPod__testLaunchable",
+		RunAs:     "testPod",
+		ConfigDir: tempDir,
+		Fetcher:   uri.DefaultFetcher,
+		RootDir:   launchableInstallDir,
+		P2exec:    util.From(runtime.Caller(0)).ExpandPath("fake_p2-exec"),
 	}
 
 	curUser, err := user.Current()

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -371,7 +371,7 @@ func (pod *Pod) Verify(manifest *Manifest, keyring openpgp.KeyRing) error {
 		digestPath := filepath.Join(temp, launchable.Version()+".sum")
 		// TODO: the fetcher should eventually be configurable, passed to a
 		// launchable from the pod that instantiated it
-		err = launchable.FetchToFile(stanza.DigestLocation, digestPath)
+		err = launchable.Fetcher.CopyLocal(stanza.DigestLocation, digestPath)
 		if err != nil {
 			return err
 		}
@@ -391,7 +391,7 @@ func (pod *Pod) Verify(manifest *Manifest, keyring openpgp.KeyRing) error {
 			}
 		} else {
 			digestSigPath := filepath.Join(temp, launchable.Version()+".sum.sig")
-			err = launchable.FetchToFile(stanza.DigestSignatureLocation, digestSigPath)
+			err = launchable.Fetcher.CopyLocal(stanza.DigestSignatureLocation, digestSigPath)
 			if err != nil {
 				return err
 			}
@@ -527,7 +527,7 @@ func (pod *Pod) getLaunchable(launchableStanza LaunchableStanza, runAsUser strin
 			Id:               launchableId,
 			RunAs:            runAsUser,
 			ConfigDir:        pod.EnvDir(),
-			FetchToFile:      hoist.DefaultFetcher(),
+			Fetcher:          uri.DefaultFetcher,
 			RootDir:          launchableRootDir,
 			P2exec:           pod.P2exec,
 			CgroupConfig:     launchableStanza.CgroupConfig,

--- a/pkg/uri/uri.go
+++ b/pkg/uri/uri.go
@@ -10,68 +10,105 @@ import (
 	"github.com/square/p2/pkg/util"
 )
 
-var leadingProto = regexp.MustCompile("^[a-zA-Z\\d\\.]+:.*")
+// Internet Standard: STD 66
+var leadingScheme = regexp.MustCompile(`^([a-zA-Z][a-zA-Z0-9+\-.]*):`)
 
-type Copier struct {
-	Client *http.Client
+// A UriFetcher presents simple methods for fetching URIs from
+// different schemes.
+type Fetcher interface {
+	// Opens a data stream to the source URI. If no URI scheme is
+	// specified, treats the URI as a path to a local file.
+	Open(uri string) (io.ReadCloser, error)
+
+	// Copy all data from the source URI to a local file at the
+	// destination path.
+	CopyLocal(srcUri, dstPath string) error
 }
 
-func NewCopier(client *http.Client) *Copier {
-	copier := &Copier{
-		Client: client,
-	}
-
-	return copier
-}
-
-var DefaultCopier *Copier = NewCopier(http.DefaultClient)
+// A default fetcher, if the user doesn't want to set any options.
+var DefaultFetcher Fetcher = BasicFetcher{http.DefaultClient}
 
 // URICopy Wraps opening and copying content from URIs. Will attempt
 // directly perform file copies if the uri is begins with file://, otherwise
 // delegates to a curl implementation.
-func URICopy(fromURI, toPath string) error {
-	return DefaultCopier.Copy(fromURI, toPath)
+var URICopy = DefaultFetcher.CopyLocal
+
+// BasicFetcher can access "file" and "http" schemes using the OS and
+// a provided HTTP client, respectively.
+type BasicFetcher struct {
+	Client *http.Client
 }
 
-func copyFile(dst, src string) error {
-	s, err := os.Open(src)
-	if err != nil {
-		return util.Errorf("Couldn't open source file '%s' for reading: %s", src, err)
+func (f BasicFetcher) Open(srcUri string) (io.ReadCloser, error) {
+	var scheme, opaque string
+	if matches := leadingScheme.FindStringSubmatch(srcUri); matches != nil {
+		scheme = strings.ToLower(matches[1])
+		opaque = srcUri[len(matches[0]):]
 	}
-	defer s.Close()
-	d, err := os.Create(dst)
-	if err != nil {
-		return util.Errorf("Couldn't open destination file '%s' for writing: %s", dst, err)
+	switch scheme {
+	case "":
+		// Assume a schemeless URI is a path to a local file
+		return os.Open(srcUri)
+	case "file":
+		// Only allow local, absolute file references
+		if !strings.HasPrefix(opaque, "///") {
+			return nil, util.Errorf("%s: invalid file URI", srcUri)
+		}
+		return os.Open(opaque[3:])
+	case "http", "https":
+		resp, err := f.Client.Get(srcUri)
+		if err != nil {
+			return nil, err
+		}
+		return resp.Body, nil
+	default:
+		return nil, util.Errorf("%s: unhandled URI scheme", srcUri)
 	}
-	if _, err := io.Copy(d, s); err != nil {
-		d.Close()
-		return util.Errorf("Couldn't copy file contents to the destination: %s", err)
-	}
-	return d.Close()
 }
 
-func (c *Copier) Copy(fromURI, toPath string) error {
-	hasProto := leadingProto.MatchString(fromURI)
-	if !hasProto {
-		return copyFile(toPath, fromURI)
+func (f BasicFetcher) CopyLocal(srcUri, dstPath string) (err error) {
+	src, err := f.Open(srcUri)
+	if err != nil {
+		return
 	}
-	if strings.HasPrefix(fromURI, "file://") {
-		return copyFile(toPath, fromURI[len("file://"):])
-	} else {
-		resp, err := c.Client.Get(fromURI)
-		if err != nil {
-			return util.Errorf("Couldn't copy file using HTTP: %s", err)
-		}
-		defer resp.Body.Close()
-		d, err := os.Create(toPath)
-		if err != nil {
-			return util.Errorf("Couldn't open destination file '%s' for writing: %s", toPath, err)
-		}
-		_, err = io.Copy(d, resp.Body)
-		if err != nil {
-			d.Close()
-			return util.Errorf("Couldn't copy to the destination file '%s': %s ", toPath, err)
-		}
-		return d.Close()
+	defer src.Close()
+	dest, err := os.Create(dstPath)
+	if err != nil {
+		return
 	}
+	defer func() {
+		// Return the Close() error unless another error happened first
+		if errC := dest.Close(); err == nil {
+			err = errC
+		}
+	}()
+	_, err = io.Copy(dest, src)
+	return
+}
+
+// A LoggedFetcher wraps another uri.Fetcher, forwarding all calls and
+// recording their arguments. Useful for unit testing.
+type LoggedFetcher struct {
+	fetcher Fetcher
+	SrcUri  string
+	DstPath string
+}
+
+func NewLoggedFetcher(fetcher Fetcher) *LoggedFetcher {
+	if fetcher == nil {
+		fetcher = DefaultFetcher
+	}
+	return &LoggedFetcher{fetcher, "", ""}
+}
+
+func (f *LoggedFetcher) Open(srcUri string) (io.ReadCloser, error) {
+	f.SrcUri = srcUri
+	f.DstPath = ""
+	return f.fetcher.Open(srcUri)
+}
+
+func (f *LoggedFetcher) CopyLocal(srcUri, dstPath string) error {
+	f.SrcUri = srcUri
+	f.DstPath = dstPath
+	return f.fetcher.CopyLocal(srcUri, dstPath)
 }

--- a/pkg/uri/uri_test.go
+++ b/pkg/uri/uri_test.go
@@ -15,12 +15,21 @@ import (
 )
 
 func TestLeadingProtoRegexMatchesProto(t *testing.T) {
-	Assert(t).IsTrue(leadingProto.MatchString("file:///foo/bar/baz"), "Should have matched")
-	Assert(t).IsTrue(leadingProto.MatchString("http://www.com/foo/bar/baz"), "Should have matched")
+	Assert(t).IsTrue(
+		leadingScheme.MatchString("file:///foo/bar/baz"),
+		"Should have matched",
+	)
+	Assert(t).IsTrue(
+		leadingScheme.MatchString("http://www.com/foo/bar/baz"),
+		"Should have matched",
+	)
 }
 
 func TestLeadingProtoRegexDoesNotMatchPath(t *testing.T) {
-	Assert(t).IsFalse(leadingProto.MatchString("/foo/bar/baz"), "Should not have matched")
+	Assert(t).IsFalse(
+		leadingScheme.MatchString("/foo/bar/baz"),
+		"Should not have matched",
+	)
 }
 
 func TestURIWillCopyFilesCorrectly(t *testing.T) {
@@ -62,13 +71,19 @@ func TestCorrectlyPullsFilesOverHTTP(t *testing.T) {
 	caller := util.From(runtime.Caller(0))
 
 	ts := httptest.NewServer(http.FileServer(http.Dir(caller.Dirname())))
-	Assert(t).IsTrue(leadingProto.MatchString(ts.URL), fmt.Sprintf("the http test server generated an invalid url (%s)", ts.URL))
+	Assert(t).IsTrue(
+		leadingScheme.MatchString(ts.URL),
+		fmt.Sprintf("the http test server generated an invalid url (%s)", ts.URL),
+	)
 	defer ts.Close()
 
 	// Do not use path.Join for URLs. It will compress consecutive forward slashes.
 	// ie, http:// becomes http:/
 	source := fmt.Sprintf("%s/%s", ts.URL, path.Base(caller.Filename))
-	Assert(t).IsTrue(leadingProto.MatchString(source), fmt.Sprintf("The url %s should have had a proto", source))
+	Assert(t).IsTrue(
+		leadingScheme.MatchString(source),
+		fmt.Sprintf("The url %s should have had a proto", source),
+	)
 
 	err = URICopy(source, copied)
 	Assert(t).IsNil(err, "the file should have been downloaded")


### PR DESCRIPTION
The "uri" module presented a nice interface for copying a file from an
arbitrary URI to a local file. But what if you just want to consume the data
stream and not store it? This commit refactors the `uri.Copier` type into the
`uri.Fetcher` interface, which exposes the URI data stream directly (you can
still make a local copy if you want).

By accessing the data stream, users can avoid allocating a temporary directory,
writing a file to it, operating on the file, then deleting it.