### PR TITLE
Better error message regarding absent preparers

### DIFF
--- a/pkg/replication/replication.go
+++ b/pkg/replication/replication.go
@@ -27,7 +27,7 @@ func (r Replicator) CheckPreparers() error {
 	for _, host := range r.Nodes {
 		_, _, err := r.Store.Pod(kp.RealityPath(host, preparer.POD_ID))
 		if err != nil {
-			return util.Errorf("Host %q does not have a preparer", host)
+			return util.Errorf("Could not verify %v state on %q: %v", preparer.POD_ID, host, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Currently any error when checking for the reality store entry
for a preparer pod will indicate that no preparer is present. This
commit improves the error message so that communication errors are
more apparent.