### PR TITLE
find*Result in health package handles empty slice inputs

### DIFF
--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -78,13 +78,14 @@ func (h ConsulHealthChecker) WatchNodeService(nodename string, serviceID string,
 				kvCheckResult := consulWatchToResult(kvCheck)
 				catalogCheckResult, HEErr := findWorstResult(catalogResults)
 				if HEErr != nil {
-					errCh <- HEErr
-				}
-				best, HEErr := findBestResult([]Result{kvCheckResult, catalogCheckResult})
-				if HEErr != nil {
-					errCh <- HEErr
+					resultCh <- kvCheckResult
 				} else {
-					resultCh <- best
+					best, HEErr := findBestResult([]Result{kvCheckResult, catalogCheckResult})
+					if HEErr != nil {
+						errCh <- HEErr
+					} else {
+						resultCh <- best
+					}
 				}
 			}
 		}

--- a/pkg/watch/health.go
+++ b/pkg/watch/health.go
@@ -22,9 +22,6 @@ const POLL_KV_FOR_PODS = 3 * time.Second
 // Duration between health checks
 const HEALTHCHECK_INTERVAL = 1 * time.Second
 
-// Healthcheck TTL
-const TTL = 60 * time.Second
-
 // Contains method for watching the consul reality store to
 // track services running on a node. A manager method:
 // MonitorPodHealth tracks the reality store and manages
@@ -208,7 +205,7 @@ func (p *PodWatch) checkHealth() {
 		return
 	}
 
-	if p.updateNeeded(health, TTL) {
+	if p.updateNeeded(health, kp.TTL) {
 		p.writeToConsul(health)
 	}
 }


### PR DESCRIPTION
In some cases findWorstResult and findBestResult were being
passed empty result slices. This was cause panics. Now when
they are passed an empty slice they return a HealthEmptyError.
HealthEmptyError wraps an error and allows callers to handle
it as they see fit.

Updates health_test to reflect these changes and includes a
test for empty slices passed to the aformentioned methods.