### PR TITLE
Force `p2-schedule` to terminate if a manifest is unschedulable

### DIFF
--- a/bin/p2-schedule/main.go
+++ b/bin/p2-schedule/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -51,8 +50,7 @@ func main() {
 	for _, manifestPath := range *manifests {
 		manifest, err := pods.ManifestFromPath(manifestPath)
 		if err != nil {
-			os.Stderr.WriteString(fmt.Sprintf("Could not read manifest at %s: %s\n", manifestPath, err))
-			continue
+			log.Fatalf("Could not read manifest at %s: %s\n", manifestPath, err)
 		}
 		path := kp.IntentPath(*nodeName, manifest.ID())
 		if *hookTypeName != "" {
@@ -64,9 +62,8 @@ func main() {
 		}
 		duration, err := store.SetPod(path, *manifest)
 		if err != nil {
-			os.Stderr.WriteString(fmt.Sprintf("Could not write manifest %s to intent store: %s\n", manifest.ID(), err))
-			continue
+			log.Fatalf("Could not write manifest %s to intent store: %s\n", manifest.ID(), err)
 		}
-		log.Printf("Scheduling %s took %s", manifest.ID(), duration)
+		log.Printf("Scheduling %s took %s\n", manifest.ID(), duration)
 	}
 }

--- a/pkg/kp/lock.go
+++ b/pkg/kp/lock.go
@@ -49,7 +49,7 @@ func (s *Store) NewLock(name string) (Lock, error) {
 func (s *Store) LockHolder(key string) (string, string, error) {
 	kvp, _, err := s.client.KV().Get(key, nil)
 	if err != nil {
-		return "", "", KVError{Op: "get", Key: key}
+		return "", "", KVError{Op: "get", Key: key, UnsafeError: err}
 	}
 	if kvp == nil || kvp.Session == "" {
 		return "", "", nil


### PR DESCRIPTION
Also exposes an `UnsafeError` field on the KVError type. Consul's
errors are not safe to print since they frequently include ACL tokens
in the text, so this can be selectively inspected during triage.