### PR TITLE
Add user-based authorization policy

### DIFF
--- a/bin/p2-preparer/main.go
+++ b/bin/p2-preparer/main.go
@@ -22,10 +22,6 @@ func main() {
 		logger.WithField("inner_err", err).Fatalln("could not load preparer config")
 	}
 
-	if preparerConfig.KeyringPath == "" {
-		logger.NoFields().Fatalln("The preparer must be launched with a keyring")
-	}
-
 	prep, err := preparer.New(preparerConfig, logger)
 	if err != nil {
 		logger.WithField("inner_err", err).Fatalln("Could not initialize preparer")
@@ -37,7 +33,7 @@ func main() {
 		"node_name": preparerConfig.NodeName,
 		"consul":    preparerConfig.ConsulAddress,
 		"hooks_dir": preparerConfig.HooksDirectory,
-		"keyring":   preparerConfig.KeyringPath,
+		"keyring":   preparerConfig.Auth["keyring"],
 		"version":   version.VERSION,
 	}).Infoln("Preparer started successfully")
 

--- a/pkg/auth/policy.go
+++ b/pkg/auth/policy.go
@@ -205,67 +205,41 @@ var _ Policy = FixedKeyringPolicy{}
 type FileKeyringPolicy struct {
 	KeyringFilename     string
 	AuthorizedDeployers map[string][]string
-	keyReqChan          chan<- (chan<- openpgp.KeyRing)
+	keyringWatcher      util.FileWatcher
 }
 
 func NewFileKeyringPolicy(
 	keyringPath string,
 	authorizedDeployers map[string][]string,
 ) (Policy, error) {
-	// Fail fast if it's an invalid file
-	info, err := os.Stat(keyringPath)
+	watcher, err := util.NewFileWatcher(
+		func(path string) (interface{}, error) {
+			return LoadKeyring(path)
+		},
+		keyringPath,
+	)
 	if err != nil {
 		return nil, err
 	}
-	keyring, err := LoadKeyring(keyringPath)
-	if err != nil {
-		return nil, err
-	}
-
-	reqChan := make(chan (chan<- openpgp.KeyRing))
-	go func() {
-		for repChan := range reqChan {
-			// If the keychain file is somehow removed or unreadably
-			// corrupted, it's better to return stale data than to lose
-			// the ability to deploy new software to the node.
-			newInfo, err := os.Stat(keyringPath)
-			if err == nil && info.ModTime() != newInfo.ModTime() {
-				// File has been modified! Reload it.
-				newKeyring, err := LoadKeyring(keyringPath)
-				if err == nil {
-					keyring = newKeyring
-					info = newInfo
-				}
-			}
-			repChan <- keyring
-		}
-	}()
-	return FileKeyringPolicy{keyringPath, authorizedDeployers, reqChan}, nil
-}
-
-func (p FileKeyringPolicy) getKeyringAsync() <-chan openpgp.KeyRing {
-	repChan := make(chan openpgp.KeyRing, 1)
-	p.keyReqChan <- repChan
-	return repChan
+	return FileKeyringPolicy{keyringPath, authorizedDeployers, watcher}, nil
 }
 
 func (p FileKeyringPolicy) AuthorizePod(manifest Manifest, logger logging.Logger) error {
 	return FixedKeyringPolicy{
-		<-p.getKeyringAsync(),
+		(<-p.keyringWatcher.GetAsync()).(openpgp.EntityList),
 		p.AuthorizedDeployers,
 	}.AuthorizePod(manifest, logger)
 }
 
 func (p FileKeyringPolicy) CheckDigest(digest Digest) error {
 	return FixedKeyringPolicy{
-		<-p.getKeyringAsync(),
+		(<-p.keyringWatcher.GetAsync()).(openpgp.EntityList),
 		p.AuthorizedDeployers,
 	}.CheckDigest(digest)
 }
 
 func (p FileKeyringPolicy) Close() {
-	close(p.keyReqChan)
-	p.keyReqChan = nil
+	p.keyringWatcher.Close()
 }
 
 // Assert that FileKeyringPolicy is a Policy

