### PR TITLE
Fix buggy unit test

### DIFF
--- a/pkg/util/stream/publisher_test.go
+++ b/pkg/util/stream/publisher_test.go
@@ -28,6 +28,7 @@ func flush(c <-chan string) int {
 // the values received and whether the channel is still open.
 func receiveAll(c <-chan string, done <-chan struct{}) (values []string, ok bool) {
 	var val string
+	values = make([]string, 0)
 	ok = true
 	for {
 		select {
@@ -247,7 +248,9 @@ func TestUnsubscribeIndependence(t *testing.T) {
 	if !reflect.DeepEqual(v1, expected) {
 		t.Error("sub1 got unexpected sequence:", v1)
 	}
-	if !(1 <= len(v2) && len(v2) <= 2) || !reflect.DeepEqual(v2, expected[:len(v2)]) {
+	// Receives are asynchronous. The only error is receiving a value whose send happened
+	// after the unsubscribe.
+	if len(v2) > 2 || !reflect.DeepEqual(v2, expected[:len(v2)]) {
 		t.Error("sub2 got unexpected sequence:", v2)
 	}
 	if !reflect.DeepEqual(v3, expected) {


### PR DESCRIPTION
The unit tests for the "stream" package failed with output:

    --- FAIL: TestUnsubscribeIndependence-2 (0.00s)
            publisher_test.go:251: sub2 got unexpected sequence: []

The unit test created a StringValuePublisher, subscribed to it. A value was
sent to the publisher, and afterwards the subscription was canceled. It was
expected that "[]" would not be received because the send of the value would
block until the subscriber had received at least the initial value.

After taking a second look at the synchronization, that behavior wasn't
accurate. Even if it was, the test was flaky because it depended on the
implementation details of the publisher rather than its high-level behavioral
contract. The only truly buggy behavior is if the subscription receives a value
that was published after the subscription was canceled.