### PR TITLE
fix integration test for health check

### DIFF
--- a/pkg/watch/health.go
+++ b/pkg/watch/health.go
@@ -117,7 +117,7 @@ func (p *PodWatch) checkHealth(node string, port int, store kp.Store) {
 		p.lastCheck, err = writeToConsul(health, store)
 		p.lastStatus = health.Status
 		if err != nil {
-			p.logger.WithField("err", err).Warningln("failed to write health data to consul")
+			p.logger.WithField("inner_err", err).Warningln("failed to write to consul")
 		}
 	}
 }
@@ -230,6 +230,7 @@ func updatePods(current []PodWatch, reality []kp.ManifestResult, logger *logging
 			newPod := PodWatch{
 				manifest:   man.Manifest,
 				shutdownCh: make(chan bool, 1),
+				logger:     logger,
 			}
 			go newPod.MonitorHealth(node, store, newPod.shutdownCh)
 			newCurrent = append(newCurrent, newPod)

--- a/pkg/watch/health_test.go
+++ b/pkg/watch/health_test.go
@@ -7,9 +7,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	. "github.com/anthonybishopric/gotcha"
 	"github.com/square/p2/pkg/health"
 	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
 )
 
@@ -32,7 +34,8 @@ func TestUpdatePods(t *testing.T) {
 
 	// ids for pods: 1, 2, test
 	// 0, 3 should have values in their shutdownCh
-	pods := updatePods(current, reality, nil, nil, "")
+	logger := logging.NewLogger(logrus.Fields{})
+	pods := updatePods(current, reality, &logger, nil, "")
 	Assert(t).AreEqual(true, <-current[0].shutdownCh, "this PodWatch should have been shutdown")
 	Assert(t).AreEqual(true, <-current[3].shutdownCh, "this PodWatch should have been shutdown")
 


### PR DESCRIPTION
Had to fix logging in the watch package. Was trying
to reference nil pointers because PodWatch's logger
field was nil.

The manifest for hello which is populated in check.go
did not have the StatusPort or StatusHTTP fields set.

Integration test for watch pkg now asserts that all
services being health checked are passing. I don't
know why I didn't do that before...