### PR TITLE
Refresh health watchers when status info changes

### DIFF
--- a/pkg/watch/health.go
+++ b/pkg/watch/health.go
@@ -129,7 +129,9 @@ func updatePods(
 	for _, pod := range current {
 		inReality := false
 		for _, man := range reality {
-			if man.Manifest.Id == pod.manifest.Id {
+			if man.Manifest.Id == pod.manifest.Id &&
+				man.Manifest.StatusHTTP == pod.manifest.StatusHTTP &&
+				man.Manifest.StatusPort == pod.manifest.StatusPort {
 				inReality = true
 				break
 			}


### PR DESCRIPTION
Changes the behavior of the health manager in "pkg/watch" so that health
updaters are restarted whenever a manifest's status polling method (port or TLS
settings) changes.