### PR TITLE
Return an error when BasicFetcher gets an HTTP error

### DIFF
--- a/pkg/uri/uri.go
+++ b/pkg/uri/uri.go
@@ -60,6 +60,14 @@ func (f BasicFetcher) Open(srcUri string) (io.ReadCloser, error) {
 		if err != nil {
 			return nil, err
 		}
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return nil, util.Errorf(
+				"%s: HTTP server returned status: %s",
+				srcUri,
+				resp.Status,
+			)
+		}
 		return resp.Body, nil
 	default:
 		return nil, util.Errorf("%s: unhandled URI scheme", srcUri)


### PR DESCRIPTION
HTTP allows meaningful data in the body of HTTP responses for many status
codes. As far as `uri.BasicFetcher.Open()` is concerned, anything except a 200
status means the data can't be accessed, so it should return an error.