### PR TITLE
Authorize a pod based on its manifest's user, not its name

### DIFF
--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -34,7 +34,7 @@ type PreparerConfig struct {
 	PodRoot              string                 `yaml:"pod_root,omitempty"`
 	StatusPort           int                    `yaml:"status_port"`
 	Auth                 map[string]interface{} `yaml:"auth,omitempty"`
-	ForbiddenPodIds      []string               `yaml:"forbidden_pod_ids,omitempty"`
+	ForbiddenUsers       []string               `yaml:"forbidden_users,omitempty"`
 	ExtraLogDestinations []LogDestination       `yaml:"extra_log_destinations,omitempty"`
 }
 
@@ -156,6 +156,7 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 			userConfig.KeyringPath,
 			userConfig.DeployPolicyPath,
 			POD_ID,
+			POD_ID,
 		)
 		if err != nil {
 			return nil, util.Errorf("error configuring user auth: %s", err)
@@ -194,20 +195,20 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 		return nil, util.Errorf("Could not create preparer pod directory: %s", err)
 	}
 
-	forbiddenPodIds := make(map[string]struct{})
-	for _, forbidden := range preparerConfig.ForbiddenPodIds {
-		forbiddenPodIds[forbidden] = struct{}{}
+	forbiddenUsers := make(map[string]bool)
+	for _, forbidden := range preparerConfig.ForbiddenUsers {
+		forbiddenUsers[forbidden] = true
 	}
 
 	return &Preparer{
-		node:            preparerConfig.NodeName,
-		store:           store,
-		hooks:           hooks.Hooks(preparerConfig.HooksDirectory, &logger),
-		hookListener:    listener,
-		Logger:          logger,
-		podRoot:         preparerConfig.PodRoot,
-		forbiddenPodIds: forbiddenPodIds,
-		authPolicy:      authPolicy,
-		caPath:          preparerConfig.CAPath,
+		node:           preparerConfig.NodeName,
+		store:          store,
+		hooks:          hooks.Hooks(preparerConfig.HooksDirectory, &logger),
+		hookListener:   listener,
+		Logger:         logger,
+		podRoot:        preparerConfig.PodRoot,
+		forbiddenUsers: forbiddenUsers,
+		authPolicy:     authPolicy,
+		caPath:         preparerConfig.CAPath,
 	}, nil
 }


### PR DESCRIPTION
Changes the UserPolicy authorization policy to look for authorization based on
the user the pod will run as, not the name of the pod. This makes the tool more
similar to "sudo", in that users are authorized to run commands (deploy
software) as other users.

This commit also renames the configuration parameter "forbidden_pod_ids" to
"forbidden_users".  Even before this commit, it was blocking users in the
"run_as" field, but its name did not convey this.