### PR TITLE
Fix servicebuilder discrepencies

### DIFF
--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -226,10 +226,10 @@ func TestWriteManifestWillReturnOldManifestTempPath(t *testing.T) {
 }
 
 func TestBuildRunitServices(t *testing.T) {
-	serviceBuilder := runit.FakeServiceBuilder()
-	serviceBuilderDir, err := ioutil.TempDir("", "servicebuilderDir")
-	Assert(t).IsNil(err, "Got an unexpected error creating a temp directory")
-	serviceBuilder.ConfigRoot = serviceBuilderDir
+	fakeSB := runit.FakeServiceBuilder()
+	defer fakeSB.Cleanup()
+	serviceBuilder := &fakeSB.ServiceBuilder
+
 	pod := Pod{
 		Id:             "testPod",
 		path:           "/data/pods/testPod",
@@ -264,10 +264,10 @@ func TestBuildRunitServices(t *testing.T) {
 }
 
 func TestUninstall(t *testing.T) {
-	serviceBuilder := runit.FakeServiceBuilder()
-	serviceBuilderDir, err := ioutil.TempDir("", "servicebuilderDir")
-	Assert(t).IsNil(err, "Got an unexpected error creating a temp directory")
-	serviceBuilder.ConfigRoot = serviceBuilderDir
+	fakeSB := runit.FakeServiceBuilder()
+	defer fakeSB.Cleanup()
+	serviceBuilder := &fakeSB.ServiceBuilder
+
 	testPodDir, err := ioutil.TempDir("", "testPodDir")
 	Assert(t).IsNil(err, "Got an unexpected error creating a temp directory")
 	pod := Pod{


### PR DESCRIPTION
Updates the servicebuild clone to fix a couple of discrepencies compared with
the canonical version:
* Didn't create the "app/log/main" directory
* Used timeout value in "run" and "log/run" scripts instead of "2"

Also makes the following improvements:
* Make it harder to accidentally remove mandatory trailing whitespace when
  using editors that remove trailing whitespaces
* Simplify some of the logic in the unit tests