### PR TITLE
Parse URIs for fetching

### DIFF
--- a/pkg/uri/uri_test.go
+++ b/pkg/uri/uri_test.go
@@ -5,8 +5,9 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -14,30 +15,12 @@ import (
 	"github.com/square/p2/pkg/util"
 )
 
-func TestLeadingProtoRegexMatchesProto(t *testing.T) {
-	Assert(t).IsTrue(
-		leadingScheme.MatchString("file:///foo/bar/baz"),
-		"Should have matched",
-	)
-	Assert(t).IsTrue(
-		leadingScheme.MatchString("http://www.com/foo/bar/baz"),
-		"Should have matched",
-	)
-}
-
-func TestLeadingProtoRegexDoesNotMatchPath(t *testing.T) {
-	Assert(t).IsFalse(
-		leadingScheme.MatchString("/foo/bar/baz"),
-		"Should not have matched",
-	)
-}
-
 func TestURIWillCopyFilesCorrectly(t *testing.T) {
 	tempdir, err := ioutil.TempDir("", "cp-dest")
 	Assert(t).IsNil(err, "Couldn't create temp dir")
 	defer os.RemoveAll(tempdir)
 	thisFile := util.From(runtime.Caller(0)).Filename
-	copied := path.Join(tempdir, "copied")
+	copied := filepath.Join(tempdir, "copied")
 	err = URICopy(fmt.Sprintf("file:///%s", thisFile), copied)
 	Assert(t).IsNil(err, "The file should have been copied")
 	copiedContents, err := ioutil.ReadFile(copied)
@@ -52,7 +35,7 @@ func TestURIWithNoProtocolTreatedLikeLocalPath(t *testing.T) {
 	Assert(t).IsNil(err, "Couldn't create temp dir")
 	defer os.RemoveAll(tempdir)
 	thisFile := util.From(runtime.Caller(0)).Filename
-	copied := path.Join(tempdir, "copied")
+	copied := filepath.Join(tempdir, "copied")
 	err = URICopy(thisFile, copied)
 	Assert(t).IsNil(err, "The file should have been copied")
 	copiedContents, err := ioutil.ReadFile(copied)
@@ -66,30 +49,21 @@ func TestCorrectlyPullsFilesOverHTTP(t *testing.T) {
 	Assert(t).IsNil(err, "Couldn't create temp dir")
 	defer os.RemoveAll(tempdir)
 
-	copied := path.Join(tempdir, "copied")
+	copied := filepath.Join(tempdir, "copied")
 
 	caller := util.From(runtime.Caller(0))
 
 	ts := httptest.NewServer(http.FileServer(http.Dir(caller.Dirname())))
-	Assert(t).IsTrue(
-		leadingScheme.MatchString(ts.URL),
-		fmt.Sprintf("the http test server generated an invalid url (%s)", ts.URL),
-	)
 	defer ts.Close()
+	serverURL, err := url.Parse(ts.URL)
+	Assert(t).IsNil(err, "should have parsed server URL")
 
-	// Do not use path.Join for URLs. It will compress consecutive forward slashes.
-	// ie, http:// becomes http:/
-	source := fmt.Sprintf("%s/%s", ts.URL, path.Base(caller.Filename))
-	Assert(t).IsTrue(
-		leadingScheme.MatchString(source),
-		fmt.Sprintf("The url %s should have had a proto", source),
-	)
-
-	err = URICopy(source, copied)
+	serverURL.Path = filepath.Base(caller.Filename)
+	err = URICopy(serverURL.String(), copied)
 	Assert(t).IsNil(err, "the file should have been downloaded")
 
 	copiedContents, err := ioutil.ReadFile(copied)
 	thisContents, err := ioutil.ReadFile(caller.Filename)
 
-	Assert(t).AreEqual(string(thisContents), string(copiedContents), fmt.Sprintf("Should have downloaded the file correctly from (%s)", source))
+	Assert(t).AreEqual(string(thisContents), string(copiedContents), "Should have downloaded the file correctly")
 }


### PR DESCRIPTION
Fixes a bug in the handling of `file://` URIs; the leading slash on an absolute path was being stripped off (notably our integration test uses these). Question marks in the URL path will have to be query-escaped.