### PR TITLE
Fix bug in Lock manager

### DIFF
--- a/pkg/kp/lock.go
+++ b/pkg/kp/lock.go
@@ -125,7 +125,7 @@ func (l Lock) continuallyRenew() {
 			err := l.Renew()
 			if err != nil {
 				l.renewalErrCh <- err
-				l.Destroy()
+				l.client.Session().Destroy(l.session, nil)
 				return
 			}
 		case <-l.quitCh:


### PR DESCRIPTION
Unit tests were failing with the following abbreviated output:

    panic: close of closed channel

    goroutine X [running]:
    github.com/square/p2/pkg/kp.Lock.Destroy()
            lock.go:148
    github.com/square/p2/pkg/kp.Lock.continuallyRenew()
            lock.go:128
    created by github.com/square/p2/pkg/kp.consulStore.NewLock
            lock.go:75

    goroutine Y [runnable]:
    ....
    github.com/square/p2/pkg/kp.(*ConsulTestFixture).Close()
            fixtures_test.go:40
    github.com/square/p2/pkg/kp.TestLock()
            lock_test.go:39
    testing.tRunner()
            testing.go:447
    created by testing.RunTests
            testing.go:555

    ...
    FAIL    github.com/square/p2/pkg/kp

There is a race between renewing a lock's session and a caller calling
`Destroy()` manually. Both execution paths try to close `quitCh`. This isn't
necessary to do when renewal fails, so this commit fixes the race by trying to
destroy a session directly in that case.