### PR TITLE
preserve the original order of bytes read from a manifest file, so th…

### DIFF
--- a/pkg/preparer/listener_test.go
+++ b/pkg/preparer/listener_test.go
@@ -70,7 +70,7 @@ func TestHookPodsInstallAndLinkCorrectly(t *testing.T) {
 			},
 		},
 	}
-	manifestBytes, err := manifest.Bytes()
+	manifestBytes, err := manifest.OriginalBytes()
 	Assert(t).IsNil(err, "manifest bytes error should have been nil")
 
 	fakeSigner, err := openpgp.NewEntity("p2", "p2-test", "p2@squareup.com", nil)

--- a/pkg/preparer/orchestrate_test.go
+++ b/pkg/preparer/orchestrate_test.go
@@ -120,7 +120,7 @@ func testSignedManifest(t *testing.T, modify func(*pods.Manifest, *openpgp.Entit
 		modify(testManifest, fakeSigner)
 	}
 
-	manifestBytes, err := testManifest.Bytes()
+	manifestBytes, err := testManifest.Marshal()
 	Assert(t).IsNil(err, "manifest bytes error should have been nil")
 
 	var buf bytes.Buffer


### PR DESCRIPTION
…at we can compare equality of a manifest as bytes to the original file