### PR TITLE
preparer: Support HTTPS

### DIFF
--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -28,6 +28,7 @@ type LogDestination struct {
 type PreparerConfig struct {
 	NodeName             string                 `yaml:"node_name"`
 	ConsulAddress        string                 `yaml:"consul_address"`
+	ConsulHttps          bool                   `yaml:"consul_https,omitempty"`
 	ConsulTokenPath      string                 `yaml:"consul_token_path,omitempty"`
 	HooksDirectory       string                 `yaml:"hooks_directory"`
 	CAPath               string                 `yaml:"ca_path,omitempty"`
@@ -204,6 +205,7 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 
 	store := kp.NewConsulStore(kp.Options{
 		Address: preparerConfig.ConsulAddress,
+		HTTPS:   preparerConfig.ConsulHttps,
 		Token:   consulToken,
 	})
 

--- a/pkg/preparer/setup_test.go
+++ b/pkg/preparer/setup_test.go
@@ -16,6 +16,7 @@ func TestLoadConfigWillMarshalYaml(t *testing.T) {
 
 	Assert(t).AreEqual("foohost", preparerConfig.NodeName, "did not read the node name correctly")
 	Assert(t).AreEqual("0.0.0.0", preparerConfig.ConsulAddress, "did not read the consul address correctly")
+	Assert(t).IsTrue(preparerConfig.ConsulHttps, "did not read consul HTTPS correctly (should be true)")
 	Assert(t).AreEqual("/etc/p2/hooks", preparerConfig.HooksDirectory, "did not read the hooks directory correctly")
 	Assert(t).AreEqual("/etc/p2.keyring", preparerConfig.Auth["keyring"], "did not read the keyring path correctly")
 	Assert(t).AreEqual(1, len(preparerConfig.ExtraLogDestinations), "should have picked up 1 log destination")

--- a/pkg/preparer/test_preparer_config.yaml
+++ b/pkg/preparer/test_preparer_config.yaml
@@ -1,6 +1,7 @@
 preparer:
   node_name: foohost
   consul_address: 0.0.0.0
+  consul_https: true
   consul_token_path: /etc/consul.token
   hooks_directory: /etc/p2/hooks
   auth:


### PR DESCRIPTION
The support is there in `kp.Options`, we just were not exposing the option in preparer config.