### PR TITLE
Add HTTP Applicator and tests

### DIFF
--- a/pkg/labels/http_applicator.go
+++ b/pkg/labels/http_applicator.go
@@ -1,0 +1,85 @@
+package labels
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/util"
+)
+
+type httpApplicator struct {
+	client *http.Client
+	// The endpoint that will be queried for matches.
+	// GetMatches will add to this endpoint a query parameter with key "selector" and value selector.String()
+	matchesEndpoint *url.URL
+	logger          logging.Logger
+}
+
+var _ Applicator = &httpApplicator{}
+
+func NewHttpApplicator(client *http.Client, matchesEndpoint *url.URL) (*httpApplicator, error) {
+	if matchesEndpoint == nil {
+		return nil, util.Errorf("matches endpoint cannot be nil")
+	}
+
+	c := client
+	if c == nil {
+		c = http.DefaultClient
+	}
+
+	return &httpApplicator{
+		logger:          logging.DefaultLogger,
+		matchesEndpoint: matchesEndpoint,
+		client:          c,
+	}, nil
+}
+
+func (h *httpApplicator) SetLabel(labelType Type, id, name, value string) error {
+	return util.Errorf("SetLabel not implemented for HttpApplicator (type %s, id %s, name %s, value %s)", labelType, id, name, value)
+}
+
+func (h *httpApplicator) RemoveLabel(labelType Type, id, name string) error {
+	return util.Errorf("RemoveLabel not implemented for HttpApplicator (type %s, id %s, name %s)", labelType, id, name)
+}
+
+func (h *httpApplicator) GetLabels(labelType Type, id string) (Labeled, error) {
+	return Labeled{}, util.Errorf("GetLabels not implemented for HttpApplicator (type %s, id %s)", labelType, id)
+}
+
+func (h *httpApplicator) GetMatches(selector Selector, labelType Type) ([]Labeled, error) {
+	params := url.Values{}
+	params.Add("selector", selector.String())
+	params.Add("type", labelType.String())
+
+	// Make value copy of URL; don't want to mutate the URL in the struct.
+	urlToGet := *h.matchesEndpoint
+	urlToGet.RawQuery = params.Encode()
+
+	resp, err := h.client.Get(urlToGet.String())
+	if err != nil {
+		return []Labeled{}, err
+	}
+
+	defer resp.Body.Close()
+
+	matches := []string{}
+	decoder := json.NewDecoder(resp.Body)
+	err = decoder.Decode(&matches)
+	if err != nil {
+		return []Labeled{}, err
+	}
+
+	labeled := make([]Labeled, len(matches))
+
+	for i, s := range matches {
+		labeled[i] = Labeled{
+			ID:        s,
+			LabelType: labelType,
+			Labels:    Set{},
+		}
+	}
+
+	return labeled, nil
+}

--- a/pkg/labels/http_applicator_test.go
+++ b/pkg/labels/http_applicator_test.go
@@ -1,0 +1,55 @@
+package labels
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	. "github.com/square/p2/Godeps/_workspace/src/github.com/anthonybishopric/gotcha"
+)
+
+const endpointSuffix = "/testendpoint"
+
+func getMatches(t *testing.T, httpResponse string) ([]Labeled, error) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		Assert(t).AreEqual(r.URL.Path, endpointSuffix, "Unexpected path requested")
+		Assert(t).AreEqual(r.URL.Query().Get("selector"), "r1=v1,r2=v2", "Unexpected selector requested")
+		Assert(t).AreEqual(r.URL.Query().Get("type"), NODE.String(), "Unexpected type requested")
+		fmt.Fprintln(w, httpResponse)
+	}))
+	defer server.Close()
+
+	url, err := url.Parse(server.URL + endpointSuffix)
+	Assert(t).IsNil(err, "expected no error parsing url")
+
+	applicator, err := NewHttpApplicator(nil, url)
+	Assert(t).IsNil(err, "expected no error creating HTTP applicator")
+	selector := Everything().Add("r1", EqualsOperator, []string{"v1"}).Add("r2", EqualsOperator, []string{"v2"})
+	return applicator.GetMatches(selector, NODE)
+}
+
+func TestGetMatches(t *testing.T) {
+	matches, err := getMatches(t, `["a","b"]`)
+	Assert(t).IsNil(err, "expected no error getting matches")
+	Assert(t).AreEqual(len(matches), 2, "Expected two matches")
+	Assert(t).AreEqual(matches[0].ID, "a", "Unexpected ID of first match")
+	Assert(t).AreEqual(matches[1].ID, "b", "Unexpected ID of second match")
+}
+
+func TestGetMatchesEmpty(t *testing.T) {
+	matches, err := getMatches(t, `[]`)
+	Assert(t).IsNil(err, "expected no error getting matches")
+	Assert(t).AreEqual(len(matches), 0, "Expected no matches")
+}
+
+func TestGetMatchesTypeError(t *testing.T) {
+	_, err := getMatches(t, `[1]`)
+	Assert(t).IsNotNil(err, "expected error getting matches")
+}
+
+func TestGetMatchesNoJson(t *testing.T) {
+	_, err := getMatches(t, `[`)
+	Assert(t).IsNotNil(err, "expected error getting matches")
+}


### PR DESCRIPTION
This allows using an HTTP server that accepts GET requests and returns
JSON lists of strings representing the nodes that match the query.