### PR TITLE
Changes pods.Manifest.Config to map[string]interface{}

### DIFF
--- a/bin/p2-bin2pod/main.go
+++ b/bin/p2-bin2pod/main.go
@@ -148,7 +148,6 @@ func makeTar(workingDir string, manifest *pods.Manifest) (string, error) {
 }
 
 func addManifestConfig(manifest *pods.Manifest) error {
-	manifest.Config = make(map[interface{}]interface{})
 	for _, pair := range *config {
 		res := strings.Split(pair, "=")
 		if len(res) != 2 {

--- a/pkg/pods/manifest.go
+++ b/pkg/pods/manifest.go
@@ -32,7 +32,7 @@ type Manifest struct {
 	Id                string                      `yaml:"id"` // public for yaml marshaling access. Use ID() instead.
 	RunAs             string                      `yaml:"run_as,omitempty"`
 	LaunchableStanzas map[string]LaunchableStanza `yaml:"launchables"`
-	Config            map[interface{}]interface{} `yaml:"config"`
+	Config            interface{}                 `yaml:"config"`
 	StatusPort        int                         `yaml:"status_port,omitempty"`
 	StatusHTTP        bool                        `yaml:"status_http,omitempty"`
 	// these fields are required to track the original text if it was signed

--- a/pkg/pods/manifest_test.go
+++ b/pkg/pods/manifest_test.go
@@ -42,7 +42,6 @@ func TestPodManifestCanBeWritten(t *testing.T) {
 	manifest := Manifest{
 		Id:                "thepod",
 		LaunchableStanzas: make(map[string]LaunchableStanza),
-		Config:            make(map[interface{}]interface{}),
 	}
 	launchable := LaunchableStanza{
 		LaunchableType: "hoist",


### PR DESCRIPTION
Before, Config was a map[interface{}]interface{}. This
was causing problems because the structure could not
be encoded as JSON.