### PR TITLE
wait for the supervise directory to appear

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -159,7 +159,7 @@ func (hl *Launchable) start(serviceBuilder *runit.ServiceBuilder, sv *runit.SV) 
 	}
 
 	for _, executable := range executables {
-		_, err = sv.Restart(&executable.Service)
+		_, err := sv.Restart(&executable.Service)
 		if err != nil && err != runit.SuperviseOkMissing {
 			return err
 		}

--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -159,7 +159,7 @@ func (hl *Launchable) start(serviceBuilder *runit.ServiceBuilder, sv *runit.SV) 
 	}
 
 	for _, executable := range executables {
-		_, err := sv.Restart(&executable.Service)
+		_, err = sv.Restart(&executable.Service)
 		if err != nil && err != runit.SuperviseOkMissing {
 			return err
 		}

--- a/pkg/hoist/hoist_launchable_test.go
+++ b/pkg/hoist/hoist_launchable_test.go
@@ -75,7 +75,7 @@ func TestInstallDir(t *testing.T) {
 
 func TestMultipleExecutables(t *testing.T) {
 	fakeLaunchable, sb := FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
-	defer cleanupFakeLaunchable(fakeLaunchable, sb)
+	defer CleanupFakeLaunchable(fakeLaunchable, sb)
 	executables, err := fakeLaunchable.Executables(runit.DefaultBuilder)
 
 	Assert(t).IsNil(err, "Error occurred when obtaining runit services for launchable")
@@ -88,7 +88,7 @@ func TestMultipleExecutables(t *testing.T) {
 
 func TestSingleRunitService(t *testing.T) {
 	launchable, sb := FakeHoistLaunchableForDir("single_script_test_hoist_launchable")
-	defer cleanupFakeLaunchable(launchable, sb)
+	defer CleanupFakeLaunchable(launchable, sb)
 	Assert(t).IsNil(launchable.MakeCurrent(), "Should have been made current")
 	executables, err := launchable.Executables(runit.DefaultBuilder)
 	Assert(t).IsNil(err, "Error occurred when obtaining runit services for launchable")
@@ -100,7 +100,7 @@ func TestSingleRunitService(t *testing.T) {
 
 func TestLaunchExecutableOnlyRunitService(t *testing.T) {
 	launchable, sb := FakeHoistLaunchableForDir("launch_script_only_test_hoist_launchable")
-	defer cleanupFakeLaunchable(launchable, sb)
+	defer CleanupFakeLaunchable(launchable, sb)
 	Assert(t).IsNil(launchable.MakeCurrent(), "Should have been made current")
 	executables, err := launchable.Executables(runit.DefaultBuilder)
 	Assert(t).IsNil(err, "Error occurred when obtaining runit services for launchable")
@@ -112,7 +112,7 @@ func TestLaunchExecutableOnlyRunitService(t *testing.T) {
 
 func TestDisable(t *testing.T) {
 	hl, sb := FakeHoistLaunchableForDir("successful_scripts_test_hoist_launchable")
-	defer cleanupFakeLaunchable(hl, sb)
+	defer CleanupFakeLaunchable(hl, sb)
 
 	disableOutput, err := hl.disable()
 	Assert(t).IsNil(err, "Got an unexpected error when calling disable on the test hoist launchable")
@@ -124,7 +124,7 @@ func TestDisable(t *testing.T) {
 
 func TestFailingDisable(t *testing.T) {
 	hl, sb := FakeHoistLaunchableForDir("failing_scripts_test_hoist_launchable")
-	defer cleanupFakeLaunchable(hl, sb)
+	defer CleanupFakeLaunchable(hl, sb)
 
 	disableOutput, err := hl.disable()
 	Assert(t).IsNotNil(err, "Expected disable to fail for this test, but it didn't")
@@ -137,7 +137,7 @@ func TestFailingDisable(t *testing.T) {
 // providing a disable script is optional, make sure we don't error
 func TestNonexistentDisable(t *testing.T) {
 	hl, sb := FakeHoistLaunchableForDir("nonexistent_scripts_test_hoist_launchable")
-	defer cleanupFakeLaunchable(hl, sb)
+	defer CleanupFakeLaunchable(hl, sb)
 
 	disableOutput, err := hl.disable()
 	Assert(t).IsNil(err, "Got an unexpected error when calling disable on the test hoist launchable")
@@ -149,7 +149,7 @@ func TestNonexistentDisable(t *testing.T) {
 
 func TestEnable(t *testing.T) {
 	hl, sb := FakeHoistLaunchableForDir("successful_scripts_test_hoist_launchable")
-	defer cleanupFakeLaunchable(hl, sb)
+	defer CleanupFakeLaunchable(hl, sb)
 
 	enableOutput, err := hl.enable()
 	Assert(t).IsNil(err, "Got an unexpected error when calling enable on the test hoist launchable")
@@ -161,7 +161,7 @@ func TestEnable(t *testing.T) {
 
 func TestFailingEnable(t *testing.T) {
 	hl, sb := FakeHoistLaunchableForDir("failing_scripts_test_hoist_launchable")
-	defer cleanupFakeLaunchable(hl, sb)
+	defer CleanupFakeLaunchable(hl, sb)
 
 	enableOutput, err := hl.enable()
 	Assert(t).IsNotNil(err, "Expected enable to fail for this test, but it didn't")
@@ -174,7 +174,7 @@ func TestFailingEnable(t *testing.T) {
 // providing an enable script is optional, make sure we don't error
 func TestNonexistentEnable(t *testing.T) {
 	hl, sb := FakeHoistLaunchableForDir("nonexistent_scripts_test_hoist_launchable")
-	defer cleanupFakeLaunchable(hl, sb)
+	defer CleanupFakeLaunchable(hl, sb)
 
 	enableOutput, err := hl.enable()
 	Assert(t).IsNil(err, "Got an unexpected error when calling enable on the test hoist launchable")
@@ -186,7 +186,7 @@ func TestNonexistentEnable(t *testing.T) {
 
 func TestFailingStop(t *testing.T) {
 	hl, sb := FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
-	defer cleanupFakeLaunchable(hl, sb)
+	defer CleanupFakeLaunchable(hl, sb)
 
 	sv := runit.ErringSV()
 
@@ -197,7 +197,7 @@ func TestFailingStop(t *testing.T) {
 
 func TestStart(t *testing.T) {
 	hl, sb := FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
-	defer cleanupFakeLaunchable(hl, sb)
+	defer CleanupFakeLaunchable(hl, sb)
 	sv := runit.FakeSV()
 	executables, err := hl.Executables(sb)
 	outFilePath := path.Join(sb.ConfigRoot, "testPod__testLaunchable.yaml")
@@ -224,7 +224,7 @@ func TestStart(t *testing.T) {
 
 func TestFailingStart(t *testing.T) {
 	hl, sb := FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
-	defer cleanupFakeLaunchable(hl, sb)
+	defer CleanupFakeLaunchable(hl, sb)
 
 	sv := runit.ErringSV()
 	executables, _ := hl.Executables(sb)
@@ -250,7 +250,7 @@ func TestFailingStart(t *testing.T) {
 
 func TestStop(t *testing.T) {
 	hl, sb := FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
-	defer cleanupFakeLaunchable(hl, sb)
+	defer CleanupFakeLaunchable(hl, sb)
 
 	sv := runit.FakeSV()
 	err := hl.stop(sb, sv)

--- a/pkg/hoist/hoist_launchable_test.go
+++ b/pkg/hoist/hoist_launchable_test.go
@@ -74,8 +74,8 @@ func TestInstallDir(t *testing.T) {
 }
 
 func TestMultipleExecutables(t *testing.T) {
-	fakeLaunchable := FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
-	defer cleanupFakeLaunchable(fakeLaunchable)
+	fakeLaunchable, sb := FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
+	defer cleanupFakeLaunchable(fakeLaunchable, sb)
 	executables, err := fakeLaunchable.Executables(runit.DefaultBuilder)
 
 	Assert(t).IsNil(err, "Error occurred when obtaining runit services for launchable")
@@ -87,8 +87,8 @@ func TestMultipleExecutables(t *testing.T) {
 }
 
 func TestSingleRunitService(t *testing.T) {
-	launchable := FakeHoistLaunchableForDir("single_script_test_hoist_launchable")
-	defer cleanupFakeLaunchable(launchable)
+	launchable, sb := FakeHoistLaunchableForDir("single_script_test_hoist_launchable")
+	defer cleanupFakeLaunchable(launchable, sb)
 	Assert(t).IsNil(launchable.MakeCurrent(), "Should have been made current")
 	executables, err := launchable.Executables(runit.DefaultBuilder)
 	Assert(t).IsNil(err, "Error occurred when obtaining runit services for launchable")
@@ -99,8 +99,8 @@ func TestSingleRunitService(t *testing.T) {
 }
 
 func TestLaunchExecutableOnlyRunitService(t *testing.T) {
-	launchable := FakeHoistLaunchableForDir("launch_script_only_test_hoist_launchable")
-	defer cleanupFakeLaunchable(launchable)
+	launchable, sb := FakeHoistLaunchableForDir("launch_script_only_test_hoist_launchable")
+	defer cleanupFakeLaunchable(launchable, sb)
 	Assert(t).IsNil(launchable.MakeCurrent(), "Should have been made current")
 	executables, err := launchable.Executables(runit.DefaultBuilder)
 	Assert(t).IsNil(err, "Error occurred when obtaining runit services for launchable")
@@ -111,8 +111,8 @@ func TestLaunchExecutableOnlyRunitService(t *testing.T) {
 }
 
 func TestDisable(t *testing.T) {
-	hl := FakeHoistLaunchableForDir("successful_scripts_test_hoist_launchable")
-	defer cleanupFakeLaunchable(hl)
+	hl, sb := FakeHoistLaunchableForDir("successful_scripts_test_hoist_launchable")
+	defer cleanupFakeLaunchable(hl, sb)
 
 	disableOutput, err := hl.disable()
 	Assert(t).IsNil(err, "Got an unexpected error when calling disable on the test hoist launchable")
@@ -123,8 +123,8 @@ func TestDisable(t *testing.T) {
 }
 
 func TestFailingDisable(t *testing.T) {
-	hl := FakeHoistLaunchableForDir("failing_scripts_test_hoist_launchable")
-	defer cleanupFakeLaunchable(hl)
+	hl, sb := FakeHoistLaunchableForDir("failing_scripts_test_hoist_launchable")
+	defer cleanupFakeLaunchable(hl, sb)
 
 	disableOutput, err := hl.disable()
 	Assert(t).IsNotNil(err, "Expected disable to fail for this test, but it didn't")
@@ -136,8 +136,8 @@ func TestFailingDisable(t *testing.T) {
 
 // providing a disable script is optional, make sure we don't error
 func TestNonexistentDisable(t *testing.T) {
-	hl := FakeHoistLaunchableForDir("nonexistent_scripts_test_hoist_launchable")
-	defer cleanupFakeLaunchable(hl)
+	hl, sb := FakeHoistLaunchableForDir("nonexistent_scripts_test_hoist_launchable")
+	defer cleanupFakeLaunchable(hl, sb)
 
 	disableOutput, err := hl.disable()
 	Assert(t).IsNil(err, "Got an unexpected error when calling disable on the test hoist launchable")
@@ -148,8 +148,8 @@ func TestNonexistentDisable(t *testing.T) {
 }
 
 func TestEnable(t *testing.T) {
-	hl := FakeHoistLaunchableForDir("successful_scripts_test_hoist_launchable")
-	defer cleanupFakeLaunchable(hl)
+	hl, sb := FakeHoistLaunchableForDir("successful_scripts_test_hoist_launchable")
+	defer cleanupFakeLaunchable(hl, sb)
 
 	enableOutput, err := hl.enable()
 	Assert(t).IsNil(err, "Got an unexpected error when calling enable on the test hoist launchable")
@@ -160,8 +160,8 @@ func TestEnable(t *testing.T) {
 }
 
 func TestFailingEnable(t *testing.T) {
-	hl := FakeHoistLaunchableForDir("failing_scripts_test_hoist_launchable")
-	defer cleanupFakeLaunchable(hl)
+	hl, sb := FakeHoistLaunchableForDir("failing_scripts_test_hoist_launchable")
+	defer cleanupFakeLaunchable(hl, sb)
 
 	enableOutput, err := hl.enable()
 	Assert(t).IsNotNil(err, "Expected enable to fail for this test, but it didn't")
@@ -173,8 +173,8 @@ func TestFailingEnable(t *testing.T) {
 
 // providing an enable script is optional, make sure we don't error
 func TestNonexistentEnable(t *testing.T) {
-	hl := FakeHoistLaunchableForDir("nonexistent_scripts_test_hoist_launchable")
-	defer cleanupFakeLaunchable(hl)
+	hl, sb := FakeHoistLaunchableForDir("nonexistent_scripts_test_hoist_launchable")
+	defer cleanupFakeLaunchable(hl, sb)
 
 	enableOutput, err := hl.enable()
 	Assert(t).IsNil(err, "Got an unexpected error when calling enable on the test hoist launchable")
@@ -185,22 +185,22 @@ func TestNonexistentEnable(t *testing.T) {
 }
 
 func TestFailingStop(t *testing.T) {
-	hl := FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
-	defer cleanupFakeLaunchable(hl)
+	hl, sb := FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
+	defer cleanupFakeLaunchable(hl, sb)
 
 	sv := runit.ErringSV()
-	err := hl.stop(runit.DefaultBuilder, sv)
+
+	err := hl.stop(sb, sv)
 
 	Assert(t).IsNotNil(err, "Expected sv stop to fail for this test, but it didn't")
 }
 
 func TestStart(t *testing.T) {
-	hl := FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
-	defer cleanupFakeLaunchable(hl)
-	serviceBuilder := runit.FakeServiceBuilder()
+	hl, sb := FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
+	defer cleanupFakeLaunchable(hl, sb)
 	sv := runit.FakeSV()
-	executables, err := hl.Executables(serviceBuilder)
-	outFilePath := path.Join(serviceBuilder.ConfigRoot, "testPod__testLaunchable.yaml")
+	executables, err := hl.Executables(sb)
+	outFilePath := path.Join(sb.ConfigRoot, "testPod__testLaunchable.yaml")
 
 	sbContentsMap := map[string]interface{}{
 		executables[0].Service.Name: map[string]interface{}{
@@ -216,19 +216,19 @@ func TestStart(t *testing.T) {
 	defer f.Close()
 	f.Write(sbContents)
 
-	err = hl.start(serviceBuilder, sv)
+	err = hl.start(sb, sv)
 
 	Assert(t).IsNil(err, "Got an unexpected error when attempting to start runit services")
 
 }
 
 func TestFailingStart(t *testing.T) {
-	hl := FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
-	defer cleanupFakeLaunchable(hl)
-	serviceBuilder := runit.FakeServiceBuilder()
+	hl, sb := FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
+	defer cleanupFakeLaunchable(hl, sb)
+
 	sv := runit.ErringSV()
-	executables, _ := hl.Executables(serviceBuilder)
-	outFilePath := path.Join(serviceBuilder.ConfigRoot, "testPod__testLaunchable.yaml")
+	executables, _ := hl.Executables(sb)
+	outFilePath := path.Join(sb.ConfigRoot, "testPod__testLaunchable.yaml")
 
 	sbContentsMap := map[string]interface{}{
 		executables[0].Service.Name: map[string]interface{}{
@@ -244,16 +244,16 @@ func TestFailingStart(t *testing.T) {
 	defer f.Close()
 	f.Write(sbContents)
 
-	err = hl.start(serviceBuilder, sv)
+	err = hl.start(sb, sv)
 	Assert(t).IsNotNil(err, "Expected an error starting runit services")
 }
 
 func TestStop(t *testing.T) {
-	hl := FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
-	defer cleanupFakeLaunchable(hl)
+	hl, sb := FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
+	defer cleanupFakeLaunchable(hl, sb)
 
 	sv := runit.FakeSV()
-	err := hl.stop(runit.DefaultBuilder, sv)
+	err := hl.stop(sb, sv)
 
 	Assert(t).IsNil(err, "Got an unexpected error when attempting to stop runit services")
 }

--- a/pkg/hoist/test_helper.go
+++ b/pkg/hoist/test_helper.go
@@ -43,7 +43,7 @@ func FakeHoistLaunchableForDir(dirName string) (*Launchable, *runit.ServiceBuild
 	return launchable, sb
 }
 
-func cleanupFakeLaunchable(h *Launchable, s *runit.ServiceBuilder) {
+func CleanupFakeLaunchable(h *Launchable, s *runit.ServiceBuilder) {
 	if os.TempDir() != h.ConfigDir {
 		os.RemoveAll(h.ConfigDir)
 	}

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -224,7 +224,8 @@ func TestBuildRunitServices(t *testing.T) {
 		path:           "/data/pods/testPod",
 		ServiceBuilder: serviceBuilder,
 	}
-	hl := hoist.FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
+	hl, sb := hoist.FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
+	defer os.RemoveAll(sb.RunitRoot)
 	hl.RunAs = "testPod"
 	executables, err := hl.Executables(serviceBuilder)
 	outFilePath := filepath.Join(serviceBuilder.ConfigRoot, "testPod.yaml")

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -225,7 +225,7 @@ func TestBuildRunitServices(t *testing.T) {
 		ServiceBuilder: serviceBuilder,
 	}
 	hl, sb := hoist.FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
-	defer os.RemoveAll(sb.RunitRoot)
+	defer hoist.CleanupFakeLaunchable(hl, sb)
 	hl.RunAs = "testPod"
 	executables, err := hl.Executables(serviceBuilder)
 	outFilePath := filepath.Join(serviceBuilder.ConfigRoot, "testPod.yaml")

--- a/pkg/runit/runit_service_test.go
+++ b/pkg/runit/runit_service_test.go
@@ -1,22 +1,39 @@
 package runit
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	. "github.com/anthonybishopric/gotcha"
 )
 
 func TestRunitServicesCanBeStarted(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "runit_service")
+	os.MkdirAll(filepath.Join(tmpdir, "supervise"), 0644)
+
+	Assert(t).IsNil(err, "test setup should have created a tmpdir")
+
+	defer os.RemoveAll(tmpdir)
+
 	sv := FakeSV()
-	service := &Service{"/var/service/foo", "foo"}
+	service := &Service{tmpdir, "foo"}
 	out, err := sv.Start(service)
 	Assert(t).IsNil(err, "There should not have been an error starting the service")
-	Assert(t).AreEqual(out, "start /var/service/foo\n", "Did not start service with correct arguments")
+	Assert(t).AreEqual(out, fmt.Sprintf("start %s\n", service.Path), "Did not start service with correct arguments")
 }
 
 func TestErrorReturnedIfRunitServiceBails(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "runit_service")
+	os.MkdirAll(filepath.Join(tmpdir, "supervise"), 0644)
+	Assert(t).IsNil(err, "test setup should have created a tmpdir")
+
+	defer os.RemoveAll(tmpdir)
+
 	sv := ErringSV()
-	service := &Service{"/var/service/foo", "foo"}
-	_, err := sv.Start(service)
+	service := &Service{tmpdir, "foo"}
+	_, err = sv.Start(service)
 	Assert(t).IsNotNil(err, "There should have been an error starting the service")
 }


### PR DESCRIPTION
This change makes sure that any operations performed with the `sv` utility wait for the existence of the supervise directory, which indicates that `runsv` is currently running.