### PR TITLE
Only update KV health for status changes

### DIFF
--- a/pkg/kp/healthmanager.go
+++ b/pkg/kp/healthmanager.go
@@ -334,7 +334,7 @@ func processHealthUpdater(
 // Helper to processHealthUpdater()
 func healthEquiv(x *WatchResult, y *WatchResult) bool {
 	return x == nil && y == nil ||
-		x != nil && y != nil && x.ValueEquiv(*y)
+		x != nil && y != nil && x.Status == y.Status
 }
 
 // Helper to processHealthUpdater()


### PR DESCRIPTION
Some services include unique output in their status checks, e.g., a current
timestamp, and this was causing the services' KV health checks to be updated on
every check. With this commit, a new health check will be written only when
"Status" changes in a check result. "Output" is still present, but it cannot be
relied upon to be the most recent value.