### PR TITLE
Authorize hook deployment as if they were the preparer

### DIFF
--- a/bin/p2-preparer/main.go
+++ b/bin/p2-preparer/main.go
@@ -36,6 +36,7 @@ func main() {
 		"consul":      preparerConfig.ConsulAddress,
 		"hooks_dir":   preparerConfig.HooksDirectory,
 		"status_port": preparerConfig.StatusPort,
+		"auth_type":   preparerConfig.Auth["type"],
 		"keyring":     preparerConfig.Auth["keyring"],
 		"version":     version.VERSION,
 	}).Infoln("Preparer started successfully")

--- a/pkg/preparer/listener.go
+++ b/pkg/preparer/listener.go
@@ -63,7 +63,7 @@ func (l *HookListener) Sync(quit <-chan struct{}, errCh chan<- error) {
 				"dest": l.DestinationDir,
 			})
 
-			err := l.authPolicy.AuthorizePod(&result.Manifest, sub)
+			err := l.authPolicy.AuthorizeHook(&result.Manifest, sub)
 			if err != nil {
 				if err, ok := err.(auth.Error); ok {
 					sub.WithFields(err.Fields).Errorln(err)

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -165,7 +165,7 @@ func (p *Preparer) handlePods(podChan <-chan pods.Manifest, quit <-chan struct{}
 
 // check if a manifest satisfies the signature requirement of this preparer
 func (p *Preparer) verifySignature(manifest pods.Manifest, logger logging.Logger) bool {
-	err := p.authPolicy.AuthorizePod(&manifest, logger)
+	err := p.authPolicy.AuthorizeApp(&manifest, logger)
 	if err != nil {
 		if err, ok := err.(auth.Error); ok {
 			logger.WithFields(err.Fields).Errorln(err)

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -155,6 +155,7 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 		authPolicy, err = auth.NewUserPolicy(
 			userConfig.KeyringPath,
 			userConfig.DeployPolicyPath,
+			POD_ID,
 		)
 		if err != nil {
 			return nil, util.Errorf("error configuring user auth: %s", err)


### PR DESCRIPTION
Hooks are not the same as apps: they are the method of extending the preparer,
not something that users will use for pushing apps. This commit separates
`auth.Policy.AuthorizePod()` into `AuthorizeApp()` for use on apps and
`AuthorizeHook()` for use on hooks. In most policies, the two are treated the
same. In `UserPolicy`, hooks are authorized using the name of the preparer, not
the name of the hook's pod.