### PR TITLE
Add params package

### DIFF
--- a/bin/p2-preparer/main.go
+++ b/bin/p2-preparer/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/preparer"
+	"github.com/square/p2/pkg/util/param"
 	"github.com/square/p2/pkg/version"
 	"github.com/square/p2/pkg/watch"
 )
@@ -28,6 +29,10 @@ func main() {
 	preparerConfig, err := preparer.LoadConfig(configPath)
 	if err != nil {
 		logger.WithError(err).Fatalln("could not load preparer config")
+	}
+	err = param.Parse(preparerConfig.Params)
+	if err != nil {
+		logger.WithError(err).Fatalln("invalid parameter")
 	}
 
 	prep, err := preparer.New(preparerConfig, logger)

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -19,6 +19,7 @@ import (
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/util"
+	"github.com/square/p2/pkg/util/param"
 )
 
 // DefaultConsulAddress is the default location for Consul when none is configured.
@@ -52,6 +53,10 @@ type PreparerConfig struct {
 	WriteKVHealth        bool                   `yaml:"write_kv_health,omitempty"`
 	UseSessionHealth     bool                   `yaml:"use_session_health,omitempty"`
 	LogLevel             string                 `yaml:"log_level,omitempty"`
+
+	// Params defines a collection of miscellaneous runtime parameters defined throughout the
+	// source files.
+	Params param.Values `yaml:"params"`
 }
 
 // Configuration fields for the "keyring" auth type

--- a/pkg/util/param/param.go
+++ b/pkg/util/param/param.go
@@ -1,0 +1,85 @@
+// The param package is a management system for configuration parameters. Much like the
+// standard library "flags" package, the param package allows parameters to be defined in
+// the file they are needed without requiring direct linkage between the usage location
+// and the configuration parser.
+//
+// In typical use, each parameter is defined as a package-level variable. During
+// initialization, the program provides a map[string]string containing parameter
+// configuration data. This map is expected to be parsed from a configuration file.
+//
+// Because the tasks are so similar, this package is implemented by re-using the low-level
+// types from the standard "flag" module.
+//
+// Example parameter declaration:
+//
+//   var threshhold = param.Int("threshhold", 5)
+//
+// Parameter use:
+//
+//   if numUsed >= *threshhold { ... }
+//
+// Parsing from a config file:
+//
+//   var config struct {
+//       FormalValue  string
+//       Params       param.Values
+//   }
+//   yaml.Unmarshal(readConfigFile(), &config)
+//   err := param.Parse(config.Params)
+//
+package param
+
+import (
+	"flag"
+	"fmt"
+)
+
+// DefaultParams holds the default set of parameters, used by all package-level functions.
+var DefaultParams flag.FlagSet
+
+// Values is a type alias that can be used to help document the configuration values that
+// are meant to be define parameters.
+type Values map[string]string
+
+// Float64 declares a new "float64"-typed parameter with the given default value.
+func Float64(name string, value float64) *float64 {
+	return DefaultParams.Float64(name, value, "")
+}
+
+// Int declares a new "int"-typed parameter with the given default value.
+func Int(name string, value int) *int {
+	return DefaultParams.Int(name, value, "")
+}
+
+// Int64 declares a new "int64"-typed parameter with the given default value.
+func Int64(name string, value int64) *int64 {
+	return DefaultParams.Int64(name, value, "")
+}
+
+// String declares a new "string"-typed parameter with the given default value.
+func String(name string, value string) *string {
+	return DefaultParams.String(name, value, "")
+}
+
+// Parse parses the parameter assignments for the default set of parameters. See
+// ParseFlags().
+func Parse(values Values) error {
+	return ParseFlags(&DefaultParams, values)
+}
+
+// ParseFlags parses a map of parameter assignments that are defined by a FlagSet.
+func ParseFlags(f *flag.FlagSet, values Values) error {
+	for name := range values {
+		if f.Lookup(name) == nil {
+			return fmt.Errorf("%s: no such parameter", name)
+		}
+	}
+	var err error
+	for name, value := range values {
+		err = f.Set(name, value)
+		if err != nil {
+			err = fmt.Errorf("%s: %s", name, err)
+		}
+	}
+	return err
+}


### PR DESCRIPTION
Adds a new "params" package which provides a less-formal way to specify
configuration parameters.  Each parameter can be declared in the package where
it's needed, and a single call to `params.Parse()` will set all defined
parameters.

This is mainly intented to permit some configurability for values that would
otherwise be declared as a package constant, or where there are too many layers
between a program's main configuration parser and the use of that configuration
value.