### PR TITLE
Add status port for p2-preparer

### DIFF
--- a/bin/p2-preparer/main.go
+++ b/bin/p2-preparer/main.go
@@ -48,7 +48,7 @@ func main() {
 		func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(w, "p2-preparer OK")
 		})
-	go http.ListenAndServe(":8080", nil)
+	go http.ListenAndServe(fmt.Sprintf(":%d", preparerConfig.StatusPort), nil)
 
 	waitForTermination(logger, quitMainUpdate, quitHookUpdate)
 

--- a/bin/p2-preparer/main.go
+++ b/bin/p2-preparer/main.go
@@ -31,12 +31,13 @@ func main() {
 	defer prep.Close()
 
 	logger.WithFields(logrus.Fields{
-		"starting":  true,
-		"node_name": preparerConfig.NodeName,
-		"consul":    preparerConfig.ConsulAddress,
-		"hooks_dir": preparerConfig.HooksDirectory,
-		"keyring":   preparerConfig.Auth["keyring"],
-		"version":   version.VERSION,
+		"starting":    true,
+		"node_name":   preparerConfig.NodeName,
+		"consul":      preparerConfig.ConsulAddress,
+		"hooks_dir":   preparerConfig.HooksDirectory,
+		"status_port": preparerConfig.StatusPort,
+		"keyring":     preparerConfig.Auth["keyring"],
+		"version":     version.VERSION,
 	}).Infoln("Preparer started successfully")
 
 	quitMainUpdate := make(chan struct{})

--- a/bin/p2-preparer/main.go
+++ b/bin/p2-preparer/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -41,6 +43,12 @@ func main() {
 	quitHookUpdate := make(chan struct{})
 	go prep.WatchForPodManifestsForNode(quitMainUpdate)
 	go prep.WatchForHooks(quitHookUpdate)
+
+	http.HandleFunc("/_status",
+		func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, "p2-preparer OK")
+		})
+	go http.ListenAndServe(":8080", nil)
 
 	waitForTermination(logger, quitMainUpdate, quitHookUpdate)
 

--- a/bin/p2-preparer/main.go
+++ b/bin/p2-preparer/main.go
@@ -44,11 +44,13 @@ func main() {
 	go prep.WatchForPodManifestsForNode(quitMainUpdate)
 	go prep.WatchForHooks(quitHookUpdate)
 
-	http.HandleFunc("/_status",
-		func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprintf(w, "p2-preparer OK")
-		})
-	go http.ListenAndServe(fmt.Sprintf(":%d", preparerConfig.StatusPort), nil)
+	if preparerConfig.StatusPort != 0 {
+		http.HandleFunc("/_status",
+			func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintf(w, "p2-preparer OK")
+			})
+		go http.ListenAndServe(fmt.Sprintf(":%d", preparerConfig.StatusPort), nil)
+	}
 
 	waitForTermination(logger, quitMainUpdate, quitHookUpdate)
 

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -32,6 +32,7 @@ type PreparerConfig struct {
 	HooksDirectory       string                 `yaml:"hooks_directory"`
 	CAPath               string                 `yaml:"ca_path,omitempty"`
 	PodRoot              string                 `yaml:"pod_root,omitempty"`
+	StatusPort           int                    `yaml:"status_port"`
 	Auth                 map[string]interface{} `yaml:"auth,omitempty"`
 	ForbiddenPodIds      []string               `yaml:"forbidden_pod_ids,omitempty"`
 	ExtraLogDestinations []LogDestination       `yaml:"extra_log_destinations,omitempty"`


### PR DESCRIPTION
This implementation counts consecutive errors from either hooks or pods. Status goes critical if the number of consecutive errors >= 10 (the constant tooManyErrors).

I have been testing on a universe by stopping consul in the universe and seeing the errors count up. I then restart consul to see if it goes healthy again. I'm not 100% clear on whether I have the "OK I'm healthy again" part right. Going to do some more testing and report back on this PR.