### PR TITLE
Remove "forbidden_users" preparer option

### DIFF
--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -35,15 +35,14 @@ type Store interface {
 }
 
 type Preparer struct {
-	node           string
-	store          Store
-	hooks          Hooks
-	hookListener   HookListener
-	Logger         logging.Logger
-	podRoot        string
-	forbiddenUsers map[string]bool
-	caPath         string
-	authPolicy     auth.Policy
+	node         string
+	store        Store
+	hooks        Hooks
+	hookListener HookListener
+	Logger       logging.Logger
+	podRoot      string
+	caPath       string
+	authPolicy   auth.Policy
 }
 
 func (p *Preparer) WatchForHooks(quit chan struct{}) {
@@ -169,17 +168,6 @@ func (p *Preparer) authorize(manifest pods.Manifest, logger logging.Logger) bool
 		}
 		return false
 	}
-
-	// Even if the authorization policy allows it, apply another
-	// filter to keep apps from being deployed as system users.
-	if manifest.ID() != POD_ID && p.forbiddenUsers[manifest.RunAsUser()] {
-		logger.WithFields(logrus.Fields{
-			"pod":    manifest.ID(),
-			"run_as": manifest.RunAsUser(),
-		}).Errorln("Invalid run_as user")
-		return false
-	}
-
 	return true
 }
 

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -34,7 +34,6 @@ type PreparerConfig struct {
 	PodRoot              string                 `yaml:"pod_root,omitempty"`
 	StatusPort           int                    `yaml:"status_port"`
 	Auth                 map[string]interface{} `yaml:"auth,omitempty"`
-	ForbiddenUsers       []string               `yaml:"forbidden_users,omitempty"`
 	ExtraLogDestinations []LogDestination       `yaml:"extra_log_destinations,omitempty"`
 }
 
@@ -195,20 +194,14 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 		return nil, util.Errorf("Could not create preparer pod directory: %s", err)
 	}
 
-	forbiddenUsers := make(map[string]bool)
-	for _, forbidden := range preparerConfig.ForbiddenUsers {
-		forbiddenUsers[forbidden] = true
-	}
-
 	return &Preparer{
-		node:           preparerConfig.NodeName,
-		store:          store,
-		hooks:          hooks.Hooks(preparerConfig.HooksDirectory, &logger),
-		hookListener:   listener,
-		Logger:         logger,
-		podRoot:        preparerConfig.PodRoot,
-		forbiddenUsers: forbiddenUsers,
-		authPolicy:     authPolicy,
-		caPath:         preparerConfig.CAPath,
+		node:         preparerConfig.NodeName,
+		store:        store,
+		hooks:        hooks.Hooks(preparerConfig.HooksDirectory, &logger),
+		hookListener: listener,
+		Logger:       logger,
+		podRoot:      preparerConfig.PodRoot,
+		authPolicy:   authPolicy,
+		caPath:       preparerConfig.CAPath,
 	}, nil
 }


### PR DESCRIPTION
The "forbidden_users" option was an extra authorization check performed after
the normal authorization policy allowed an app to be installed. It allowed
certain "run_as" usernames to be blacklisted. Since the "user" policy is
already verifying the "run_as" user, the extra check is redundant.

This commit removes the "forbidden_users" option from the config struct and all
internal uses of it. It can continue to be specified in the preparer's config
without error; it will simply have no effect.