### PR TITLE
Add --workdir flag to p2-exec to change working directory

### DIFF
--- a/bin/p2-exec/main.go
+++ b/bin/p2-exec/main.go
@@ -26,6 +26,7 @@ var (
 	cgroupName     = kingpin.Flag("cgroup", "the name of the cgroup that should be created").Short('c').String()
 	nolim          = kingpin.Flag("nolimit", "remove rlimits").Short('n').Bool()
 	clearEnv       = kingpin.Flag("clearenv", "clear all environment variables before loading envDir").Bool()
+	workDir        = kingpin.Flag("workdir", "set working directory").Short('w').String()
 
 	cmd = kingpin.Arg("command", "the command to execute").Required().Strings()
 )
@@ -71,6 +72,13 @@ func main() {
 
 	if *username != "" {
 		err := changeUser(*username)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	if *workDir != "" {
+		err := os.Chdir(*workDir)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
Adds a new --workdir (short: -w) flag to the p2-exec command that allows it to
change the working directory before exec-ing its main command.