### PR TITLE
Fix ZipResultSets conditions

### DIFF
--- a/pkg/preparer/result_set.go
+++ b/pkg/preparer/result_set.go
@@ -36,7 +36,7 @@ func ZipResultSets(intent, reality []kp.ManifestResult) (ret []ManifestPair) {
 			rID = reality[realityIndex].Manifest.ID()
 		}
 
-		if rID == "" || iID < rID {
+		if iID != "" && (rID == "" || iID < rID) {
 			// if rID == "", then realityIndex is out of range, but we're still in
 			// the loop, therefore intentIndex must be in range
 			ret = append(ret, ManifestPair{
@@ -44,7 +44,7 @@ func ZipResultSets(intent, reality []kp.ManifestResult) (ret []ManifestPair) {
 				Intent: intent[intentIndex].Manifest,
 			})
 			intentIndex++
-		} else if iID == "" || rID < iID {
+		} else if rID != "" && (iID == "" || rID < iID) {
 			// and vice versa
 			ret = append(ret, ManifestPair{
 				ID:      rID,

--- a/pkg/preparer/result_set_test.go
+++ b/pkg/preparer/result_set_test.go
@@ -1,6 +1,8 @@
 package preparer
 
 import (
+	"math/rand"
+	"strconv"
 	"testing"
 
 	. "github.com/square/p2/Godeps/_workspace/src/github.com/anthonybishopric/gotcha"
@@ -24,36 +26,68 @@ func TestZipBasic(t *testing.T) {
 	}
 
 	pairs := ZipResultSets(intent, reality)
-	ValidatePairList(t, pairs)
-	for _, pair := range pairs {
-		switch pair.ID {
-		case "bar":
-			Assert(t).IsNotNil(pair.Intent, "bar pair should have intent")
-			Assert(t).IsNotNil(pair.Reality, "bar pair should have reality")
-		case "baz":
-			// the nil pointer inside ManifestPair is getting boxed into an
-			// interface when passed as an argument
-			// therefore, Assert(t).IsNil doesn't work here
-			if pair.Intent != nil {
-				t.Error("baz pair should not have intent")
-			}
-			Assert(t).IsNotNil(pair.Reality, "baz pair should have reality")
-		case "foo":
-			Assert(t).IsNotNil(pair.Intent, "foo pair should have intent")
-			if pair.Reality != nil {
-				t.Error("baz pair should not have reality")
-			}
-		}
-	}
+	ValidatePairList(t, pairs, intent, reality)
 }
 
-func ValidatePairList(t *testing.T, l []ManifestPair) {
+func ValidatePairList(t *testing.T, l []ManifestPair, intent, reality []kp.ManifestResult) {
 	for _, pair := range l {
+		// fuzz check #1: all three fields of the Pair should have the same ID
 		if pair.Intent != nil {
 			Assert(t).AreEqual(pair.ID, pair.Intent.ID(), "intent manifest should have had same ID")
 		}
 		if pair.Reality != nil {
 			Assert(t).AreEqual(pair.ID, pair.Reality.ID(), "reality manifest should have had same ID")
 		}
+
+		// fuzz check #2: if Pair.Intent is non-nil, then it should be in the
+		// source intent list, and vice versa
+		var intentFound bool
+		for _, m := range intent {
+			if pair.ID == m.Manifest.ID() {
+				// cannot use Assert.IsNil against a pointer
+				if pair.Intent == nil {
+					t.Errorf("source intent list and pair contained matching id %q, but pair did not contain intent manifest", pair.ID)
+				}
+				intentFound = true
+			}
+		}
+		Assert(t).IsTrue(pair.Intent == nil || intentFound, "should have found at least one manifest in the source intent list")
+
+		// fuzz check #3: same as #2, but for reality
+		var realityFound bool
+		for _, m := range reality {
+			if pair.ID == m.Manifest.ID() {
+				// cannot use Assert.IsNil against a pointer
+				if pair.Reality == nil {
+					t.Errorf("source reality list and pair contained matching id %q, but pair did not contain reality manifest", pair.ID)
+				}
+				realityFound = true
+			}
+		}
+		Assert(t).IsTrue(pair.Reality == nil || realityFound, "should have found at least one manifest in the source reality list")
 	}
+}
+
+func TestZipFuzz(t *testing.T) {
+	for i := 0; i < 500; i++ {
+		intent := generateRandomManifestList(100)
+		reality := generateRandomManifestList(100)
+		ValidatePairList(t, ZipResultSets(intent, reality), intent, reality)
+	}
+}
+
+// generates a list of manifests that is baseLength in length, then randomly
+// discards up to half the elements
+func generateRandomManifestList(baseLength int) []kp.ManifestResult {
+	indices := rand.Perm(baseLength)
+	discard := rand.Intn(baseLength / 2)
+
+	ret := make([]kp.ManifestResult, baseLength-discard)
+	for i := range ret {
+		ret[i] = kp.ManifestResult{
+			Manifest: podWithID(strconv.Itoa(indices[i])),
+		}
+	}
+
+	return ret
 }


### PR DESCRIPTION
Luckily this panic is only encountered when trying to DELETE a manifest (since intent has to be shorter than reality to cause the panic, vice versa does not cause it) so it won't be triggered in production conditions any time soon.

I'm going to try and write some fuzz tests for this before merging, because this is the third time I've had to modify a logically straightforward function...