### PR TITLE
Increase headroom for cgroup memory limits

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -124,7 +124,7 @@ func (subsys Subsystems) SetMemory(name string, bytes int) error {
 	}
 
 	softLimit := bytes
-	hardLimit := bytes + bytes/10
+	hardLimit := 2 * bytes
 	if hardLimit < softLimit {
 		// Deal with overflow
 		hardLimit = softLimit


### PR DESCRIPTION
An extra 10% appears to be too restrictive in practice. It would be nice to
make this configurable, but that can come later.