### PR TITLE
Use generic types when parsing authentication settings

### DIFF
--- a/pkg/preparer/orchestrate_test.go
+++ b/pkg/preparer/orchestrate_test.go
@@ -169,7 +169,7 @@ func testPreparer(t *testing.T, f *FakeStore) (*Preparer, *fakeHooks, string) {
 		HooksDirectory:  util.From(runtime.Caller(0)).ExpandPath("test_hooks"),
 		PodRoot:         podRoot,
 		ForbiddenPodIds: []string{"root"},
-		Auth:            map[string]string{"type": "none"},
+		Auth:            map[string]interface{}{"type": "none"},
 	}
 	p, err := New(cfg, logging.DefaultLogger)
 	Assert(t).IsNil(err, "Test setup error: should not have erred when trying to load a fake preparer")


### PR DESCRIPTION
Uses an `interface{}` type when parsing the preparer's "auth" section. `string`
is too restrictive because `KeyringAuth` needs to encode a list of strings.