### PR TITLE
Refactor hook install

### DIFF
--- a/bin/p2-install-hook/main.go
+++ b/bin/p2-install-hook/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"log"
+	"path/filepath"
+
+	"github.com/square/p2/Godeps/_workspace/src/gopkg.in/alecthomas/kingpin.v1"
+	"github.com/square/p2/pkg/hooks"
+	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/version"
+)
+
+var (
+	manifestURI = kingpin.Arg("manifest", "a path or url to a pod manifest that will be installed and launched immediately.").String()
+	podRoot     = kingpin.Flag("pod-root", "the root of the pods directory").Default(pods.DEFAULT_PATH).String()
+	hookRoot    = kingpin.Flag("hook-root", "the root of the hook scripts directory").Default(hooks.DEFAULT_PATH).String()
+	hookType    = kingpin.Flag("hook-type", "the type of the hook (if unspecified, defaults to global)").String()
+)
+
+func main() {
+	kingpin.Version(version.VERSION)
+	kingpin.Parse()
+
+	manifest, err := pods.ManifestFromURI(*manifestURI)
+	if err != nil {
+		log.Fatalf("%s", err)
+	}
+
+	// /data/pods/hooks/<event>/<id>
+	// if the event is the empty string (global hook), then that path segment
+	// will be cleaned out
+	pod := pods.NewPod(manifest.ID(), pods.PodPath(filepath.Join(*podRoot, "hooks", *hookType), manifest.ID()))
+	err = pod.Install(manifest)
+	if err != nil {
+		log.Fatalf("Could not install manifest %s: %s", manifest.ID(), err)
+	}
+	// hooks write their current manifest manually since it's normally done at
+	// launch time
+	_, err = pod.WriteCurrentManifest(manifest)
+	if err != nil {
+		log.Fatalf("Could not write current manifest for %s: %s", manifest.ID(), err)
+	}
+
+	err = hooks.InstallHookScripts(*hookRoot, pod, manifest, logging.DefaultLogger)
+	if err != nil {
+		log.Fatalf("Could not write hook scripts: %s", err)
+	}
+}

--- a/pkg/hooks/install.go
+++ b/pkg/hooks/install.go
@@ -1,0 +1,72 @@
+package hooks
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/square/p2/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/runit"
+	"github.com/square/p2/pkg/util"
+)
+
+// Populates the given directory with executor scripts for each launch script of
+// the given pod, which must be installed. Any orphaned executor scripts (from a
+// past install, but no longer present in this pod) will be cleaned out.
+func InstallHookScripts(dir string, hookPod *pods.Pod, manifest pods.Manifest, logger logging.Logger) error {
+	err := os.MkdirAll(dir, 0755)
+	if err != nil {
+		return err
+	}
+
+	// TODO: globbing based on the structure of the name is gross, each hook pod
+	// should have its own dir of scripts and running hooks should iterate over
+	// the directories
+	rmPattern := filepath.Join(dir, fmt.Sprintf("%s__*", hookPod.Id))
+	matches, err := filepath.Glob(rmPattern)
+	if err != nil {
+		// error return from filepath.Glob is guaranteed to be ErrBadPattern
+		return util.Errorf("error while removing old hook scripts: pattern %q is malformed", rmPattern)
+	}
+	for _, match := range matches {
+		err = os.Remove(match)
+		if err != nil {
+			logger.WithErrorAndFields(err, logrus.Fields{"script_path": match}).Errorln("Could not remove old hook script")
+		}
+	}
+
+	launchables, err := hookPod.Launchables(manifest)
+	if err != nil {
+		return err
+	}
+	for _, launchable := range launchables {
+		executables, err := launchable.Executables(runit.DefaultBuilder)
+		if err != nil {
+			return err
+		}
+
+		for _, executable := range executables {
+			// Write a script to the event directory that executes the pod's executables
+			// with the correct environment for that pod.
+			scriptPath := filepath.Join(dir, executable.Service.Name)
+			file, err := os.OpenFile(scriptPath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0744)
+			defer file.Close()
+			if err != nil {
+				logger.WithErrorAndFields(err, logrus.Fields{"script_path": scriptPath}).Errorln("Could not open new hook script")
+			}
+			err = executable.WriteExecutor(file)
+			if err != nil {
+				logger.WithErrorAndFields(err, logrus.Fields{"script_path": scriptPath}).Errorln("Could not write new hook script")
+			}
+		}
+		// for convenience as we do with regular launchables, make these ones
+		// current under the launchable directory
+		err = launchable.MakeCurrent()
+		if err != nil {
+			logger.WithErrorAndFields(err, logrus.Fields{"launchable_id": launchable.Id}).Errorln("Could not set hook launchable to current")
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Moved the most logically complex part of hook installation (writing hook scripts) into the hooks package, and created a corresponding binary that uses it. Will be useful for distributing hooks without hitting everything.