### PR TITLE
Add TLS configuration options for Consul connection

### DIFF
--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -40,7 +40,6 @@ type Preparer struct {
 	hookListener HookListener
 	Logger       logging.Logger
 	podRoot      string
-	caPath       string
 	authPolicy   auth.Policy
 }
 


### PR DESCRIPTION
Adds the `cert_file`, `key_file`, and `ca_file` configuration options for the
p2-preparer.  These options are used to configure the TLS transport options for
the client used to communicate with the Consul agent.