### PR TITLE
Enable global hooks

### DIFF
--- a/bin/p2-watch/main.go
+++ b/bin/p2-watch/main.go
@@ -17,7 +17,7 @@ import (
 var (
 	nodeName      = kingpin.Flag("node", "The node to do the scheduling on. Uses the hostname by default.").String()
 	watchReality  = kingpin.Flag("reality", "Watch the reality store instead of the intent store. False by default").Default("false").Bool()
-	hookTypeName  = kingpin.Flag("hook-type", "Watch a particular hook type instead of the intent store.").String()
+	hookTypeName  = kingpin.Flag("hook-type", "Watch a particular hook type instead of the intent store, or \"global\" for all hooks.").String()
 	consulAddress = kingpin.Flag("consul", "The address of the consul node to use. Defaults to 0.0.0.0:8500").String()
 	consulToken   = kingpin.Flag("token", "The ACL to use for accessing consul.").String()
 	headers       = kingpin.Flag("header", "An HTTP header to add to requests, in KEY=VALUE form. Can be specified multiple times.").StringMap()
@@ -46,12 +46,14 @@ func main() {
 	path := kp.IntentPath(*nodeName)
 	if *watchReality {
 		path = kp.RealityPath(*nodeName)
+	} else if *hookTypeName == "global" {
+		path = kp.HookPath()
 	} else if *hookTypeName != "" {
 		hookType, err := hooks.AsHookType(*hookTypeName)
 		if err != nil {
 			log.Fatalln(err)
 		}
-		path = kp.HookPath(hookType, *nodeName)
+		path = kp.HookPath(hookType.String())
 	}
 	log.Printf("Watching manifests at %s\n", path)
 

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -25,7 +25,7 @@ func TestExecutableHooksAreRun(t *testing.T) {
 	podId := "TestPod"
 	manifest := pods.Manifest{Id: podId}
 	hooks := Hooks(os.TempDir(), &logging.DefaultLogger)
-	hooks.runHooks(tempDir, AFTER_INSTALL, pods.NewPod(podId, podDir), &manifest)
+	hooks.runHooks(tempDir, AFTER_INSTALL, pods.NewPod(podId, podDir), &manifest, logging.DefaultLogger)
 
 	contents, err := ioutil.ReadFile(path.Join(tempDir, "output"))
 	Assert(t).IsNil(err, "the error should have been nil")
@@ -48,7 +48,7 @@ func TestNonExecutableHooksAreNotRun(t *testing.T) {
 	podId := "TestPod"
 	manifest := pods.Manifest{Id: podId}
 	hooks := Hooks(os.TempDir(), &logging.DefaultLogger)
-	hooks.runHooks(tempDir, AFTER_INSTALL, pods.NewPod(podId, podDir), &manifest)
+	hooks.runHooks(tempDir, AFTER_INSTALL, pods.NewPod(podId, podDir), &manifest, logging.DefaultLogger)
 
 	if _, err := os.Stat(path.Join(tempDir, "failed")); err == nil {
 		t.Fatal("`failed` file exists; non-executable hook ran but should not have run")
@@ -71,7 +71,7 @@ func TestDirectoriesDoNotBreakEverything(t *testing.T) {
 	pod := pods.NewPod(podId, podDir)
 	logger := logging.TestLogger()
 	hooks := Hooks(os.TempDir(), &logger)
-	err = hooks.runHooks(tempDir, AFTER_INSTALL, pod, &manifest)
+	err = hooks.runHooks(tempDir, AFTER_INSTALL, pod, &manifest, logging.DefaultLogger)
 
 	Assert(t).IsNil(err, "Got an error when running a directory inside the hooks directory")
 }

--- a/pkg/kp/constants.go
+++ b/pkg/kp/constants.go
@@ -2,8 +2,6 @@ package kp
 
 import (
 	"strings"
-
-	"github.com/square/p2/pkg/hooks"
 )
 
 const (
@@ -21,8 +19,8 @@ func RealityPath(args ...string) string {
 	return strings.Join(append([]string{REALITY_TREE}, args...), "/")
 }
 
-func HookPath(hookType hooks.HookType, args ...string) string {
-	return strings.Join(append([]string{HOOK_TREE, hookType.String()}, args...), "/")
+func HookPath(args ...string) string {
+	return strings.Join(append([]string{HOOK_TREE}, args...), "/")
 }
 
 func LockPath(args ...string) string {


### PR DESCRIPTION
next step would be disabling typed hooks, but we'll have to do that after we migrate all our hooks (including those from other teams) to the new system.