--- a/pkg/preparer/orchestrate_test.go
+++ b/pkg/preparer/orchestrate_test.go
@@ -169,6 +169,7 @@ func testPreparer(t *testing.T, f *FakeStore) (*Preparer, *fakeHooks, string) {
 		HooksDirectory:  util.From(runtime.Caller(0)).ExpandPath("test_hooks"),
 		PodRoot:         podRoot,
 		ForbiddenPodIds: []string{"root"},
+		Auth:            map[string]string{"type": "none"},
 	}
 	p, err := New(cfg, logging.DefaultLogger)
 	Assert(t).IsNil(err, "Test setup error: should not have erred when trying to load a fake preparer")

--- a/pkg/preparer/setup_test.go
+++ b/pkg/preparer/setup_test.go
@@ -17,7 +17,7 @@ func TestLoadConfigWillMarshalYaml(t *testing.T) {
 	Assert(t).AreEqual("foohost", preparerConfig.NodeName, "did not read the node name correctly")
 	Assert(t).AreEqual("0.0.0.0", preparerConfig.ConsulAddress, "did not read the consul address correctly")
 	Assert(t).AreEqual("/etc/p2/hooks", preparerConfig.HooksDirectory, "did not read the hooks directory correctly")
-	Assert(t).AreEqual("/etc/p2.keyring", preparerConfig.KeyringPath, "did not read the keyring path correctly")
+	Assert(t).AreEqual("/etc/p2.keyring", preparerConfig.Auth["keyring"], "did not read the keyring path correctly")
 	Assert(t).AreEqual(1, len(preparerConfig.ExtraLogDestinations), "should have picked up 1 log destination")
 	destination := preparerConfig.ExtraLogDestinations[0]
 	Assert(t).AreEqual(logging.OUT_SOCKET, destination.Type, "should have been the socket type")

--- a/pkg/preparer/test_preparer_config.yaml
+++ b/pkg/preparer/test_preparer_config.yaml
@@ -3,7 +3,9 @@ preparer:
   consul_address: 0.0.0.0
   consul_token_path: /etc/consul.token
   hooks_directory: /etc/p2/hooks
-  keyring: /etc/p2.keyring
+  auth:
+    type: keyring
+    keyring: /etc/p2.keyring
   extra_log_destinations:
   - type: socket
     path: /var/log/p2-socket.out

--- a/pkg/util/watcher.go
+++ b/pkg/util/watcher.go
@@ -1,0 +1,57 @@
+package util
+
+import (
+	"os"
+)
+
+// A FileWatcher caches data that is parsed from a file. Requests for
+// the file's data are serialized through the FileWatcher. When the
+// data are needed, if the file has changed since the last time it was
+// read (determined by examining mtime), it will be re-loaded before
+// returning the data.
+type FileWatcher struct {
+	reqChan chan<- (chan<- interface{})
+}
+
+func NewFileWatcher(
+	parse func(path string) (interface{}, error),
+	path string,
+) (FileWatcher, error) {
+	// Fail fast if it's an invalid file
+	info, err := os.Stat(path)
+	if err != nil {
+		return FileWatcher{}, err
+	}
+	data, err := parse(path)
+	if err != nil {
+		return FileWatcher{}, err
+	}
+	reqChan := make(chan (chan<- interface{}))
+	go func() {
+		for repChan := range reqChan {
+			// If the file is somehow removed or corrupted, it's
+			// better to return stale data than to drop everything.
+			newInfo, err := os.Stat(path)
+			if err == nil && info.ModTime() != newInfo.ModTime() {
+				// File has been modified! Reload it.
+				newData, err := parse(path)
+				if err == nil {
+					data = newData
+					info = newInfo
+				}
+			}
+			repChan <- data
+		}
+	}()
+	return FileWatcher{reqChan}, nil
+}
+
+func (w FileWatcher) GetAsync() <-chan interface{} {
+	repChan := make(chan interface{}, 1)
+	w.reqChan <- repChan
+	return repChan
+}
+
+func (w FileWatcher) Close() {
+	close(w.reqChan)
+}


### PR DESCRIPTION
Adds a new deploy authorization policy to the preparer based on an external
user-based policy file.  This PR consists of a two commits that are pure
refactors and one commit to implement the new policy.