### PR TITLE
Rework pkg/replication to be easier for clients to work with.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ install:
   - sudo mv consul /usr/bin/
 
 script:
-  - rake test
+  - rake test_all
   - integration/travis.sh

--- a/Rakefile
+++ b/Rakefile
@@ -23,9 +23,14 @@ task :build do
   e "go build -v ./..."
 end
 
-desc 'Test all projects'
+desc 'Test all projects (short only)'
 task :test => [:build] do
-  e "go test -timeout 20s ./..."
+  e "go test -short -timeout 10s ./..."
+end
+
+desc 'Test all projects'
+task :test_all => [:build] do
+  e "go test -timeout 120s ./..."
 end
 
 desc 'Update all dependencies'

--- a/bin/p2-replicate/main.go
+++ b/bin/p2-replicate/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 	"os/user"
-	"sort"
 	"time"
 
 	"github.com/square/p2/Godeps/_workspace/src/github.com/Sirupsen/logrus"
@@ -65,35 +64,13 @@ func main() {
 		log.Fatalf("%s", err)
 	}
 
-	healthResults, err := healthChecker.Service(manifest.ID())
-	if err != nil {
-		log.Fatalf("Could not get initial health results: %s", err)
-	}
-	order := health.SortOrder{
-		Nodes:  *hosts,
-		Health: healthResults,
-	}
-	sort.Sort(order)
-
-	repl := replication.Replicator{
-		Manifest: manifest,
-		Store:    store,
-		Health:   healthChecker,
-		Nodes:    *hosts, // sorted by the health.SortOrder
-		Active:   len(*hosts) - *minNodes,
-		Logger: logging.NewLogger(logrus.Fields{
-			"pod": manifest.ID(),
-		}),
-		Threshold: health.HealthState(*threshold),
-	}
-	repl.Logger.Logger.Formatter = &logrus.TextFormatter{
+	logger := logging.NewLogger(logrus.Fields{
+		"pod": manifest.ID(),
+	})
+	logger.Logger.Formatter = &logrus.TextFormatter{
 		DisableTimestamp: false,
 		FullTimestamp:    true,
 		TimestampFormat:  "15:04:05.000",
-	}
-
-	if err := repl.CheckPreparers(); err != nil {
-		log.Fatalf("Preparer check failed: %s", err)
 	}
 
 	// create a lock with a meaningful name and set up a renewal loop for it
@@ -106,43 +83,39 @@ func main() {
 		log.Fatalf("Could not retrieve user: %s", err)
 	}
 	lockMessage := fmt.Sprintf("%q from %q at %q", thisUser.Username, thisHost, time.Now())
-	lock, errCh, err := store.NewLock(lockMessage, nil)
+	repl, err := replication.NewReplicator(
+		manifest,
+		logger,
+		*hosts,
+		len(*hosts)-*minNodes,
+		store,
+		healthChecker,
+		health.HealthState(*threshold),
+		lockMessage,
+	)
 	if err != nil {
-		log.Fatalf("Could not generate lock: %s", err)
+		log.Fatalf("Could not initialize replicator: %s", err)
 	}
-	// deferring on main is not particularly useful, since os.Exit will skip
-	// the defer, so we have to manually destroy the lock at the right exit
-	// paths
-	go func() {
-		for err := range errCh {
-			// if the renewal failed, then either the lock is already dead
-			// or the consul agent cannot be reached
-			log.Fatalf("Lock could not be renewed: %s", err)
-		}
-	}()
-	if err := repl.LockHosts(lock, *overrideLock); err != nil {
-		lock.Destroy()
-		log.Fatalf("Could not lock all hosts: %s", err)
+
+	replication, errCh, err := repl.InitializeReplication(*overrideLock)
+	if err != nil {
+		log.Fatalf("Unable to initialize replication: %s", err)
 	}
 
 	// auto-drain this channel
-	errs := make(chan error)
 	go func() {
-		for range errs {
+		for range errCh {
 		}
 	}()
 
-	quitch := make(chan struct{})
 	go func() {
 		// clear lock immediately on ctrl-C
 		signals := make(chan os.Signal, 1)
 		signal.Notify(signals, os.Interrupt)
 		<-signals
-		close(quitch)
-		lock.Destroy()
+		replication.Cancel()
 		os.Exit(1)
 	}()
 
-	repl.Enact(errs, quitch)
-	lock.Destroy()
+	replication.Enact()
 }

--- a/pkg/kp/fixtures_test.go
+++ b/pkg/kp/fixtures_test.go
@@ -17,6 +17,10 @@ type ConsulTestFixture struct {
 
 // Create a new test fixture that spins up a local Consul server.
 func NewConsulTestFixture(t *testing.T) *ConsulTestFixture {
+	if testing.Short() {
+		t.Skip("skipping test dependent on consul because of short mode")
+	}
+
 	// testutil.NewTestServerConfig will skip the test if "consul" isn't in the system path.
 	// We'd rather the test fail.
 	defer func() {

--- a/pkg/replication/common_test_setup.go
+++ b/pkg/replication/common_test_setup.go
@@ -1,0 +1,201 @@
+package replication
+
+import (
+	"fmt"
+	"io/ioutil"
+	"sync/atomic"
+	"testing"
+
+	"github.com/square/p2/pkg/health"
+	"github.com/square/p2/pkg/health/checker"
+	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/pods"
+
+	"github.com/square/p2/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/testutil"
+)
+
+var testNodes = []string{"node1", "node2"}
+
+const (
+	testLockMessage      = "lock is held by replicator_test.go"
+	testPodId            = "test_pod"
+	testPreparerManifest = `id: p2-preparer`
+)
+
+func testReplicatorAndServer(t *testing.T) (Replicator, kp.Store, *testutil.TestServer) {
+	active := 1
+	store, server := makeStore(t)
+
+	healthChecker := happyHealthChecker()
+	threshold := health.Passing
+	replicator, err := NewReplicator(
+		basicManifest(),
+		basicLogger(),
+		testNodes,
+		active,
+		store,
+		healthChecker,
+		threshold,
+		testLockMessage,
+	)
+
+	if err != nil {
+		t.Fatalf("Unable to initialize replicator: %s", err)
+	}
+	return replicator, store, server
+}
+
+func makeStore(t *testing.T) (kp.Store, *testutil.TestServer) {
+	if testing.Short() {
+		t.Skip("skipping test dependendent on consul because of short mode")
+	}
+
+	// testutil.NewTestServerConfig will skip the test if "consul" isn't in the system path.
+	// We'd rather the test fail.
+	defer func() {
+		if t.Skipped() {
+			t.Fatalf("test skipped by testutil package")
+		}
+	}()
+
+	// Create server
+	server := testutil.NewTestServerConfig(t, func(c *testutil.TestServerConfig) {
+		// consul output in test output is noisy
+		c.Stdout = ioutil.Discard
+		c.Stderr = ioutil.Discard
+
+		// If ports are left to their defaults, this test conflicts
+		// with the test consul servers in pkg/kp
+		var offset uint64
+		idx := int(atomic.AddUint64(&offset, 1))
+		c.Ports = &testutil.TestPortConfig{
+			DNS:     26000 + idx,
+			HTTP:    27000 + idx,
+			RPC:     28000 + idx,
+			SerfLan: 29000 + idx,
+			SerfWan: 30000 + idx,
+			Server:  31000 + idx,
+		}
+	})
+
+	store := kp.NewConsulStore(kp.Options{
+		Address: server.HTTPAddr,
+	})
+	return store, server
+}
+
+// Adds preparer manifest to reality tree to fool replication library into
+// thinking it is installed on the test nodes
+func setupPreparers(server *testutil.TestServer) {
+	for _, node := range testNodes {
+		key := fmt.Sprintf("reality/%s/p2-preparer", node)
+		server.SetKV(key, []byte(testPreparerManifest))
+	}
+}
+
+type alwaysHappyHealthChecker struct {
+}
+
+func (h alwaysHappyHealthChecker) WatchNodeService(
+	nodename string,
+	serviceID string,
+	resultCh chan<- health.Result,
+	errCh chan<- error,
+	quitCh <-chan struct{},
+) {
+	happyResult := health.Result{
+		ID:     testPodId,
+		Status: health.Passing,
+	}
+	for {
+		select {
+		case <-quitCh:
+			return
+		case resultCh <- happyResult:
+		}
+	}
+}
+
+func (h alwaysHappyHealthChecker) Service(serviceID string) (map[string]health.Result, error) {
+	results := make(map[string]health.Result)
+	for _, node := range testNodes {
+		results[node] = health.Result{
+			ID:     testPodId,
+			Status: health.Passing,
+		}
+	}
+	return results, nil
+}
+
+// creates an implementation of checker.ConsulHealthChecker that always reports
+// satisfied health checks for testing purposes
+func happyHealthChecker() checker.ConsulHealthChecker {
+	return alwaysHappyHealthChecker{}
+}
+
+type channelBasedHealthChecker struct {
+	// maps node name to a channel on which fake results can be provided
+	resultsChans map[string]chan health.Result
+
+	t *testing.T
+}
+
+// Pass along whatever results come through c.resultsChan
+func (c channelBasedHealthChecker) WatchNodeService(
+	nodename string,
+	serviceID string,
+	resultCh chan<- health.Result,
+	errCh chan<- error,
+	quitCh <-chan struct{},
+) {
+	inputCh, ok := c.resultsChans[nodename]
+	if ok {
+		for result := range inputCh {
+			resultCh <- result
+		}
+	} else {
+		c.t.Fatalf("No results channel configured for %s", nodename)
+	}
+}
+
+// This is used by the initial health query in the replication library for
+// sorting purposes, just return all healthy
+func (c channelBasedHealthChecker) Service(serviceID string) (map[string]health.Result, error) {
+	results := make(map[string]health.Result)
+	for _, node := range testNodes {
+		results[node] = health.Result{
+			ID:     testPodId,
+			Status: health.Passing,
+		}
+	}
+	return results, nil
+}
+
+// returns an implementation of checker.ConsulHealthChecker that will provide
+// results based on what is passed on the returned  chanel
+func channelHealthChecker(nodes []string, t *testing.T) (checker.ConsulHealthChecker, map[string]chan health.Result) {
+	resultsChans := make(map[string]chan health.Result)
+	for _, node := range nodes {
+		resultsChans[node] = make(chan health.Result)
+	}
+	return channelBasedHealthChecker{
+		resultsChans: resultsChans,
+		t:            t,
+	}, resultsChans
+}
+
+func basicLogger() logging.Logger {
+	return logging.NewLogger(
+		logrus.Fields{
+			"pod": "testpod",
+		},
+	)
+}
+
+func basicManifest() pods.Manifest {
+	builder := pods.NewManifestBuilder()
+	builder.SetID(testPodId)
+	return builder.GetManifest()
+}

--- a/pkg/replication/replication.go
+++ b/pkg/replication/replication.go
@@ -1,61 +1,99 @@
 package replication
 
 import (
+	"sort"
 	"time"
 
-	"github.com/square/p2/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	"github.com/square/p2/pkg/health"
 	"github.com/square/p2/pkg/health/checker"
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
-	"github.com/square/p2/pkg/preparer"
 	"github.com/square/p2/pkg/util"
+
+	"github.com/square/p2/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
 
-type Replicator struct {
-	Manifest  pods.Manifest // the manifest to replicate
-	Logger    logging.Logger
-	Nodes     []string
-	Active    int // maximum number of nodes to update concurrently
-	Store     kp.Store
-	Health    checker.ConsulHealthChecker
-	Threshold health.HealthState // minimum state to treat as "healthy"
+type replicationError struct {
+	err error
+	// Indicates if the error halted replication or if it is recoverable
+	isFatal bool
 }
 
-// Checks that the preparer is running on every host being deployed to.
-func (r Replicator) CheckPreparers() error {
-	for _, host := range r.Nodes {
-		_, _, err := r.Store.Pod(kp.RealityPath(host, preparer.POD_ID))
-		if err != nil {
-			return util.Errorf("Could not verify %v state on %q: %v", preparer.POD_ID, host, err)
-		}
+// Assert that replicationError implements the error interface
+var _ error = replicationError{}
+
+func (r replicationError) Error() string {
+	return r.err.Error()
+}
+
+func IsFatalError(err error) bool {
+	if replErr, ok := err.(replicationError); ok {
+		return replErr.isFatal
 	}
-	return nil
+	return false
+}
+
+type Replication interface {
+	// Proceed with the prescribed replication
+	Enact()
+
+	// Cancel the prescribed replication
+	Cancel()
+}
+
+// A replication contains the information required to do a single replication (deploy).
+type replication struct {
+	active    int
+	nodes     []string
+	store     kp.Store
+	manifest  pods.Manifest
+	health    checker.ConsulHealthChecker
+	threshold health.HealthState // minimum state to treat as "healthy"
+	logger    logging.Logger
+
+	// communicates errors back to the caller, such as an error renewing
+	// the deploy lock
+	errCh chan<- error
+	// signals replication cancellation by the caller
+	replicationCancelledCh chan struct{}
+	// signals any supplementary goroutines to exit once the
+	// replication has completed successfully
+	replicationDoneCh chan struct{}
+	// Used to cancel replication due to a lock renewal failure or a
+	// cancellation by the caller
+	quitCh chan struct{}
 }
 
 // Attempts to claim a lock on every host being deployed to.
 // if overrideLock is true, will destroy any session holding any of the keys we
 // wish to lock
-func (r Replicator) LockHosts(lock kp.Lock, overrideLock bool) error {
-	for _, host := range r.Nodes {
-		lockPath := kp.LockPath(host, r.Manifest.ID())
+func (r replication) lockHosts(overrideLock bool, lockMessage string) error {
+	lock, renewalErrCh, err := r.store.NewLock(lockMessage, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, host := range r.nodes {
+		lockPath := kp.LockPath(host, r.manifest.ID())
 		err := r.lock(lock, lockPath, overrideLock)
 
 		if err != nil {
 			return err
 		}
 	}
+	go r.handleRenewalErrors(lock, renewalErrCh)
+
 	return nil
 }
 
 // Attempts to claim a lock. If the overrideLock is set, any existing lock holder
 // will be destroyed and one more attempt will be made to acquire the lock
-func (r Replicator) lock(lock kp.Lock, lockPath string, overrideLock bool) error {
+func (r replication) lock(lock kp.Lock, lockPath string, overrideLock bool) error {
 	err := lock.Lock(lockPath)
 
 	if _, ok := err.(kp.AlreadyLockedError); ok {
-		holder, id, err := r.Store.LockHolder(lockPath)
+		holder, id, err := r.store.LockHolder(lockPath)
 		if err != nil {
 			return util.Errorf("Lock already held for %q, could not determine holder due to error: %s", lockPath, err)
 		} else if holder == "" {
@@ -66,7 +104,7 @@ func (r Replicator) lock(lock kp.Lock, lockPath string, overrideLock bool) error
 			// limited time
 			return util.Errorf("Lock for %q is blocked due to delay by previous holder", lockPath)
 		} else if overrideLock {
-			err = r.Store.DestroyLockHolder(id)
+			err = r.store.DestroyLockHolder(id)
 			if err != nil {
 				return util.Errorf("Unable to destroy the current lock holder (%s) for %q: %s", holder, lockPath, err)
 			}
@@ -85,7 +123,32 @@ func (r Replicator) lock(lock kp.Lock, lockPath string, overrideLock bool) error
 // Execute the replication.
 // note: error management could use some improvement, errors coming out of
 // updateOne need to be scoped to the node that they came from
-func (r Replicator) Enact(errCh chan<- error, quitCh <-chan struct{}) {
+func (r replication) Enact() {
+	defer close(r.replicationDoneCh)
+
+	// Sort nodes from least healthy to most healthy to maximize overall
+	// cluster health
+	healthResults, err := r.health.Service(r.manifest.ID())
+	if err != nil {
+		err = replicationError{
+			err:     err,
+			isFatal: true,
+		}
+		select {
+		case r.errCh <- err:
+		case <-r.quitCh:
+		}
+		return
+	}
+
+	// Sort nodes by health from worst to best to maximize overall
+	// cluster health
+	order := health.SortOrder{
+		Nodes:  r.nodes,
+		Health: healthResults,
+	}
+	sort.Sort(order)
+
 	nodeQueue := make(chan string)
 	done := make(chan string)
 	innerQuit := make(chan struct{})
@@ -94,10 +157,10 @@ func (r Replicator) Enact(errCh chan<- error, quitCh <-chan struct{}) {
 	defer close(innerQuit)
 
 	// this loop multiplexes the node queue across some goroutines
-	for i := 0; i < r.Active; i++ {
+	for i := 0; i < r.active; i++ {
 		go func() {
 			for node := range nodeQueue {
-				r.updateOne(node, done, errCh, innerQuit)
+				r.updateOne(node, done, innerQuit)
 			}
 		}()
 	}
@@ -105,46 +168,74 @@ func (r Replicator) Enact(errCh chan<- error, quitCh <-chan struct{}) {
 	// this goroutine populates the node queue
 	go func() {
 		defer close(nodeQueue)
-		for _, node := range r.Nodes {
+		for _, node := range r.nodes {
 			select {
 			case nodeQueue <- node:
 				// a worker will consume it
-			case <-innerQuit:
+			case <-r.quitCh:
 				return
 			}
 		}
 	}()
 
 	// the main blocking loop processes replies from workers
-	for doneIndex := 0; doneIndex < len(r.Nodes); {
+	for doneIndex := 0; doneIndex < len(r.nodes); {
 		select {
 		case <-done:
 			doneIndex++
-		case <-quitCh:
+		case <-r.quitCh:
 			return
 		}
 	}
 }
 
+// Cancels all goroutines (e.g. replication and lock renewal)
+func (r replication) Cancel() {
+	close(r.replicationCancelledCh)
+}
+
+// Listen for errors in lock renewal. If the lock can't be renewed, we need to
+// 1) stop replication and 2) communicate the error up a level
+// If replication finishes, destroy the lock
+func (r replication) handleRenewalErrors(lock kp.Lock, renewalErrCh chan error) {
+	defer func() {
+		close(r.quitCh)
+		close(r.errCh)
+		lock.Destroy()
+	}()
+
+	select {
+	case <-r.replicationDoneCh:
+	case <-r.replicationCancelledCh:
+	case err := <-renewalErrCh:
+		// communicate the error to the caller.
+		r.errCh <- replicationError{
+			err:     err,
+			isFatal: true,
+		}
+		return
+	}
+}
+
 // note: logging should be delegated somehow
-func (r Replicator) updateOne(node string, done chan<- string, errCh chan<- error, quitCh <-chan struct{}) {
-	targetSHA, _ := r.Manifest.SHA()
-	nodeLogger := r.Logger.SubLogger(logrus.Fields{"node": node})
+func (r replication) updateOne(node string, done chan<- string, quitCh <-chan struct{}) {
+	targetSHA, _ := r.manifest.SHA()
+	nodeLogger := r.logger.SubLogger(logrus.Fields{"node": node})
 	nodeLogger.WithField("sha", targetSHA).Infoln("Updating node")
 
-	_, err := r.Store.SetPod(kp.IntentPath(node, r.Manifest.ID()), r.Manifest)
+	_, err := r.store.SetPod(kp.IntentPath(node, r.manifest.ID()), r.manifest)
 	for err != nil {
 		nodeLogger.WithError(err).Errorln("Could not write intent store")
-		errCh <- err
+		r.errCh <- err
 		time.Sleep(1 * time.Second)
-		_, err = r.Store.SetPod(kp.IntentPath(node, r.Manifest.ID()), r.Manifest)
+		_, err = r.store.SetPod(kp.IntentPath(node, r.manifest.ID()), r.manifest)
 	}
 
 	realityResults := make(chan []kp.ManifestResult)
 	realityErr := make(chan error)
 	realityQuit := make(chan struct{})
 	defer close(realityQuit)
-	go r.Store.WatchPods(kp.RealityPath(node, r.Manifest.ID()), realityQuit, realityErr, realityResults)
+	go r.store.WatchPods(kp.RealityPath(node, r.manifest.ID()), realityQuit, realityErr, realityResults)
 REALITY_LOOP:
 	for {
 		select {
@@ -152,12 +243,15 @@ REALITY_LOOP:
 			return
 		case err := <-realityErr:
 			nodeLogger.WithError(err).Errorln("Could not read reality store")
-			errCh <- err
+			select {
+			case r.errCh <- err:
+			case <-quitCh:
+			}
 		case mResult := <-realityResults:
 			if len(mResult) != 1 {
 				msg := "Got unexpected number of results when watching reality"
 				nodeLogger.WithField("n", len(mResult)).Errorln(msg)
-				errCh <- util.Errorf(msg)
+				r.errCh <- util.Errorf(msg)
 			} else {
 				receivedSHA, _ := mResult[0].Manifest.SHA()
 				if receivedSHA == targetSHA {
@@ -174,7 +268,7 @@ REALITY_LOOP:
 	healthErr := make(chan error)
 	healthQuit := make(chan struct{})
 	defer close(healthQuit)
-	go r.Health.WatchNodeService(node, r.Manifest.ID(), healthResults, healthErr, healthQuit)
+	go r.health.WatchNodeService(node, r.manifest.ID(), healthResults, healthErr, healthQuit)
 HEALTH_LOOP:
 	for {
 		select {
@@ -182,14 +276,17 @@ HEALTH_LOOP:
 			return
 		case err := <-healthErr:
 			nodeLogger.WithError(err).Errorln("Could not read health check")
-			errCh <- err
+			select {
+			case r.errCh <- err:
+			case <-quitCh:
+			}
 		case res := <-healthResults:
 			id := res.ID
 			status := res.Status
 			// treat an empty threshold as "passing"
 			threshold := health.Passing
-			if r.Threshold != "" {
-				threshold = r.Threshold
+			if r.threshold != "" {
+				threshold = r.threshold
 			}
 			// is this status less than the threshold?
 			if health.Compare(status, threshold) < 0 {
@@ -199,7 +296,7 @@ HEALTH_LOOP:
 			}
 		}
 	}
-	r.Logger.WithField("node", node).Infoln("Node is current and healthy")
+	r.logger.WithField("node", node).Infoln("Node is current and healthy")
 
 	select {
 	case done <- node:

--- a/pkg/replication/replication_test.go
+++ b/pkg/replication/replication_test.go
@@ -1,0 +1,444 @@
+package replication
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/square/p2/pkg/health"
+	"github.com/square/p2/pkg/kp"
+
+	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/testutil"
+)
+
+func TestEnact(t *testing.T) {
+	replicator, _, server := testReplicatorAndServer(t)
+	defer server.Stop()
+
+	// Make the kv store look like preparer is installed on test nodes
+	setupPreparers(server)
+
+	replication, errCh, err := replicator.InitializeReplication(false)
+	if err != nil {
+		t.Fatalf("Unable to initialize replication: %s", err)
+	}
+
+	doneCh := make(chan struct{})
+
+	failIfErrors(errCh, doneCh, t)
+	imitatePreparers(server, doneCh)
+
+	go func() {
+		replication.Enact()
+		close(doneCh)
+	}()
+	select {
+	case <-time.After(10 * time.Second):
+		t.Fatalf("Replication did not finish within timeout period")
+	case <-doneCh:
+	}
+}
+
+func TestWaitsForHealthy(t *testing.T) {
+	active := 1
+	store, server := makeStore(t)
+	defer server.Stop()
+
+	healthChecker, resultsCh := channelHealthChecker(testNodes, t)
+	threshold := health.Passing
+	replicator, err := NewReplicator(
+		basicManifest(),
+		basicLogger(),
+		testNodes,
+		active,
+		store,
+		healthChecker,
+		threshold,
+		testLockMessage,
+	)
+	if err != nil {
+		t.Fatalf("Unable to initialize replicator: %s", err)
+	}
+
+	// Make the kv store look like preparer is installed on test nodes
+	setupPreparers(server)
+
+	replication, errCh, err := replicator.InitializeReplication(false)
+	if err != nil {
+		t.Fatalf("Unable to initialize replication: %s", err)
+	}
+
+	doneCh := make(chan struct{})
+
+	failIfErrors(errCh, doneCh, t)
+	imitatePreparers(server, doneCh)
+
+	// If replication finishes before we mark all nodes as healthy, the
+	// test fails. This bool tracks whether replication ending is okay
+	okayToFinish := false
+
+	go func() {
+		replication.Enact()
+		if !okayToFinish {
+			t.Fatalf("Replication finished before all nodes were healthy")
+		}
+		close(doneCh)
+	}()
+
+	// Mark first node as unhealthy and the remainder as healthy
+	for i, node := range testNodes {
+		if i == 0 {
+			go func(node string) {
+				for x := 0; x < 5; x++ {
+					resultsCh[node] <- health.Result{
+						ID:     testPodId,
+						Status: health.Critical,
+					}
+				}
+
+				okayToFinish = true
+				// Now report as healthy, which means it's okay for replication to end
+				resultsCh[node] <- health.Result{
+					ID:     testPodId,
+					Status: health.Passing,
+				}
+				close(resultsCh[node])
+			}(node)
+		} else {
+			// Mark the rest of the nodes as healthy constantly and
+			// quit once replication is over
+			go func(node string) {
+				for {
+					select {
+					case resultsCh[node] <- health.Result{
+						ID:     testPodId,
+						Status: health.Passing,
+					}:
+					case <-doneCh:
+						close(resultsCh[node])
+						return
+					}
+				}
+			}(node)
+		}
+	}
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Replication took longer than test timeout")
+	case <-doneCh:
+	}
+}
+
+func TestReplicationStopsIfCanceled(t *testing.T) {
+	active := 1
+	store, server := makeStore(t)
+	defer server.Stop()
+
+	healthChecker, resultsCh := channelHealthChecker(testNodes, t)
+	threshold := health.Passing
+	manifest := basicManifest()
+	replicator, err := NewReplicator(
+		manifest,
+		basicLogger(),
+		testNodes,
+		active,
+		store,
+		healthChecker,
+		threshold,
+		testLockMessage,
+	)
+	if err != nil {
+		t.Fatalf("Unable to initialize replicator: %s", err)
+	}
+
+	// Make the kv store look like preparer is installed on test nodes
+	setupPreparers(server)
+
+	replication, errCh, err := replicator.InitializeReplication(false)
+	if err != nil {
+		t.Fatalf("Unable to initialize replication: %s", err)
+	}
+
+	doneCh := make(chan struct{})
+
+	failIfErrors(errCh, doneCh, t)
+	imitatePreparers(server, doneCh)
+
+	// If replication finishes before we cancel it, test fails. This bool
+	// tracks whether replication ending is okay
+	okayToFinish := false
+	go func() {
+		replication.Enact()
+		if !okayToFinish {
+			t.Fatalf("Replication finished before cancellation occurred")
+		}
+	}()
+
+	// Report unhealthy for a few iterations; replication should not
+	// succeed successfully
+	healthFedChannel := make(chan struct{})
+	for _, node := range testNodes {
+		go func(node string) {
+			for i := 0; i < 5; i++ {
+				select {
+				case resultsCh[node] <- health.Result{
+					ID:     testPodId,
+					Status: health.Critical,
+				}:
+				case <-doneCh:
+					return
+				}
+			}
+			close(healthFedChannel)
+		}(node)
+	}
+	select {
+	case <-healthFedChannel:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Test timed out feeding health values, replication probably deadlocked")
+	}
+	okayToFinish = true
+	replication.Cancel()
+	close(doneCh)
+
+	// One node should have been updated because active == 1, the other
+	// should not have been because health never passed
+	realityBytes := server.GetKV(fmt.Sprintf("reality/%s/%s", testNodes[0], testPodId))
+	manifestBytes, err := manifest.Marshal()
+	if err != nil {
+		t.Fatalf("Unable to get bytes from manifest: %s", err)
+	}
+
+	if !bytes.Equal(realityBytes, manifestBytes) {
+		t.Fatalf("Expected reality for %s to be %s: was %s", testNodes[0], string(manifestBytes), string(realityBytes))
+	}
+
+	realityBytes = server.GetKV(fmt.Sprintf("reality/%s/%s", testNodes[1], testPodId))
+	if bytes.Equal(realityBytes, manifestBytes) {
+		t.Fatalf("The second node shouldn't have been deployed to but it was")
+	}
+}
+
+func TestStopsIfLockDestroyed(t *testing.T) {
+	active := 1
+	store, server := makeStore(t)
+	defer server.Stop()
+
+	healthChecker, resultsCh := channelHealthChecker(testNodes, t)
+	threshold := health.Passing
+	manifest := basicManifest()
+
+	// Make the kv store look like preparer is installed on test nodes
+	setupPreparers(server)
+
+	// Create the replication manually for this test so we can trigger lock
+	// renewals on a faster interval (to keep test short)
+	errCh := make(chan error)
+	replication := &replication{
+		active:    active,
+		nodes:     testNodes,
+		store:     store,
+		manifest:  manifest,
+		health:    healthChecker,
+		threshold: threshold,
+		logger:    basicLogger(),
+		errCh:     errCh,
+		replicationCancelledCh: make(chan struct{}),
+		replicationDoneCh:      make(chan struct{}),
+		quitCh:                 make(chan struct{}),
+	}
+
+	triggerRenewalCh := make(chan time.Time)
+	lock, renewalErrCh, err := store.NewLock(testLockMessage, triggerRenewalCh)
+	if err != nil {
+		t.Fatalf("Unable to create initial replication lock: %s", err)
+	}
+
+	for _, host := range testNodes {
+		lockPath := kp.LockPath(host, manifest.ID())
+		err := replication.lock(lock, lockPath, false)
+
+		if err != nil {
+			t.Fatalf("Unable to perform initial replication lock: %s", err)
+		}
+	}
+	go replication.handleRenewalErrors(lock, renewalErrCh)
+
+	doneCh := make(chan struct{})
+
+	go func() {
+		select {
+		case err := <-errCh:
+			if err == nil || !IsFatalError(err) {
+				t.Fatalf("Should have seen a fatal lock renewal error before replication finished")
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Did not get expected lock renewal error within timeout")
+		}
+	}()
+	failIfErrors(errCh, doneCh, t)
+	imitatePreparers(server, doneCh)
+
+	go func() {
+		replication.Enact()
+		close(doneCh)
+	}()
+
+	// Report healthy for one node, and unhealthy for the rest so
+	// replication cannot finish without interruption
+	for i, node := range testNodes {
+		if i == 0 {
+			go func(node string) {
+				for {
+					select {
+					case resultsCh[node] <- health.Result{
+						ID:     testPodId,
+						Status: health.Passing,
+					}:
+					case <-doneCh:
+						return
+					}
+					time.Sleep(500 * time.Millisecond)
+				}
+			}(node)
+		} else {
+			go func(node string) {
+				for {
+					select {
+					case resultsCh[node] <- health.Result{
+						ID:     testPodId,
+						Status: health.Critical,
+					}:
+					case <-doneCh:
+						return
+					}
+					time.Sleep(500 * time.Millisecond)
+				}
+			}(node)
+		}
+	}
+
+	// Wait for the first node to be deployed
+	firstNodeDeployed := make(chan struct{})
+	manifestBytes, err := manifest.Marshal()
+	if err != nil {
+		t.Fatalf("Unable to get bytes from manifest: %s", err)
+	}
+	go func() {
+		realityKey := fmt.Sprintf("reality/%s/%s", testNodes[0], testPodId)
+		for range time.Tick(10 * time.Millisecond) {
+			if bytes.Equal(server.GetKV(realityKey), manifestBytes) {
+				close(firstNodeDeployed)
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Took too long for first node to be deployed")
+	case <-firstNodeDeployed:
+	}
+
+	// Trigger some lock renewals, confirm that replication is still going (doneCh not closed)
+	for i := 0; i < 3; i++ {
+		select {
+		case triggerRenewalCh <- time.Now():
+		case <-doneCh:
+			t.Fatalf("Replication ended prematurely (lock couldn't be renewed but wasn't destroyed yet)")
+		case <-time.After(1 * time.Second):
+			t.Fatalf("Test timed out triggering a lock renewal")
+		}
+	}
+
+	// Destroy lock holder so the next renewal will fail
+	lockPath := kp.LockPath(testNodes[0], manifest.ID())
+	_, id, err := store.LockHolder(lockPath)
+	if err != nil {
+		t.Fatalf("Unable to determine lock holder in order to destroy the lock: %s", err)
+	}
+
+	err = store.DestroyLockHolder(id)
+	if err != nil {
+		t.Fatalf("Unable to destroy lock holder")
+	}
+
+	// Trigger one more renewal which should cause replication to stop
+	select {
+	case triggerRenewalCh <- time.Now():
+	case <-time.After(1 * time.Second):
+		t.Fatalf("Test timed out triggering a lock renewal")
+	case <-doneCh:
+		t.Fatalf("Replication ended prematurely")
+	}
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Took too long for replication to end after lock cancellation")
+	case <-doneCh:
+	}
+
+	// One node should have been updated because active == 1, the other
+	// should not have been because health never passed
+	realityBytes := server.GetKV(fmt.Sprintf("reality/%s/%s", testNodes[0], testPodId))
+
+	if !bytes.Equal(realityBytes, manifestBytes) {
+		t.Fatalf("Expected reality for %s to be %s: was %s", testNodes[0], string(manifestBytes), string(realityBytes))
+	}
+
+	realityBytes = server.GetKV(fmt.Sprintf("reality/%s/%s", testNodes[1], testPodId))
+	if bytes.Equal(realityBytes, manifestBytes) {
+		t.Fatalf("The second node shouldn't have been deployed to but it was")
+	}
+}
+
+// Imitate preparers by copying data from /intent tree to /reality tree
+// to simulate deployment
+func imitatePreparers(server *testutil.TestServer, quitCh <-chan struct{}) {
+	// testutil.Server calls t.Fatalf() if a key doesn't exist, so put some
+	// dummy data into /intent and /reality for the test pod so we don't
+	// accidentally fail tests by merely testing a key
+	dummyManifest := []byte("id: wrong_manifest")
+	for _, node := range testNodes {
+		intentKey := fmt.Sprintf("intent/%s/%s", node, testPodId)
+		server.SetKV(intentKey, dummyManifest)
+		realityKey := fmt.Sprintf("reality/%s/%s", node, testPodId)
+		server.SetKV(realityKey, dummyManifest)
+	}
+
+	// Now do the actual copies
+	go func() {
+		for {
+			select {
+			case <-quitCh:
+				return
+			default:
+				for _, node := range testNodes {
+					intentKey := fmt.Sprintf("intent/%s/%s", node, testPodId)
+					realityKey := fmt.Sprintf("reality/%s/%s", node, testPodId)
+					intentBytes := server.GetKV(intentKey)
+					if !bytes.Equal(intentBytes, dummyManifest) {
+						server.SetKV(realityKey, intentBytes)
+					}
+				}
+			}
+		}
+	}()
+}
+
+func failIfErrors(errCh <-chan error, quitCh <-chan struct{}, t *testing.T) {
+	go func() {
+		for {
+			select {
+			case <-quitCh:
+				return
+			case err := <-errCh:
+				if err != nil {
+					t.Fatalf("Unexpected error during replication: %s", err)
+				}
+			}
+		}
+	}()
+}

--- a/pkg/replication/replicator.go
+++ b/pkg/replication/replicator.go
@@ -1,0 +1,95 @@
+package replication
+
+import (
+	"github.com/square/p2/pkg/health"
+	"github.com/square/p2/pkg/health/checker"
+	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/preparer"
+	"github.com/square/p2/pkg/util"
+)
+
+type Replicator interface {
+	InitializeReplication(overrideLock bool) (Replication, chan error, error)
+}
+
+// Replicator creates replications
+type replicator struct {
+	manifest  pods.Manifest // the manifest to replicate
+	logger    logging.Logger
+	nodes     []string
+	active    int // maximum number of nodes to update concurrently
+	store     kp.Store
+	health    checker.ConsulHealthChecker
+	threshold health.HealthState // minimum state to treat as "healthy"
+
+	lockMessage string
+}
+
+func NewReplicator(
+	manifest pods.Manifest,
+	logger logging.Logger,
+	nodes []string,
+	active int,
+	store kp.Store,
+	health checker.ConsulHealthChecker,
+	threshold health.HealthState,
+	lockMessage string,
+) (Replicator, error) {
+	if active < 1 {
+		return replicator{}, util.Errorf("Active must be >= 1, was %d", active)
+	}
+	return replicator{
+		manifest:    manifest,
+		logger:      logger,
+		nodes:       nodes,
+		active:      active,
+		store:       store,
+		health:      health,
+		threshold:   threshold,
+		lockMessage: lockMessage,
+	}, nil
+}
+
+// Initializes a replication after performing some initial validation.
+// Validation errors are returned immediately, and asynchronous errors are
+// passed on the returned channel
+func (r replicator) InitializeReplication(overrideLock bool) (Replication, chan error, error) {
+	err := r.checkPreparers()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	errCh := make(chan error)
+	replication := &replication{
+		active:    r.active,
+		nodes:     r.nodes,
+		store:     r.store,
+		manifest:  r.manifest,
+		health:    r.health,
+		threshold: r.threshold,
+		logger:    r.logger,
+		errCh:     errCh,
+		replicationCancelledCh: make(chan struct{}),
+		replicationDoneCh:      make(chan struct{}),
+		quitCh:                 make(chan struct{}),
+	}
+
+	err = replication.lockHosts(overrideLock, r.lockMessage)
+	if err != nil {
+		return nil, errCh, err
+	}
+	return replication, errCh, nil
+}
+
+// Checks that the preparer is running on every host being deployed to.
+func (r replicator) checkPreparers() error {
+	for _, host := range r.nodes {
+		_, _, err := r.store.Pod(kp.RealityPath(host, preparer.POD_ID))
+		if err != nil {
+			return util.Errorf("Could not verify %v state on %q: %v", preparer.POD_ID, host, err)
+		}
+	}
+	return nil
+}

--- a/pkg/replication/replicator_test.go
+++ b/pkg/replication/replicator_test.go
@@ -1,0 +1,129 @@
+package replication
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/preparer"
+)
+
+func TestInitializeReplication(t *testing.T) {
+	replicator, store, server := testReplicatorAndServer(t)
+	defer server.Stop()
+
+	// Make the kv store look like preparer is installed on test nodes
+	setupPreparers(server)
+
+	// err being nil ensures that checking preparers and locking the hosts
+	// succeeded
+	replication, _, err := replicator.InitializeReplication(false)
+	if err != nil {
+		t.Fatalf("Error initializing replication: %s", err)
+	}
+	defer replication.Cancel()
+
+	// Confirm that the appropriate kv keys have been locked
+	for _, node := range testNodes {
+		lockPath := kp.LockPath(node, testPodId)
+		lockHolder, _, err := store.LockHolder(lockPath)
+		if err != nil {
+			t.Fatalf("Unexpected error checking for lock holder: %s", err)
+		}
+
+		if lockHolder != testLockMessage {
+			t.Errorf("Expected lock holder for key '%s' to be '%s', was '%s'", lockPath, testLockMessage, lockHolder)
+		}
+	}
+}
+
+func TestInitializeReplicationFailsIfNoPreparers(t *testing.T) {
+	replicator, _, server := testReplicatorAndServer(t)
+	defer server.Stop()
+
+	// We expect an error here because the reality keys for the preparer
+	// have no data, which in production would mean that the preparer is
+	// not installed on the hosts being replicated to
+	_, _, err := replicator.InitializeReplication(false)
+	if err == nil {
+		t.Fatalf("Expected error due to preparer not existing in reality, but no error occurred")
+	}
+
+	matched, err := regexp.MatchString(fmt.Sprintf("verify %s state", preparer.POD_ID), err.Error())
+	if err != nil {
+		t.Fatalf("Unable to compare error message to expected string")
+	}
+
+	if !matched {
+		t.Fatalf("Expected error message to be related to preparer state, but was %s", err.Error())
+	}
+}
+
+func TestInitializeReplicationFailsIfLockExists(t *testing.T) {
+	replicator, store, server := testReplicatorAndServer(t)
+	defer server.Stop()
+
+	// This makes it look like the preparers are installed on the hosts
+	// we're deploying to
+	for _, node := range testNodes {
+		key := fmt.Sprintf("reality/%s/p2-preparer", node)
+		server.SetKV(key, []byte(testPreparerManifest))
+	}
+
+	// Claim a lock on a host and verify that InitializeReplication fails
+	lock, _, err := store.NewLock("competing lock", nil)
+	if err != nil {
+		t.Fatalf("Unable to set up competing lock: %s", err)
+	}
+	defer lock.Destroy()
+	lockPath := kp.LockPath(testNodes[0], testPodId)
+	err = lock.Lock(lockPath)
+	if err != nil {
+		t.Fatalf("Unable to set up competing lock: %s", err)
+	}
+
+	_, _, err = replicator.InitializeReplication(false)
+	if err == nil {
+		t.Fatalf("Expected error due to competing lock, but no error occurred")
+	}
+
+	matched, err := regexp.MatchString("already held", err.Error())
+	if err != nil {
+		t.Fatalf("Unable to compare error message to expected string")
+	}
+
+	if !matched {
+		t.Fatalf("Expected error message to be related to a lock already being held, but was %s", err.Error())
+	}
+}
+
+func TestInitializeReplicationCanOverrideLocks(t *testing.T) {
+	replicator, store, server := testReplicatorAndServer(t)
+	defer server.Stop()
+
+	// This makes it look like the preparers are installed on the hosts
+	// we're deploying to
+	for _, node := range testNodes {
+		key := fmt.Sprintf("reality/%s/p2-preparer", node)
+		server.SetKV(key, []byte(testPreparerManifest))
+	}
+
+	// Claim a lock on a host and verify that InitializeReplication fails
+	lock, _, err := store.NewLock("competing lock", nil)
+	if err != nil {
+		t.Fatalf("Unable to set up competing lock: %s", err)
+	}
+	defer lock.Destroy()
+	lockPath := kp.LockPath(testNodes[0], testPodId)
+	err = lock.Lock(lockPath)
+	if err != nil {
+		t.Fatalf("Unable to set up competing lock: %s", err)
+	}
+
+	replication, _, err := replicator.InitializeReplication(true)
+	if err != nil {
+		t.Fatalf("Expected InitializeReplication to override competing lock, but error occured: %s", err)
+	}
+	replication.Cancel()
+}


### PR DESCRIPTION
1) kp.NewLock() now will auto renew the lock in consul until explicitly
stopped
2) The functionality of Replicator was split into two structs,
Replicator and Replication. Replicator has an InitializeReplication()
function that returns a single-use instance of Replication, which has
the necessary data to perform a replication of a pod to a set of nodes.