### PR TITLE
Support forceable restarts after timeout

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/square/p2/pkg/artifact"
 	"github.com/square/p2/pkg/cgroups"
@@ -29,6 +30,7 @@ type Launchable struct {
 	P2exec           string         // The path to p2-exec
 	CgroupConfig     cgroups.Config // Cgroup parameters to use with p2-exec
 	CgroupConfigName string         // The string in PLATFORM_CONFIG to pass to p2-exec
+	RestartTimeout   time.Duration  // How long to wait when restarting the services in this launchable.
 }
 
 func (hl *Launchable) Halt(serviceBuilder *runit.ServiceBuilder, sv *runit.SV) error {
@@ -158,7 +160,7 @@ func (hl *Launchable) start(serviceBuilder *runit.ServiceBuilder, sv *runit.SV) 
 	}
 
 	for _, executable := range executables {
-		_, err := sv.Restart(&executable.Service)
+		_, err := sv.Restart(&executable.Service, hl.RestartTimeout)
 		if err != nil && err != runit.SuperviseOkMissing {
 			return err
 		}

--- a/pkg/pods/manifest.go
+++ b/pkg/pods/manifest.go
@@ -25,6 +25,7 @@ type LaunchableStanza struct {
 	Location                string         `yaml:"location"`
 	DigestLocation          string         `yaml:"digest_location,omitempty"`
 	DigestSignatureLocation string         `yaml:"digest_signature_location,omitempty"`
+	RestartTimeout          string         `yaml:"restart_timeout,omitempty"`
 	CgroupConfig            cgroups.Config `yaml:"cgroup,omitempty"`
 }
 

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -147,6 +147,11 @@ func (p *Preparer) handlePods(podChan <-chan pods.Manifest, quit <-chan struct{}
 			if working {
 				pod := pods.NewPod(manifestToLaunch.ID(), pods.PodPath(p.podRoot, manifestToLaunch.ID()))
 
+				// TODO better solution: force the preparer to have a 0s default timeout, prevent KILLs
+				if pod.Id == POD_ID {
+					pod.DefaultTimeout = time.Duration(0)
+				}
+
 				ok := p.installAndLaunchPod(&manifestToLaunch, pod, manifestLogger)
 				if ok {
 					manifestToLaunch = pods.Manifest{}


### PR DESCRIPTION
All restarts are now forcible by default with a 60 second timeout, except for the preparer pod, which will never use forcible restart to ensure that bootstrapping continues to function correctly.

Each launchable section now supports an optional `restart_timeout` flag which can express a `time.Duration` that will be passed (in seconds) to the `sv force-restart` command. If no restart duration is provided, we continue to use `sv restart` and do not use KILL. 