### PR TITLE
servicebuilder reimplementation, round 2

### DIFF
--- a/pkg/runit/fake_servicebuilder
+++ b/pkg/runit/fake_servicebuilder
@@ -1,3 +1,0 @@
-#!/usr/bin/env sh
-
-echo $@

--- a/pkg/runit/servicebuilder.go
+++ b/pkg/runit/servicebuilder.go
@@ -18,51 +18,85 @@
 package runit
 
 import (
-	"bytes"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"os"
-	"os/exec"
-	"path"
+	"path/filepath"
 
 	"github.com/square/p2/pkg/util"
 
 	"gopkg.in/yaml.v2"
 )
 
-type SBTemplate struct {
-	name       string
-	runClauses map[string]map[string][]string
+type ServiceTemplate struct {
+	Run      []string `yaml:"run"`
+	Log      []string `yaml:"log,omitempty"`
+	Sleep    int      `yaml:"sleep,omitempty"`
+	LogSleep int      `yaml:"logsleep,omitempty"`
 }
 
-type SBTemplateEntry struct {
-	baseCmd []string
-}
-
-func NewSBTemplate(name string) *SBTemplate {
-	return &SBTemplate{
-		name:       name,
-		runClauses: make(map[string]map[string][]string),
+func (s ServiceTemplate) RunScript() ([]byte, error) {
+	if len(s.Run) == 0 {
+		return nil, util.Errorf("empty run script")
 	}
-}
 
-func (template *SBTemplate) AddEntry(app string, run []string) {
-	template.runClauses[app] = map[string][]string{"run": run}
-}
-
-func (template *SBTemplate) Write(out io.Writer) error {
-	b, err := yaml.Marshal(template.runClauses)
+	args, err := yaml.Marshal(s.Run)
 	if err != nil {
-		return util.Errorf("Could not marshal servicebuilder template %s as YAML: %s", template.name, err)
+		return nil, err
 	}
-	_, err = out.Write(b)
-	return err
+
+	// default sleep to reduce spinning on a broken run script
+	sleep := 2
+	if s.Sleep != 0 {
+		sleep = s.Sleep
+	}
+
+	ret := fmt.Sprintf(`#!/usr/bin/ruby
+$stderr.reopen(STDOUT)
+require 'yaml'
+sleep %v
+exec *YAML.load(DATA.read)
+__END__
+%s`, sleep, args)
+	return []byte(ret), nil
+}
+
+func (s ServiceTemplate) LogScript() ([]byte, error) {
+	if len(s.Log) == 0 {
+		// use a default log script that makes a logdir, chowns it and execs
+		// svlogd into it
+		return []byte(`#!/usr/bin/ruby
+require 'fileutils'
+FileUtils.mkdir_p('./main')
+FileUtils.chown('nobody', 'nobody', './main')
+sleep 2
+exec('chpst', '-unobody', 'svlogd', '-tt', './main')
+`), nil
+	}
+
+	args, err := yaml.Marshal(s.Log)
+	if err != nil {
+		return nil, err
+	}
+
+	sleep := 2
+	if s.LogSleep != 0 {
+		sleep = s.LogSleep
+	}
+
+	ret := fmt.Sprintf(`#!/usr/bin/ruby
+require 'yaml'
+sleep %v
+exec *YAML.load(DATA.read)
+__END__
+%s`, sleep, args)
+	return []byte(ret), nil
 }
 
 type ServiceBuilder struct {
-	ConfigRoot  string
-	StagingRoot string
-	RunitRoot   string
+	ConfigRoot  string // directory to generate YAML files
+	StagingRoot string // directory to place staged runit services
+	RunitRoot   string // directory of runsvdir
 	Bin         string
 }
 
@@ -75,52 +109,160 @@ var DefaultBuilder = &ServiceBuilder{
 
 var DefaultChpst = "/usr/bin/chpst"
 
-func (b *ServiceBuilder) serviceYamlPath(name string) string {
-	return path.Join(b.ConfigRoot, fmt.Sprintf("%s.yaml", name))
-}
-
-func (b *ServiceBuilder) Write(template *SBTemplate) (string, error) {
-	yamlPath := b.serviceYamlPath(template.name)
-	fileinfo, _ := os.Stat(yamlPath)
-	if fileinfo != nil && fileinfo.IsDir() {
-		return "", util.Errorf("%s is a directory, but should be empty or a file", yamlPath)
-	}
-
-	f, err := os.OpenFile(yamlPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-	if err != nil {
-		return "", util.Errorf("Could not write servicebuilder template %s: %s", template.name, err)
-	}
-	defer f.Close()
-
-	return yamlPath, template.Write(f)
-}
-
-func (b *ServiceBuilder) Remove(template *SBTemplate) error {
-	yamlPath := b.serviceYamlPath(template.name)
-
-	err := os.Remove(yamlPath)
+// write a servicebuilder yaml file
+// in addition to backwards compat with the real servicebuilder, this file
+// stores the truth of what services are "supposed" to exist right now, which
+// is needed for pruning unused services later
+func (s *ServiceBuilder) write(path string, templates map[string]ServiceTemplate) error {
+	text, err := yaml.Marshal(templates)
 	if err != nil {
 		return err
+	}
+
+	return ioutil.WriteFile(path, text, 0644)
+}
+
+// convert the servicebuilder yaml file into a runit service directory
+func (s *ServiceBuilder) stage(templates map[string]ServiceTemplate) error {
+	for serviceName, template := range templates {
+		stageDir := filepath.Join(s.StagingRoot, serviceName)
+		// create the default log directory
+		err := os.MkdirAll(filepath.Join(stageDir, "log"), 0755)
+		if err != nil {
+			return err
+		}
+
+		runScript, err := template.RunScript()
+		if err != nil {
+			return err
+		}
+		if _, err := util.WriteIfChanged(filepath.Join(stageDir, "run"), runScript, 0755); err != nil {
+			return err
+		}
+
+		logScript, err := template.LogScript()
+		if err != nil {
+			return err
+		}
+		if _, err := util.WriteIfChanged(filepath.Join(stageDir, "log", "run"), logScript, 0755); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// symlink the runit service directory into the actual directory being monitored
+// by runsvdir
+// runsvdir will automatically start a service for each new directory (unless a
+// down file exists)
+func (s *ServiceBuilder) activate(templates map[string]ServiceTemplate) error {
+	for serviceName := range templates {
+		linkPath := filepath.Join(s.RunitRoot, serviceName)
+		stageDir := filepath.Join(s.StagingRoot, serviceName)
+
+		info, err := os.Lstat(linkPath)
+		if err == nil {
+			// if it exists, make sure it is actually a symlink
+			if info.Mode()&os.ModeSymlink == 0 {
+				return util.Errorf("%s is not a symlink", linkPath)
+			}
+
+			// and that it points to the right place
+			target, err := os.Readlink(linkPath)
+			if err != nil {
+				return err
+			}
+			if target != stageDir {
+				return util.Errorf("%s is a symlink to %s (expected %s)", linkPath, target, stageDir)
+			}
+		} else if os.IsNotExist(err) {
+			if err = os.Symlink(stageDir, linkPath); err != nil {
+				return err
+			}
+		} else if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// public API to write, stage and activate a servicebuilder template
+func (s *ServiceBuilder) Activate(name string, templates map[string]ServiceTemplate) error {
+	if err := s.write(filepath.Join(s.ConfigRoot, name+".yaml"), templates); err != nil {
+		return err
+	}
+	if err := s.stage(templates); err != nil {
+		return err
+	}
+	return s.activate(templates)
+}
+
+// using the servicebuilder yaml files, find any extraneous runit services and
+// remove them
+// runsvdir automatically stops services that no longer exist, explicit stop is
+// not required
+func (s *ServiceBuilder) Prune() error {
+	configs, err := s.loadConfigDir()
+	if err != nil {
+		return err
+	}
+
+	links, err := ioutil.ReadDir(s.RunitRoot)
+	if err != nil {
+		return err
+	}
+	for _, link := range links {
+		if _, exists := configs[link.Name()]; !exists {
+			if err = os.Remove(filepath.Join(s.RunitRoot, link.Name())); err != nil {
+				return err
+			}
+		}
+	}
+
+	stages, err := ioutil.ReadDir(s.StagingRoot)
+	if err != nil {
+		return err
+	}
+	for _, stage := range stages {
+		if _, exists := configs[stage.Name()]; !exists {
+			if err = os.RemoveAll(filepath.Join(s.StagingRoot, stage.Name())); err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil
 }
 
-// Rebuild executes the servicebuilder binary with the given configuration. Any
-// templates written up to this point will be used to create or update existing services.
-// Servicebuilder will err if two or more services with the same name have been configured.
-func (b *ServiceBuilder) Rebuild() (string, error) {
-	return b.RebuildWithStreams(os.Stdin)
-}
+// loadConfigDir reads all the files in the ConfigRoot and converts them into a
+// single map of servicetemplates.
+func (s *ServiceBuilder) loadConfigDir() (map[string]ServiceTemplate, error) {
+	ret := make(map[string]ServiceTemplate)
 
-func (b *ServiceBuilder) RebuildWithStreams(stdin io.Reader) (string, error) {
-	cmd := exec.Command(b.Bin, "-c", b.ConfigRoot, "-s", b.StagingRoot, "-d", b.RunitRoot)
-	cmd.Stdin = stdin
-	buffer := bytes.Buffer{}
-	cmd.Stdout = &buffer
-	err := cmd.Run()
+	entries, err := ioutil.ReadDir(s.ConfigRoot)
 	if err != nil {
-		return "", util.Errorf("Could not run servicebuilder rebuild: %s", err)
+		return nil, err
 	}
-	return buffer.String(), nil
+
+	for _, entry := range entries {
+		entryContents, err := ioutil.ReadFile(filepath.Join(s.ConfigRoot, entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+
+		entryTemplate := make(map[string]ServiceTemplate)
+		err = yaml.Unmarshal(entryContents, entryTemplate)
+		if err != nil {
+			return nil, err
+		}
+
+		for name, template := range entryTemplate {
+			if _, exists := ret[name]; exists {
+				return nil, util.Errorf("service with name %s was defined twice (from %s)", name, entry.Name())
+			}
+			ret[name] = template
+		}
+	}
+
+	return ret, nil
 }

--- a/pkg/runit/servicebuilder_test.go
+++ b/pkg/runit/servicebuilder_test.go
@@ -1,127 +1,113 @@
 package runit
 
 import (
-	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
-	"runtime"
-	"strings"
+	"path/filepath"
+	"reflect"
 	"testing"
 
 	. "github.com/anthonybishopric/gotcha"
 	"gopkg.in/yaml.v2"
 )
 
-func TestServiceBuilderOutputsValidYaml(t *testing.T) {
-	template := NewSBTemplate("exemplar")
-	template.AddEntry("exemplar", []string{"ls", "-lah", "/foo/bar"})
-	out := bytes.Buffer{}
-	err := template.Write(&out)
-	Assert(t).IsNil(err, "Did not expect to error")
-	bytes, err := ioutil.ReadAll(&out)
-	Assert(t).IsNil(err, "Did not expect to error")
-	outMap := make(map[interface{}]interface{})
-	yaml.Unmarshal(bytes, &outMap)
-	expected := `exemplar:
-  run:
-  - ls
-  - -lah
-  - /foo/bar
-`
-	Assert(t).AreEqual(expected, string(bytes), "The generated YAML was not what was expected")
+var fakeTemplate map[string]ServiceTemplate = map[string]ServiceTemplate{
+	"foo": ServiceTemplate{
+		Run: []string{"foo", "one", "two"},
+	},
 }
 
-func expandLocal(local string) string {
-	_, file, _, _ := runtime.Caller(0)
-	return path.Join(path.Dir(file), local)
+func TestWriteTemplate(t *testing.T) {
+	sb := FakeServiceBuilder()
+	defer os.RemoveAll(sb.ConfigRoot)
+	defer os.RemoveAll(sb.StagingRoot)
+	defer os.RemoveAll(sb.RunitRoot)
+
+	fakePath := filepath.Join(sb.ConfigRoot, "test.yaml")
+	err := sb.write(fakePath, fakeTemplate)
+	Assert(t).IsNil(err, "should have written templates")
+
+	fakeYaml, err := ioutil.ReadFile(fakePath)
+	Assert(t).IsNil(err, "should have read templates")
+
+	test := make(map[string]ServiceTemplate)
+	err = yaml.Unmarshal(fakeYaml, test)
+	Assert(t).IsNil(err, "should have parsed templates")
+
+	Assert(t).IsTrue(reflect.DeepEqual(test, fakeTemplate), "should have been equal")
 }
 
-func fakeServiceBuilder(t *testing.T) ServiceBuilder {
-	confDir, err := ioutil.TempDir("", "sb-conf")
-	Assert(t).IsNil(err, "confdir should have been created (test setup error)")
+func TestStagedContents(t *testing.T) {
+	sb := FakeServiceBuilder()
+	defer os.RemoveAll(sb.ConfigRoot)
+	defer os.RemoveAll(sb.StagingRoot)
+	defer os.RemoveAll(sb.RunitRoot)
 
-	stagingDir, err := ioutil.TempDir("", "sb-stage")
-	Assert(t).IsNil(err, "stagingdir should have been created (test setup error)")
-	defer os.RemoveAll(stagingDir)
-	runitDir, err := ioutil.TempDir("", "sb-runit")
-	Assert(t).IsNil(err, "runitdir should have been created (test setup error)")
-	defer os.RemoveAll(runitDir)
+	err := sb.stage(fakeTemplate)
+	Assert(t).IsNil(err, "should have staged")
 
-	fakeSb := expandLocal("fake_servicebuilder")
+	info, err := os.Stat(filepath.Join(sb.StagingRoot, "foo"))
+	Assert(t).IsNil(err, "should have statted staging dir")
+	Assert(t).IsTrue(info.IsDir(), "staging dir should have been a dir")
 
-	return ServiceBuilder{
-		ConfigRoot:  confDir,
-		StagingRoot: stagingDir,
-		RunitRoot:   runitDir,
-		Bin:         fakeSb,
-	}
+	info, err = os.Stat(filepath.Join(sb.StagingRoot, "foo", "run"))
+	Assert(t).IsNil(err, "should have statted staging run")
+	Assert(t).IsFalse(info.IsDir(), "staging run should have been a file")
+	Assert(t).IsTrue(info.Mode()&0100 == 0100, "staging run should have been executable")
+
+	info, err = os.Stat(filepath.Join(sb.StagingRoot, "foo", "log"))
+	Assert(t).IsNil(err, "should have statted staging log dir")
+	Assert(t).IsTrue(info.IsDir(), "staging log dir should have been a dir")
+
+	info, err = os.Stat(filepath.Join(sb.StagingRoot, "foo", "log", "run"))
+	Assert(t).IsNil(err, "should have statted staging log run")
+	Assert(t).IsFalse(info.IsDir(), "staging log run should have been a file")
+	Assert(t).IsTrue(info.Mode()&0100 == 0100, "staging log run should have been executable")
 }
 
-func TestServiceBuilderCanTakeSBTemplates(t *testing.T) {
-	template := NewSBTemplate("exemplar")
-	template.AddEntry("exemplar", []string{"ls", "-lah", "/foo/bar"})
+func TestActivateSucceedsTwice(t *testing.T) {
+	sb := FakeServiceBuilder()
+	defer os.RemoveAll(sb.ConfigRoot)
+	defer os.RemoveAll(sb.StagingRoot)
+	defer os.RemoveAll(sb.RunitRoot)
 
-	builder := fakeServiceBuilder(t)
-	defer os.RemoveAll(builder.ConfigRoot)
-	defer os.RemoveAll(builder.StagingRoot)
-	defer os.RemoveAll(builder.RunitRoot)
-	confDir := builder.ConfigRoot
+	err := sb.activate(fakeTemplate)
+	Assert(t).IsNil(err, "should have activated service")
+	target, err := os.Readlink(filepath.Join(sb.RunitRoot, "foo"))
+	Assert(t).IsNil(err, "should have read link for activated service")
+	Assert(t).IsTrue(target == filepath.Join(sb.StagingRoot, "foo"), "should have symlinked to the staging dir")
 
-	outPath, err := builder.Write(template)
-	Assert(t).IsNil(err, "there should not have been an error when writing the template")
-	Assert(t).AreEqual(path.Join(confDir, "exemplar.yaml"), outPath, "the written servicebuilder path was not what we expected")
-
-	f, err := os.Open(outPath)
-	defer f.Close()
-	Assert(t).IsNil(err, "Could not open out path for exemplar")
-	content, err := ioutil.ReadAll(f)
-	Assert(t).IsNil(err, "Could not read file")
-
-	expected := `exemplar:
-  run:
-  - ls
-  - -lah
-  - /foo/bar
-`
-	Assert(t).AreEqual(expected, string(content), "The generated YAML was not what was expected")
-
-	// attempt to write the file a second time. This verifies that we are actually able to do it without erring
-	_, err = builder.Write(template)
-	Assert(t).IsNil(err, "Was not able to write the servicebuilder file a second time")
+	// do it again to make sure repeated activations work fine
+	err = sb.activate(fakeTemplate)
+	Assert(t).IsNil(err, "should have activated service")
+	target, err = os.Readlink(filepath.Join(sb.RunitRoot, "foo"))
+	Assert(t).IsNil(err, "should have read link for activated service")
+	Assert(t).IsTrue(target == filepath.Join(sb.StagingRoot, "foo"), "should have symlinked to the staging dir")
 }
 
-func TestServiceBuilderWillExecuteRebuild(t *testing.T) {
-	builder := fakeServiceBuilder(t)
-	defer os.RemoveAll(builder.ConfigRoot)
-	defer os.RemoveAll(builder.StagingRoot)
-	defer os.RemoveAll(builder.RunitRoot)
+func TestPrune(t *testing.T) {
+	sb := FakeServiceBuilder()
+	defer os.RemoveAll(sb.ConfigRoot)
+	defer os.RemoveAll(sb.StagingRoot)
+	defer os.RemoveAll(sb.RunitRoot)
 
-	output, err := builder.RebuildWithStreams(os.Stdin)
-	Assert(t).IsNil(err, "Could not execute fake servicebuilder")
+	// first create the service
+	err := sb.Activate("foo", fakeTemplate)
+	Assert(t).IsNil(err, "should have activated service")
+	_, err = os.Readlink(filepath.Join(sb.RunitRoot, "foo"))
+	Assert(t).IsNil(err, "should have created activation symlink")
 
-	Assert(t).IsTrue(strings.Contains(output, builder.ConfigRoot), fmt.Sprintf("the config root should have been passed in cmd: %s", output))
-}
+	// now remove the service's yaml file
+	err = sb.Activate("foo", map[string]ServiceTemplate{})
+	Assert(t).IsNil(err, "should have activated service")
+	// symlink should still exist, haven't pruned yet
+	_, err = os.Readlink(filepath.Join(sb.RunitRoot, "foo"))
+	Assert(t).IsNil(err, "should have created activation symlink")
 
-func TestServiceBuilderCanRemoveServiceFiles(t *testing.T) {
-	builder := fakeServiceBuilder(t)
-	defer os.RemoveAll(builder.ConfigRoot)
-	defer os.RemoveAll(builder.StagingRoot)
-	defer os.RemoveAll(builder.RunitRoot)
-	template := NewSBTemplate("exemplar")
-	filePath := path.Join(builder.ConfigRoot, "exemplar.yaml")
-
-	f, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-	Assert(t).IsNil(err, "unable to open fake servicebuilder file for writing")
-
-	_, err = f.WriteString("foo")
-	Assert(t).IsNil(err, "unable to write fake servicebuilder file")
-
-	_, err = os.Stat(filePath)
-	Assert(t).IsNil(err, "Unable to stat the fake servicebuilder file")
-	builder.Remove(template)
-	_, err = os.Stat(filePath)
-	Assert(t).IsNotNil(err, "File still exists after it was supposed to be removed")
-
+	err = sb.Prune()
+	Assert(t).IsNil(err, "should have pruned")
+	_, err = os.Readlink(filepath.Join(sb.RunitRoot, "foo"))
+	Assert(t).IsTrue(os.IsNotExist(err), "should have removed activation symlink")
+	_, err = os.Stat(filepath.Join(sb.StagingRoot, "foo"))
+	Assert(t).IsTrue(os.IsNotExist(err), "should have removed staging dir")
 }

--- a/pkg/util/write.go
+++ b/pkg/util/write.go
@@ -1,0 +1,48 @@
+package util
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+)
+
+func WriteIfChanged(filename string, data []byte, perm os.FileMode) (bool, error) {
+	modified := false
+
+	content, err := ioutil.ReadFile(filename)
+	if !os.IsNotExist(err) && err != nil {
+		// file existed, but could not be read
+		return modified, err
+	}
+
+	if os.IsNotExist(err) || bytes.Compare(content, data) != 0 {
+		openPerm := perm
+		if perm == 0 {
+			// if the file gets created with perm=0, then all the permission
+			// bits will be turned off
+			// a more sensible default is to use 0666 (and then umask gets
+			// applied)
+			openPerm = 0666
+		}
+
+		modified = true
+		err = ioutil.WriteFile(filename, data, openPerm)
+		if err != nil {
+			return modified, err
+		}
+	}
+
+	if perm != 0 {
+		info, err := os.Stat(filename)
+		if err != nil {
+			return modified, err
+		}
+
+		if info.Mode() != perm {
+			modified = true
+			err = os.Chmod(filename, perm)
+		}
+	}
+
+	return modified, err
+}

--- a/pkg/util/write_test.go
+++ b/pkg/util/write_test.go
@@ -1,0 +1,96 @@
+package util
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/anthonybishopric/gotcha"
+)
+
+func TestWriteNewFile(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "write")
+	Assert(t).IsNil(err, "should have created tmpdir")
+	defer os.RemoveAll(tmp)
+
+	write, err := WriteIfChanged(filepath.Join(tmp, "tmp"), []byte("tmp"), 0600)
+	Assert(t).IsNil(err, "should have written")
+	Assert(t).IsTrue(write, "should have written")
+
+	info, err := os.Stat(filepath.Join(tmp, "tmp"))
+	Assert(t).IsNil(err, "should have statted new file")
+	Assert(t).IsTrue(info.Mode() == 0600, "should have had 0600 permissions")
+
+	content, err := ioutil.ReadFile(filepath.Join(tmp, "tmp"))
+	Assert(t).IsNil(err, "should have read new file")
+	Assert(t).IsTrue(bytes.Equal(content, []byte("tmp")), "should have written correct contents")
+}
+
+func TestNewFileZeroPerms(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "write")
+	Assert(t).IsNil(err, "should have created tmpdir")
+	defer os.RemoveAll(tmp)
+
+	write, err := WriteIfChanged(filepath.Join(tmp, "tmp"), []byte("tmp"), 0)
+	Assert(t).IsNil(err, "should have written")
+	Assert(t).IsTrue(write, "should have written")
+
+	info, err := os.Stat(filepath.Join(tmp, "tmp"))
+	Assert(t).IsNil(err, "should have statted new file")
+	Assert(t).IsTrue(info.Mode() != 0, "should not have had 0 permissions")
+}
+
+func TestWriteUnchangedFile(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "write")
+	Assert(t).IsNil(err, "should have created tmpdir")
+	defer os.RemoveAll(tmp)
+
+	err = ioutil.WriteFile(filepath.Join(tmp, "tmp"), []byte("tmp"), 0600)
+	Assert(t).IsNil(err, "should have written file initially")
+
+	info, err := os.Stat(filepath.Join(tmp, "tmp"))
+	Assert(t).IsNil(err, "should have statted new file")
+
+	write, err := WriteIfChanged(filepath.Join(tmp, "tmp"), []byte("tmp"), 0600)
+	Assert(t).IsNil(err, "should have written without error")
+	Assert(t).IsFalse(write, "should not have actually written")
+
+	info2, err := os.Stat(filepath.Join(tmp, "tmp"))
+	Assert(t).IsNil(err, "should have statted new file second time")
+	Assert(t).IsTrue(info.ModTime() == info2.ModTime(), "should not have modified file")
+}
+
+func TestUpdatePermissions(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "write")
+	Assert(t).IsNil(err, "should have created tmpdir")
+	defer os.RemoveAll(tmp)
+
+	err = ioutil.WriteFile(filepath.Join(tmp, "tmp"), []byte("tmp"), 0600)
+	Assert(t).IsNil(err, "should have written file initially")
+
+	write, err := WriteIfChanged(filepath.Join(tmp, "tmp"), []byte("tmp"), 0644)
+	Assert(t).IsNil(err, "should have written without error")
+	Assert(t).IsTrue(write, "should have actually chmodded")
+
+	info, err := os.Stat(filepath.Join(tmp, "tmp"))
+	Assert(t).IsNil(err, "should have statted new file second time")
+	Assert(t).IsTrue(info.Mode() == 0644, "should have changed to mode 0644")
+}
+
+func TestNoUpdatePermissionsDuringWrite(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "write")
+	Assert(t).IsNil(err, "should have created tmpdir")
+	defer os.RemoveAll(tmp)
+
+	err = ioutil.WriteFile(filepath.Join(tmp, "tmp"), []byte("tmp"), 0600)
+	Assert(t).IsNil(err, "should have written file initially")
+
+	_, err = WriteIfChanged(filepath.Join(tmp, "tmp"), []byte("tmp2"), 0)
+	Assert(t).IsNil(err, "should have written without error")
+
+	info, err := os.Stat(filepath.Join(tmp, "tmp"))
+	Assert(t).IsNil(err, "should have statted new file")
+	Assert(t).IsTrue(info.Mode() == 0600, "should still be 0600 mode")
+}


### PR DESCRIPTION
The first two commits are the same as in the original branch. For the third commit, the original branch moved servicebuilder into the hoistlaunchable, which caused one file to be created for each launchable. This causes conflicts with existing servicebuilder files.

This new branch instead uses the new servicebuilder in the existing pod.buildRunitServices. This preserves the one-file-per-pod behavior that we were using before, which means conflicts will not be created between old p2 servicebuilder files and new ones.

Thorough testing is in progress, but the code is ready for review. My travis branch will be rebased back on top of this after merge.