### PR TITLE
Kill the preparer when its status server dies

### DIFF
--- a/bin/p2-preparer/main.go
+++ b/bin/p2-preparer/main.go
@@ -59,7 +59,10 @@ func main() {
 			func(w http.ResponseWriter, r *http.Request) {
 				fmt.Fprintf(w, "p2-preparer OK")
 			})
-		go http.ListenAndServe(fmt.Sprintf(":%d", preparerConfig.StatusPort), nil)
+		go func() {
+			err := http.ListenAndServe(fmt.Sprintf(":%d", preparerConfig.StatusPort), nil)
+			logger.WithError(err).Fatalln("status server exited")
+		}()
 	}
 
 	// Launch health checking watch. This watch tracks health of


### PR DESCRIPTION
If the preparer is unable to correctly report its health, it isn't functioning
properly. This commit causes the whole preparer to die when its HTTP status
server dies, so that the preparer has a chance of fixing itself when it starts
up again.