### PR TITLE
Add "--show-consul-errors-unsafe" flag to show Consul errors

### DIFF
--- a/bin/p2-preparer/main.go
+++ b/bin/p2-preparer/main.go
@@ -8,6 +8,8 @@ import (
 	"syscall"
 
 	"github.com/Sirupsen/logrus"
+	"gopkg.in/alecthomas/kingpin.v1"
+
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/preparer"
 	"github.com/square/p2/pkg/version"
@@ -15,6 +17,9 @@ import (
 )
 
 func main() {
+	// Other packages define flags, and they need parsing here.
+	kingpin.Parse()
+
 	logger := logging.NewLogger(logrus.Fields{})
 	configPath := os.Getenv("CONFIG_PATH")
 	if configPath == "" {

--- a/pkg/kp/lock.go
+++ b/pkg/kp/lock.go
@@ -78,7 +78,7 @@ func (l Lock) Lock(key string) error {
 	}, nil)
 
 	if err != nil {
-		return util.Errorf("Could not acquire lock on %s", key)
+		return KVError{Op: "acquire lock", Key: key, UnsafeError: err}
 	}
 	if success {
 		return nil


### PR DESCRIPTION
We don't want to show Consul errors all the time—they can leak ACL tokens—but
when debugging a problem involving Consul, that kind of information is very
important to understanding what's going on. This commit adds a command line
flag that will enable detailed log messages, to be used only when needed.