### PR TITLE
small logging improvements

### DIFF
--- a/bin/p2-inspect/main.go
+++ b/bin/p2-inspect/main.go
@@ -59,11 +59,11 @@ func main() {
 
 	intents, _, err := store.ListPods(kp.INTENT_TREE)
 	if err != nil {
-		log.Fatalf("Could not list intent kvpairs: %s", err)
+		log.Fatalf("Could not list intent kvpairs: %s", err.(kp.KVError).UnsafeError)
 	}
 	realities, _, err := store.ListPods(kp.REALITY_TREE)
 	if err != nil {
-		log.Fatalf("Could not list reality kvpairs: %s", err)
+		log.Fatalf("Could not list reality kvpairs: %s", err.(kp.KVError).UnsafeError)
 	}
 
 	statusMap := make(map[string]map[string]NodePodStatus)

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -91,7 +91,7 @@ func runDirectory(dirpath string, environment []string, logger logging.Logger) e
 			logger.WithFields(logrus.Fields{
 				"path":   fullpath,
 				"output": hookOut.String(),
-			}).Infoln("Executed hook")
+			}).Infof("Executed %s", path.Base(fullpath))
 		}
 	}
 


### PR DESCRIPTION
Allows callers of p2-inspect to read the unsafe error instead of
the sanitized one (assumes that all callers of p2-inspect are human)

Prints name of hook executed instead of an unqualified name.