### PR TITLE
Remove OS X firewall message

### DIFF
--- a/pkg/watch/health_test.go
+++ b/pkg/watch/health_test.go
@@ -81,7 +81,7 @@ func TestUpdateStatus(t *testing.T) {
 
 func TestResultFromCheck(t *testing.T) {
 	http.HandleFunc("/_status", statusHandler)
-	go http.ListenAndServe(":8080", nil)
+	go http.ListenAndServe("localhost:8080", nil)
 	client := http.DefaultClient
 	sc := StatusChecker{
 		ID:   "hello",


### PR DESCRIPTION
Changes the status handler in the "pkg/watch" unit test to only bind to the
"localhost" address. This change prevents the Mac OS X firewall from prompting
me "Do you want the application 'watch.test' to accept incoming network
connections?" every time I ran unit tests.