### PR TITLE
Move servicebuilder functionality into p2

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -33,14 +33,23 @@ type Launchable struct {
 }
 
 func (hl *Launchable) Halt(serviceBuilder *runit.ServiceBuilder, sv *runit.SV) error {
-	// probably want to do something with output at some point
 	_, err := hl.disable()
 	if err != nil {
 		return err
 	}
 
-	// probably want to do something with output at some point
 	err = hl.stop(serviceBuilder, sv)
+	if err != nil {
+		return err
+	}
+
+	// send an empty list of templates, to clean up all the runit services for
+	// this launchable
+	err = serviceBuilder.Activate(hl.Id, map[string]runit.ServiceTemplate{})
+	if err != nil {
+		return err
+	}
+	err = serviceBuilder.Prune()
 	if err != nil {
 		return err
 	}
@@ -54,18 +63,44 @@ func (hl *Launchable) Halt(serviceBuilder *runit.ServiceBuilder, sv *runit.SV) e
 }
 
 func (hl *Launchable) Launch(serviceBuilder *runit.ServiceBuilder, sv *runit.SV) error {
-	// probably want to do something with output at some point
-	err := hl.start(serviceBuilder, sv)
-	if err != nil {
-		return util.Errorf("Could not launch %s: %s", hl.Id, err)
+	if err := hl.MakeCurrent(); err != nil {
+		return err
 	}
 
-	_, err = hl.enable()
+	if _, err := hl.postActivate(); err != nil {
+		return err
+	}
+
+	if err := hl.buildServices(serviceBuilder); err != nil {
+		return err
+	}
+
+	if err := hl.start(serviceBuilder, sv); err != nil {
+		return err
+	}
+
+	_, err := hl.enable()
 	return err
 }
 
-func (hl *Launchable) PostActivate() (string, error) {
-	// TODO: unexport this method (requires integrating BuildRunitServices into this API)
+func (hl *Launchable) buildServices(sb *runit.ServiceBuilder) error {
+	executables, err := hl.Executables(sb)
+	if err != nil {
+		return err
+	}
+
+	templates := make(map[string]runit.ServiceTemplate)
+	for _, executable := range executables {
+		if _, ok := templates[executable.Service.Name]; ok {
+			return util.Errorf("Duplicate executable name %s for launchable %s", executable.Service.Name, hl.Id)
+		}
+		templates[executable.Service.Name] = runit.ServiceTemplate{Run: executable.Exec}
+	}
+
+	return sb.Activate(hl.Id, templates)
+}
+
+func (hl *Launchable) postActivate() (string, error) {
 	output, err := hl.invokeBinScript("post-activate")
 
 	// providing a post-activate script is optional, ignore those errors
@@ -271,7 +306,7 @@ func (hl *Launchable) CurrentDir() string {
 }
 
 func (hl *Launchable) MakeCurrent() error {
-	// TODO: unexport this method (requires integrating BuildRunitServices into this API)
+	// TODO: unexport this method (hooks still use it)
 	return hl.flipSymlink(hl.CurrentDir())
 }
 

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -127,35 +127,8 @@ func (pod *Pod) Launch(manifest *Manifest) (bool, error) {
 		return false, err
 	}
 
-	var successes []bool
-	for _, launchable := range launchables {
-		err := launchable.MakeCurrent()
-		if err != nil {
-			// being unable to flip a symlink is a catastrophic error
-			return false, err
-		}
-
-		out, err := launchable.PostActivate()
-		if err != nil {
-			// if a launchable's post-activate fails, we probably can't
-			// launch it, but this does not break the entire pod
-			pod.logLaunchableError(launchable.Id, err, out)
-			successes = append(successes, false)
-		} else {
-			if out != "" {
-				pod.logInfo(out)
-			}
-			successes = append(successes, true)
-		}
-	}
-
-	err = pod.buildRunitServices(launchables)
-
 	success := true
-	for i, launchable := range launchables {
-		if !successes[i] {
-			continue
-		}
+	for _, launchable := range launchables {
 		err = launchable.Launch(pod.ServiceBuilder, pod.SV) // TODO: make these configurable
 		if err != nil {
 			// Log the failure but continue
@@ -170,37 +143,11 @@ func (pod *Pod) Launch(manifest *Manifest) (bool, error) {
 		pod.logInfo("Launched pod but one or more services failed to start")
 	}
 
-	return success, nil
-}
-
-// Write servicebuilder *.yaml file and run servicebuilder, which will register runit services for this
-// pod.
-func (pod *Pod) buildRunitServices(launchables []hoist.Launchable) error {
-	// if the service is new, building the runit services also starts them, making the sv start superfluous but harmless
-	sbTemplate := runit.NewSBTemplate(pod.Id)
-	for _, launchable := range launchables {
-		executables, err := launchable.Executables(pod.ServiceBuilder)
-		if err != nil {
-			return err
-		}
-		for _, executable := range executables {
-			sbTemplate.AddEntry(executable.Service.Name, executable.Exec)
-		}
-		if err != nil {
-			// Log the failure but continue
-			pod.logLaunchableError(launchable.Id, err, "Unable to launch launchable")
-		}
-	}
-	_, err := pod.ServiceBuilder.Write(sbTemplate)
+	err = pod.ServiceBuilder.Prune()
 	if err != nil {
-		return err
+		pod.logError(err, "Could not prune services")
 	}
-
-	_, err = pod.ServiceBuilder.Rebuild()
-	if err != nil {
-		return err
-	}
-	return nil
+	return success, err
 }
 
 func (pod *Pod) WriteCurrentManifest(manifest *Manifest) (string, error) {
@@ -284,24 +231,12 @@ func (pod *Pod) Uninstall() error {
 		return err
 	}
 
-	// halt launchables
+	// halt launchables and remove their runit services
 	for _, launchable := range launchables {
 		err = launchable.Halt(runit.DefaultBuilder, runit.DefaultSV) // TODO: make these configurable
 		if err != nil {
-			// log and continue
+			pod.logLaunchableError(launchable.Id, err, "could not halt launchable")
 		}
-	}
-
-	// remove runit services
-	sbTemplate := runit.NewSBTemplate(pod.Id)
-	err = pod.ServiceBuilder.Remove(sbTemplate)
-	if err != nil {
-		return err
-	}
-
-	_, err = pod.ServiceBuilder.Rebuild()
-	if err != nil {
-		return err
 	}
 
 	// remove pod home dir

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 
 	"github.com/square/p2/pkg/hoist"
+	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/runit"
 	"github.com/square/p2/pkg/util"
-	"gopkg.in/yaml.v2"
 
 	. "github.com/anthonybishopric/gotcha"
 )
@@ -214,44 +214,6 @@ func TestWriteManifestWillReturnOldManifestTempPath(t *testing.T) {
 	manifestMustEqual(updated, writtenCurrent, t)
 }
 
-func TestBuildRunitServices(t *testing.T) {
-	serviceBuilder := runit.FakeServiceBuilder()
-	serviceBuilderDir, err := ioutil.TempDir("", "servicebuilderDir")
-	Assert(t).IsNil(err, "Got an unexpected error creating a temp directory")
-	serviceBuilder.ConfigRoot = serviceBuilderDir
-	pod := Pod{
-		Id:             "testPod",
-		path:           "/data/pods/testPod",
-		ServiceBuilder: serviceBuilder,
-	}
-	hl, sb := hoist.FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
-	defer hoist.CleanupFakeLaunchable(hl, sb)
-	hl.RunAs = "testPod"
-	executables, err := hl.Executables(serviceBuilder)
-	outFilePath := filepath.Join(serviceBuilder.ConfigRoot, "testPod.yaml")
-
-	Assert(t).IsNil(err, "Got an unexpected error when attempting to start runit services")
-
-	pod.buildRunitServices([]hoist.Launchable{*hl})
-	f, err := os.Open(outFilePath)
-	defer f.Close()
-	bytes, err := ioutil.ReadAll(f)
-	Assert(t).IsNil(err, "Got an unexpected error reading the servicebuilder yaml file")
-
-	expectedMap := map[string]interface{}{
-		executables[0].Service.Name: map[string]interface{}{
-			"run": executables[0].Exec,
-		},
-		executables[1].Service.Name: map[string]interface{}{
-			"run": executables[1].Exec,
-		},
-	}
-	expected, err := yaml.Marshal(expectedMap)
-	Assert(t).IsNil(err, "Got error marshalling expected map to yaml")
-
-	Assert(t).AreEqual(string(bytes), string(expected), "Servicebuilder yaml file didn't have expected contents")
-}
-
 func TestUninstall(t *testing.T) {
 	serviceBuilder := runit.FakeServiceBuilder()
 	serviceBuilderDir, err := ioutil.TempDir("", "servicebuilderDir")
@@ -263,6 +225,7 @@ func TestUninstall(t *testing.T) {
 		Id:             "testPod",
 		path:           testPodDir,
 		ServiceBuilder: serviceBuilder,
+		logger:         logging.DefaultLogger,
 	}
 	manifest := getTestPodManifest(t)
 	manifestContent, err := manifest.Bytes()
@@ -276,8 +239,6 @@ func TestUninstall(t *testing.T) {
 
 	err = pod.Uninstall()
 	Assert(t).IsNil(err, "Error uninstalling pod")
-	_, err = os.Stat(serviceBuilderFilePath)
-	Assert(t).IsTrue(os.IsNotExist(err), "Expected file to not exist after uninstall")
 	_, err = os.Stat(pod.currentPodManifestPath())
 	Assert(t).IsTrue(os.IsNotExist(err), "Expected file to not exist after uninstall")
 }

--- a/pkg/runit/fake_servicebuilder
+++ b/pkg/runit/fake_servicebuilder
@@ -1,3 +1,0 @@
-#!/usr/bin/env sh
-
-echo $@

--- a/pkg/runit/servicebuilder.go
+++ b/pkg/runit/servicebuilder.go
@@ -18,51 +18,85 @@
 package runit
 
 import (
-	"bytes"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"os"
-	"os/exec"
-	"path"
+	"path/filepath"
 
 	"github.com/square/p2/pkg/util"
 
 	"gopkg.in/yaml.v2"
 )
 
-type SBTemplate struct {
-	name       string
-	runClauses map[string]map[string][]string
+type ServiceTemplate struct {
+	Run      []string `yaml:"run"`
+	Log      []string `yaml:"log,omitempty"`
+	Sleep    int      `yaml:"sleep,omitempty"`
+	LogSleep int      `yaml:"logsleep,omitempty"`
 }
 
-type SBTemplateEntry struct {
-	baseCmd []string
-}
-
-func NewSBTemplate(name string) *SBTemplate {
-	return &SBTemplate{
-		name:       name,
-		runClauses: make(map[string]map[string][]string),
+func (s ServiceTemplate) RunScript() ([]byte, error) {
+	if len(s.Run) == 0 {
+		return nil, util.Errorf("empty run script")
 	}
-}
 
-func (template *SBTemplate) AddEntry(app string, run []string) {
-	template.runClauses[app] = map[string][]string{"run": run}
-}
-
-func (template *SBTemplate) Write(out io.Writer) error {
-	b, err := yaml.Marshal(template.runClauses)
+	args, err := yaml.Marshal(s.Run)
 	if err != nil {
-		return util.Errorf("Could not marshal servicebuilder template %s as YAML: %s", template.name, err)
+		return nil, err
 	}
-	_, err = out.Write(b)
-	return err
+
+	// default sleep to reduce spinning on a broken run script
+	sleep := 2
+	if s.Sleep != 0 {
+		sleep = s.Sleep
+	}
+
+	ret := fmt.Sprintf(`#!/usr/bin/ruby
+$stderr.reopen(STDOUT)
+require 'yaml'
+sleep %v
+exec *YAML.load(DATA.read)
+__END__
+%s`, sleep, args)
+	return []byte(ret), nil
+}
+
+func (s ServiceTemplate) LogScript() ([]byte, error) {
+	if len(s.Log) == 0 {
+		// use a default log script that makes a logdir, chowns it and execs
+		// svlogd into it
+		return []byte(`#!/usr/bin/ruby
+require 'fileutils'
+FileUtils.mkdir_p('./main')
+FileUtils.chown('nobody', 'nobody', './main')
+sleep 2
+exec('chpst', '-unobody', 'svlogd', '-tt', './main')
+`), nil
+	}
+
+	args, err := yaml.Marshal(s.Log)
+	if err != nil {
+		return nil, err
+	}
+
+	sleep := 2
+	if s.LogSleep != 0 {
+		sleep = s.LogSleep
+	}
+
+	ret := fmt.Sprintf(`#!/usr/bin/ruby
+require 'yaml'
+sleep %v
+exec *YAML.load(DATA.read)
+__END__
+%s`, sleep, args)
+	return []byte(ret), nil
 }
 
 type ServiceBuilder struct {
-	ConfigRoot  string
-	StagingRoot string
-	RunitRoot   string
+	ConfigRoot  string // directory to generate YAML files
+	StagingRoot string // directory to place staged runit services
+	RunitRoot   string // directory of runsvdir
 	Bin         string
 }
 
@@ -75,52 +109,160 @@ var DefaultBuilder = &ServiceBuilder{
 
 var DefaultChpst = "/usr/bin/chpst"
 
-func (b *ServiceBuilder) serviceYamlPath(name string) string {
-	return path.Join(b.ConfigRoot, fmt.Sprintf("%s.yaml", name))
-}
-
-func (b *ServiceBuilder) Write(template *SBTemplate) (string, error) {
-	yamlPath := b.serviceYamlPath(template.name)
-	fileinfo, _ := os.Stat(yamlPath)
-	if fileinfo != nil && fileinfo.IsDir() {
-		return "", util.Errorf("%s is a directory, but should be empty or a file", yamlPath)
-	}
-
-	f, err := os.OpenFile(yamlPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-	if err != nil {
-		return "", util.Errorf("Could not write servicebuilder template %s: %s", template.name, err)
-	}
-	defer f.Close()
-
-	return yamlPath, template.Write(f)
-}
-
-func (b *ServiceBuilder) Remove(template *SBTemplate) error {
-	yamlPath := b.serviceYamlPath(template.name)
-
-	err := os.Remove(yamlPath)
+// write a servicebuilder yaml file
+// in addition to backwards compat with the real servicebuilder, this file
+// stores the truth of what services are "supposed" to exist right now, which
+// is needed for pruning unused services later
+func (s *ServiceBuilder) write(path string, templates map[string]ServiceTemplate) error {
+	text, err := yaml.Marshal(templates)
 	if err != nil {
 		return err
+	}
+
+	return ioutil.WriteFile(path, text, 0644)
+}
+
+// convert the servicebuilder yaml file into a runit service directory
+func (s *ServiceBuilder) stage(templates map[string]ServiceTemplate) error {
+	for serviceName, template := range templates {
+		stageDir := filepath.Join(s.StagingRoot, serviceName)
+		// create the default log directory
+		err := os.MkdirAll(filepath.Join(stageDir, "log"), 0755)
+		if err != nil {
+			return err
+		}
+
+		runScript, err := template.RunScript()
+		if err != nil {
+			return err
+		}
+		if _, err := util.WriteIfChanged(filepath.Join(stageDir, "run"), runScript, 0755); err != nil {
+			return err
+		}
+
+		logScript, err := template.LogScript()
+		if err != nil {
+			return err
+		}
+		if _, err := util.WriteIfChanged(filepath.Join(stageDir, "log", "run"), logScript, 0755); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// symlink the runit service directory into the actual directory being monitored
+// by runsvdir
+// runsvdir will automatically start a service for each new directory (unless a
+// down file exists)
+func (s *ServiceBuilder) activate(templates map[string]ServiceTemplate) error {
+	for serviceName := range templates {
+		linkPath := filepath.Join(s.RunitRoot, serviceName)
+		stageDir := filepath.Join(s.StagingRoot, serviceName)
+
+		info, err := os.Lstat(linkPath)
+		if err == nil {
+			// if it exists, make sure it is actually a symlink
+			if info.Mode()&os.ModeSymlink == 0 {
+				return util.Errorf("%s is not a symlink", linkPath)
+			}
+
+			// and that it points to the right place
+			target, err := os.Readlink(linkPath)
+			if err != nil {
+				return err
+			}
+			if target != stageDir {
+				return util.Errorf("%s is a symlink to %s (expected %s)", linkPath, target, stageDir)
+			}
+		} else if os.IsNotExist(err) {
+			if err = os.Symlink(stageDir, linkPath); err != nil {
+				return err
+			}
+		} else if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// public API to write, stage and activate a servicebuilder template
+func (s *ServiceBuilder) Activate(name string, templates map[string]ServiceTemplate) error {
+	if err := s.write(filepath.Join(s.ConfigRoot, name+".yaml"), templates); err != nil {
+		return err
+	}
+	if err := s.stage(templates); err != nil {
+		return err
+	}
+	return s.activate(templates)
+}
+
+// using the servicebuilder yaml files, find any extraneous runit services and
+// remove them
+// runsvdir automatically stops services that no longer exist, explicit stop is
+// not required
+func (s *ServiceBuilder) Prune() error {
+	configs, err := s.loadConfigDir()
+	if err != nil {
+		return err
+	}
+
+	links, err := ioutil.ReadDir(s.RunitRoot)
+	if err != nil {
+		return err
+	}
+	for _, link := range links {
+		if _, exists := configs[link.Name()]; !exists {
+			if err = os.Remove(filepath.Join(s.RunitRoot, link.Name())); err != nil {
+				return err
+			}
+		}
+	}
+
+	stages, err := ioutil.ReadDir(s.StagingRoot)
+	if err != nil {
+		return err
+	}
+	for _, stage := range stages {
+		if _, exists := configs[stage.Name()]; !exists {
+			if err = os.RemoveAll(filepath.Join(s.StagingRoot, stage.Name())); err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil
 }
 
-// Rebuild executes the servicebuilder binary with the given configuration. Any
-// templates written up to this point will be used to create or update existing services.
-// Servicebuilder will err if two or more services with the same name have been configured.
-func (b *ServiceBuilder) Rebuild() (string, error) {
-	return b.RebuildWithStreams(os.Stdin)
-}
+// loadConfigDir reads all the files in the ConfigRoot and converts them into a
+// single map of servicetemplates.
+func (s *ServiceBuilder) loadConfigDir() (map[string]ServiceTemplate, error) {
+	ret := make(map[string]ServiceTemplate)
 
-func (b *ServiceBuilder) RebuildWithStreams(stdin io.Reader) (string, error) {
-	cmd := exec.Command(b.Bin, "-c", b.ConfigRoot, "-s", b.StagingRoot, "-d", b.RunitRoot)
-	cmd.Stdin = stdin
-	buffer := bytes.Buffer{}
-	cmd.Stdout = &buffer
-	err := cmd.Run()
+	entries, err := ioutil.ReadDir(s.ConfigRoot)
 	if err != nil {
-		return "", util.Errorf("Could not run servicebuilder rebuild: %s", err)
+		return nil, err
 	}
-	return buffer.String(), nil
+
+	for _, entry := range entries {
+		entryContents, err := ioutil.ReadFile(filepath.Join(s.ConfigRoot, entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+
+		entryTemplate := make(map[string]ServiceTemplate)
+		err = yaml.Unmarshal(entryContents, entryTemplate)
+		if err != nil {
+			return nil, err
+		}
+
+		for name, template := range entryTemplate {
+			if _, exists := ret[name]; exists {
+				return nil, util.Errorf("service with name %s was defined twice (from %s)", name, entry.Name())
+			}
+			ret[name] = template
+		}
+	}
+
+	return ret, nil
 }

--- a/pkg/runit/servicebuilder_test.go
+++ b/pkg/runit/servicebuilder_test.go
@@ -1,127 +1,113 @@
 package runit
 
 import (
-	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
-	"runtime"
-	"strings"
+	"path/filepath"
+	"reflect"
 	"testing"
 
 	. "github.com/anthonybishopric/gotcha"
 	"gopkg.in/yaml.v2"
 )
 
-func TestServiceBuilderOutputsValidYaml(t *testing.T) {
-	template := NewSBTemplate("exemplar")
-	template.AddEntry("exemplar", []string{"ls", "-lah", "/foo/bar"})
-	out := bytes.Buffer{}
-	err := template.Write(&out)
-	Assert(t).IsNil(err, "Did not expect to error")
-	bytes, err := ioutil.ReadAll(&out)
-	Assert(t).IsNil(err, "Did not expect to error")
-	outMap := make(map[interface{}]interface{})
-	yaml.Unmarshal(bytes, &outMap)
-	expected := `exemplar:
-  run:
-  - ls
-  - -lah
-  - /foo/bar
-`
-	Assert(t).AreEqual(expected, string(bytes), "The generated YAML was not what was expected")
+var fakeTemplate map[string]ServiceTemplate = map[string]ServiceTemplate{
+	"foo": ServiceTemplate{
+		Run: []string{"foo", "one", "two"},
+	},
 }
 
-func expandLocal(local string) string {
-	_, file, _, _ := runtime.Caller(0)
-	return path.Join(path.Dir(file), local)
+func TestWriteTemplate(t *testing.T) {
+	sb := FakeServiceBuilder()
+	defer os.RemoveAll(sb.ConfigRoot)
+	defer os.RemoveAll(sb.StagingRoot)
+	defer os.RemoveAll(sb.RunitRoot)
+
+	fakePath := filepath.Join(sb.ConfigRoot, "test.yaml")
+	err := sb.write(fakePath, fakeTemplate)
+	Assert(t).IsNil(err, "should have written templates")
+
+	fakeYaml, err := ioutil.ReadFile(fakePath)
+	Assert(t).IsNil(err, "should have read templates")
+
+	test := make(map[string]ServiceTemplate)
+	err = yaml.Unmarshal(fakeYaml, test)
+	Assert(t).IsNil(err, "should have parsed templates")
+
+	Assert(t).IsTrue(reflect.DeepEqual(test, fakeTemplate), "should have been equal")
 }
 
-func fakeServiceBuilder(t *testing.T) ServiceBuilder {
-	confDir, err := ioutil.TempDir("", "sb-conf")
-	Assert(t).IsNil(err, "confdir should have been created (test setup error)")
+func TestStagedContents(t *testing.T) {
+	sb := FakeServiceBuilder()
+	defer os.RemoveAll(sb.ConfigRoot)
+	defer os.RemoveAll(sb.StagingRoot)
+	defer os.RemoveAll(sb.RunitRoot)
 
-	stagingDir, err := ioutil.TempDir("", "sb-stage")
-	Assert(t).IsNil(err, "stagingdir should have been created (test setup error)")
-	defer os.RemoveAll(stagingDir)
-	runitDir, err := ioutil.TempDir("", "sb-runit")
-	Assert(t).IsNil(err, "runitdir should have been created (test setup error)")
-	defer os.RemoveAll(runitDir)
+	err := sb.stage(fakeTemplate)
+	Assert(t).IsNil(err, "should have staged")
 
-	fakeSb := expandLocal("fake_servicebuilder")
+	info, err := os.Stat(filepath.Join(sb.StagingRoot, "foo"))
+	Assert(t).IsNil(err, "should have statted staging dir")
+	Assert(t).IsTrue(info.IsDir(), "staging dir should have been a dir")
 
-	return ServiceBuilder{
-		ConfigRoot:  confDir,
-		StagingRoot: stagingDir,
-		RunitRoot:   runitDir,
-		Bin:         fakeSb,
-	}
+	info, err = os.Stat(filepath.Join(sb.StagingRoot, "foo", "run"))
+	Assert(t).IsNil(err, "should have statted staging run")
+	Assert(t).IsFalse(info.IsDir(), "staging run should have been a file")
+	Assert(t).IsTrue(info.Mode()&0100 == 0100, "staging run should have been executable")
+
+	info, err = os.Stat(filepath.Join(sb.StagingRoot, "foo", "log"))
+	Assert(t).IsNil(err, "should have statted staging log dir")
+	Assert(t).IsTrue(info.IsDir(), "staging log dir should have been a dir")
+
+	info, err = os.Stat(filepath.Join(sb.StagingRoot, "foo", "log", "run"))
+	Assert(t).IsNil(err, "should have statted staging log run")
+	Assert(t).IsFalse(info.IsDir(), "staging log run should have been a file")
+	Assert(t).IsTrue(info.Mode()&0100 == 0100, "staging log run should have been executable")
 }
 
-func TestServiceBuilderCanTakeSBTemplates(t *testing.T) {
-	template := NewSBTemplate("exemplar")
-	template.AddEntry("exemplar", []string{"ls", "-lah", "/foo/bar"})
+func TestActivateSucceedsTwice(t *testing.T) {
+	sb := FakeServiceBuilder()
+	defer os.RemoveAll(sb.ConfigRoot)
+	defer os.RemoveAll(sb.StagingRoot)
+	defer os.RemoveAll(sb.RunitRoot)
 
-	builder := fakeServiceBuilder(t)
-	defer os.RemoveAll(builder.ConfigRoot)
-	defer os.RemoveAll(builder.StagingRoot)
-	defer os.RemoveAll(builder.RunitRoot)
-	confDir := builder.ConfigRoot
+	err := sb.activate(fakeTemplate)
+	Assert(t).IsNil(err, "should have activated service")
+	target, err := os.Readlink(filepath.Join(sb.RunitRoot, "foo"))
+	Assert(t).IsNil(err, "should have read link for activated service")
+	Assert(t).IsTrue(target == filepath.Join(sb.StagingRoot, "foo"), "should have symlinked to the staging dir")
 
-	outPath, err := builder.Write(template)
-	Assert(t).IsNil(err, "there should not have been an error when writing the template")
-	Assert(t).AreEqual(path.Join(confDir, "exemplar.yaml"), outPath, "the written servicebuilder path was not what we expected")
-
-	f, err := os.Open(outPath)
-	defer f.Close()
-	Assert(t).IsNil(err, "Could not open out path for exemplar")
-	content, err := ioutil.ReadAll(f)
-	Assert(t).IsNil(err, "Could not read file")
-
-	expected := `exemplar:
-  run:
-  - ls
-  - -lah
-  - /foo/bar
-`
-	Assert(t).AreEqual(expected, string(content), "The generated YAML was not what was expected")
-
-	// attempt to write the file a second time. This verifies that we are actually able to do it without erring
-	_, err = builder.Write(template)
-	Assert(t).IsNil(err, "Was not able to write the servicebuilder file a second time")
+	// do it again to make sure repeated activations work fine
+	err = sb.activate(fakeTemplate)
+	Assert(t).IsNil(err, "should have activated service")
+	target, err = os.Readlink(filepath.Join(sb.RunitRoot, "foo"))
+	Assert(t).IsNil(err, "should have read link for activated service")
+	Assert(t).IsTrue(target == filepath.Join(sb.StagingRoot, "foo"), "should have symlinked to the staging dir")
 }
 
-func TestServiceBuilderWillExecuteRebuild(t *testing.T) {
-	builder := fakeServiceBuilder(t)
-	defer os.RemoveAll(builder.ConfigRoot)
-	defer os.RemoveAll(builder.StagingRoot)
-	defer os.RemoveAll(builder.RunitRoot)
+func TestPrune(t *testing.T) {
+	sb := FakeServiceBuilder()
+	defer os.RemoveAll(sb.ConfigRoot)
+	defer os.RemoveAll(sb.StagingRoot)
+	defer os.RemoveAll(sb.RunitRoot)
 
-	output, err := builder.RebuildWithStreams(os.Stdin)
-	Assert(t).IsNil(err, "Could not execute fake servicebuilder")
+	// first create the service
+	err := sb.Activate("foo", fakeTemplate)
+	Assert(t).IsNil(err, "should have activated service")
+	_, err = os.Readlink(filepath.Join(sb.RunitRoot, "foo"))
+	Assert(t).IsNil(err, "should have created activation symlink")
 
-	Assert(t).IsTrue(strings.Contains(output, builder.ConfigRoot), fmt.Sprintf("the config root should have been passed in cmd: %s", output))
-}
+	// now remove the service's yaml file
+	err = sb.Activate("foo", map[string]ServiceTemplate{})
+	Assert(t).IsNil(err, "should have activated service")
+	// symlink should still exist, haven't pruned yet
+	_, err = os.Readlink(filepath.Join(sb.RunitRoot, "foo"))
+	Assert(t).IsNil(err, "should have created activation symlink")
 
-func TestServiceBuilderCanRemoveServiceFiles(t *testing.T) {
-	builder := fakeServiceBuilder(t)
-	defer os.RemoveAll(builder.ConfigRoot)
-	defer os.RemoveAll(builder.StagingRoot)
-	defer os.RemoveAll(builder.RunitRoot)
-	template := NewSBTemplate("exemplar")
-	filePath := path.Join(builder.ConfigRoot, "exemplar.yaml")
-
-	f, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-	Assert(t).IsNil(err, "unable to open fake servicebuilder file for writing")
-
-	_, err = f.WriteString("foo")
-	Assert(t).IsNil(err, "unable to write fake servicebuilder file")
-
-	_, err = os.Stat(filePath)
-	Assert(t).IsNil(err, "Unable to stat the fake servicebuilder file")
-	builder.Remove(template)
-	_, err = os.Stat(filePath)
-	Assert(t).IsNotNil(err, "File still exists after it was supposed to be removed")
-
+	err = sb.Prune()
+	Assert(t).IsNil(err, "should have pruned")
+	_, err = os.Readlink(filepath.Join(sb.RunitRoot, "foo"))
+	Assert(t).IsTrue(os.IsNotExist(err), "should have removed activation symlink")
+	_, err = os.Stat(filepath.Join(sb.StagingRoot, "foo"))
+	Assert(t).IsTrue(os.IsNotExist(err), "should have removed staging dir")
 }

--- a/pkg/util/write.go
+++ b/pkg/util/write.go
@@ -1,0 +1,48 @@
+package util
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+)
+
+func WriteIfChanged(filename string, data []byte, perm os.FileMode) (bool, error) {
+	modified := false
+
+	content, err := ioutil.ReadFile(filename)
+	if !os.IsNotExist(err) && err != nil {
+		// file existed, but could not be read
+		return modified, err
+	}
+
+	if os.IsNotExist(err) || bytes.Compare(content, data) != 0 {
+		openPerm := perm
+		if perm == 0 {
+			// if the file gets created with perm=0, then all the permission
+			// bits will be turned off
+			// a more sensible default is to use 0666 (and then umask gets
+			// applied)
+			openPerm = 0666
+		}
+
+		modified = true
+		err = ioutil.WriteFile(filename, data, openPerm)
+		if err != nil {
+			return modified, err
+		}
+	}
+
+	if perm != 0 {
+		info, err := os.Stat(filename)
+		if err != nil {
+			return modified, err
+		}
+
+		if info.Mode() != perm {
+			modified = true
+			err = os.Chmod(filename, perm)
+		}
+	}
+
+	return modified, err
+}

--- a/pkg/util/write_test.go
+++ b/pkg/util/write_test.go
@@ -1,0 +1,96 @@
+package util
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/anthonybishopric/gotcha"
+)
+
+func TestWriteNewFile(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "write")
+	Assert(t).IsNil(err, "should have created tmpdir")
+	defer os.RemoveAll(tmp)
+
+	write, err := WriteIfChanged(filepath.Join(tmp, "tmp"), []byte("tmp"), 0600)
+	Assert(t).IsNil(err, "should have written")
+	Assert(t).IsTrue(write, "should have written")
+
+	info, err := os.Stat(filepath.Join(tmp, "tmp"))
+	Assert(t).IsNil(err, "should have statted new file")
+	Assert(t).IsTrue(info.Mode() == 0600, "should have had 0600 permissions")
+
+	content, err := ioutil.ReadFile(filepath.Join(tmp, "tmp"))
+	Assert(t).IsNil(err, "should have read new file")
+	Assert(t).IsTrue(bytes.Equal(content, []byte("tmp")), "should have written correct contents")
+}
+
+func TestNewFileZeroPerms(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "write")
+	Assert(t).IsNil(err, "should have created tmpdir")
+	defer os.RemoveAll(tmp)
+
+	write, err := WriteIfChanged(filepath.Join(tmp, "tmp"), []byte("tmp"), 0)
+	Assert(t).IsNil(err, "should have written")
+	Assert(t).IsTrue(write, "should have written")
+
+	info, err := os.Stat(filepath.Join(tmp, "tmp"))
+	Assert(t).IsNil(err, "should have statted new file")
+	Assert(t).IsTrue(info.Mode() != 0, "should not have had 0 permissions")
+}
+
+func TestWriteUnchangedFile(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "write")
+	Assert(t).IsNil(err, "should have created tmpdir")
+	defer os.RemoveAll(tmp)
+
+	err = ioutil.WriteFile(filepath.Join(tmp, "tmp"), []byte("tmp"), 0600)
+	Assert(t).IsNil(err, "should have written file initially")
+
+	info, err := os.Stat(filepath.Join(tmp, "tmp"))
+	Assert(t).IsNil(err, "should have statted new file")
+
+	write, err := WriteIfChanged(filepath.Join(tmp, "tmp"), []byte("tmp"), 0600)
+	Assert(t).IsNil(err, "should have written without error")
+	Assert(t).IsFalse(write, "should not have actually written")
+
+	info2, err := os.Stat(filepath.Join(tmp, "tmp"))
+	Assert(t).IsNil(err, "should have statted new file second time")
+	Assert(t).IsTrue(info.ModTime() == info2.ModTime(), "should not have modified file")
+}
+
+func TestUpdatePermissions(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "write")
+	Assert(t).IsNil(err, "should have created tmpdir")
+	defer os.RemoveAll(tmp)
+
+	err = ioutil.WriteFile(filepath.Join(tmp, "tmp"), []byte("tmp"), 0600)
+	Assert(t).IsNil(err, "should have written file initially")
+
+	write, err := WriteIfChanged(filepath.Join(tmp, "tmp"), []byte("tmp"), 0644)
+	Assert(t).IsNil(err, "should have written without error")
+	Assert(t).IsTrue(write, "should have actually chmodded")
+
+	info, err := os.Stat(filepath.Join(tmp, "tmp"))
+	Assert(t).IsNil(err, "should have statted new file second time")
+	Assert(t).IsTrue(info.Mode() == 0644, "should have changed to mode 0644")
+}
+
+func TestNoUpdatePermissionsDuringWrite(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "write")
+	Assert(t).IsNil(err, "should have created tmpdir")
+	defer os.RemoveAll(tmp)
+
+	err = ioutil.WriteFile(filepath.Join(tmp, "tmp"), []byte("tmp"), 0600)
+	Assert(t).IsNil(err, "should have written file initially")
+
+	_, err = WriteIfChanged(filepath.Join(tmp, "tmp"), []byte("tmp2"), 0)
+	Assert(t).IsNil(err, "should have written without error")
+
+	info, err := os.Stat(filepath.Join(tmp, "tmp"))
+	Assert(t).IsNil(err, "should have statted new file")
+	Assert(t).IsTrue(info.Mode() == 0600, "should still be 0600 mode")
+}


### PR DESCRIPTION
Managed to PR this before leaving the office for the last time! Summary:

- no dependency on external servicebuilder script
- the new servicebuilder does not explicitly stop and start services like the old one did. runsvdir does that already when new directories are added or removed.
  - I was considering writing the down file to make all services downed-by-default, which would give p2 more control over the moment that the service starts, but I don't think the distinction is particularly significant here, because the next thing we do (right after creating the service directory) is starting the service.
- servicebuilder functionality invoked as part of hoist launchable.Launch, removed from pod.Launch.
  - To preserve the behavior of servicebuilder wrt cleaning up old services, pod invokes the new Prune method to remove nonexistent services. launchables also invoke prune during their halt, which preserves the other behavior we wanted (deploying a pod with no launchables will remove the services for that pod). The pod-invoked Prune might actually be redundant because of that, now that I think about it.
- post-activate now kills deploys if it crashes. I know we used to make this a non-halting failure, but based on some of the services we've seen, I think bailing here makes more sense, especially since enable is also a killing script.
- post-activate is unexported from launchable, since pod.Launch no longer needs to call it. this should shrink the shared API surface for docker launchables.