### PR TITLE
Orchestration-related refactors part 1

### DIFF
--- a/pkg/kp/constants.go
+++ b/pkg/kp/constants.go
@@ -9,6 +9,7 @@ const (
 	REALITY_TREE string = "reality"
 	HOOK_TREE    string = "hooks"
 	LOCK_TREE    string = "lock"
+	RC_TREE      string = "replication_controller"
 )
 
 func IntentPath(args ...string) string {
@@ -25,4 +26,8 @@ func HookPath(args ...string) string {
 
 func LockPath(args ...string) string {
 	return strings.Join(append([]string{LOCK_TREE}, args...), "/")
+}
+
+func RCPath(args ...string) string {
+	return strings.Join(append([]string{RC_TREE}, args...), "/")
 }

--- a/pkg/kp/rcstore/fake_store.go
+++ b/pkg/kp/rcstore/fake_store.go
@@ -73,6 +73,10 @@ func (s *fakeStore) List() ([]fields.RC, error) {
 	return results, nil
 }
 
+func (s *fakeStore) WatchNew(quit <-chan struct{}) (<-chan []fields.RC, <-chan error) {
+	return nil, nil
+}
+
 func (s *fakeStore) Lock(id fields.ID, session string) (bool, error) {
 	entry, ok := s.rcs[id]
 	if !ok {

--- a/pkg/kp/rcstore/fake_store.go
+++ b/pkg/kp/rcstore/fake_store.go
@@ -18,6 +18,7 @@ type fakeEntry struct {
 	fields.RC
 	watchers      map[int]chan struct{}
 	lastWatcherId int
+	locked        string
 }
 
 var _ Store = &fakeStore{}
@@ -70,6 +71,18 @@ func (s *fakeStore) List() ([]fields.RC, error) {
 		i += 1
 	}
 	return results, nil
+}
+
+func (s *fakeStore) Lock(id fields.ID, session string) (bool, error) {
+	entry, ok := s.rcs[id]
+	if !ok {
+		return false, util.Errorf("Nonexistent rc")
+	}
+	if entry.locked == "" {
+		entry.locked = session
+		return true, nil
+	}
+	return false, nil
 }
 
 func (s *fakeStore) Disable(id fields.ID) error {

--- a/pkg/kp/rcstore/store.go
+++ b/pkg/kp/rcstore/store.go
@@ -17,6 +17,16 @@ type Store interface {
 	Get(id fields.ID) (fields.RC, error)
 	List() ([]fields.RC, error)
 
+	// Use the given session string (which uniquely identifies the lock holder)
+	// to acquire a lock on the specified replication controller. If the lock
+	// was successfully claimed, return (true, nil). If the request completed
+	// but the lock was already held, return (false, nil). Otherwise return an
+	// appropriate error.
+	//
+	// The lock will be taken against an ephemeral key, so it is safe to use a
+	// session that deletes its keys on invalidation.
+	Lock(id fields.ID, session string) (bool, error)
+
 	SetDesiredReplicas(fields.ID, int) error
 	Disable(fields.ID) error
 	Delete(fields.ID) error

--- a/pkg/kp/rcstore/store.go
+++ b/pkg/kp/rcstore/store.go
@@ -11,11 +11,7 @@ import (
 type Store interface {
 	// Create creates a replication controller with the specified manifest and selectors.
 	// The node selector is used to determine what nodes the replication controller may schedule on.
-	// The pod label set is:
-	// 1) applied to every pod the replication controller schedules,
-	// 2) used to determine what pods are already scheduled.
-	// Note that this implies that creating two replication controllers with the same podLabels
-	// means that the two will see each others' pods.
+	// The pod label set is applied to every pod the replication controller schedules.
 	Create(manifest pods.Manifest, nodeSelector labels.Selector, podLabels labels.Set) (fields.RC, error)
 
 	Get(id fields.ID) (fields.RC, error)

--- a/pkg/kp/rcstore/store.go
+++ b/pkg/kp/rcstore/store.go
@@ -17,6 +17,12 @@ type Store interface {
 	Get(id fields.ID) (fields.RC, error)
 	List() ([]fields.RC, error)
 
+	// Watch for changes to the entire store and output the current list of RCs
+	// any time it changes. This function blocks; close the quit channel to
+	// terminate. Callers must drain the returned channels, including the error
+	// channel.
+	WatchNew(quit <-chan struct{}) (<-chan []fields.RC, <-chan error)
+
 	// Use the given session string (which uniquely identifies the lock holder)
 	// to acquire a lock on the specified replication controller. If the lock
 	// was successfully claimed, return (true, nil). If the request completed

--- a/pkg/rc/replication_controller.go
+++ b/pkg/rc/replication_controller.go
@@ -32,7 +32,7 @@ type ReplicationController interface {
 	WatchDesires(quit <-chan struct{}) <-chan error
 
 	// CurrentNodes() returns all nodes that this replication controller is currently scheduled on,
-	// according to the pod label set associated with the replication controller.
+	// by selecting pods labeled with the replication controller's ID.
 	CurrentNodes() ([]string, error)
 
 	// Internal: meetDesires synchronously schedules or unschedules pods to meet desired state.
@@ -184,7 +184,7 @@ func (rc *replicationController) eligibleNodes() ([]string, error) {
 }
 
 func (rc *replicationController) CurrentNodes() ([]string, error) {
-	selector := rc.PodLabels.AsSelector()
+	selector := labels.Everything().Add(rcIdLabel, labels.EqualsOperator, []string{rc.Id().String()})
 
 	pods, err := rc.podApplicator.GetMatches(selector, labels.POD)
 	if err != nil {

--- a/pkg/replication/replication.go
+++ b/pkg/replication/replication.go
@@ -75,7 +75,7 @@ func (r replication) lockHosts(overrideLock bool, lockMessage string) error {
 	}
 
 	for _, host := range r.nodes {
-		lockPath := kp.LockPath(host, r.manifest.ID())
+		lockPath := kp.LockPath(kp.IntentPath(host, r.manifest.ID()))
 		err := r.lock(lock, lockPath, overrideLock)
 
 		if err != nil {

--- a/pkg/replication/replication_test.go
+++ b/pkg/replication/replication_test.go
@@ -257,7 +257,7 @@ func TestStopsIfLockDestroyed(t *testing.T) {
 	}
 
 	for _, host := range testNodes {
-		lockPath := kp.LockPath(host, manifest.ID())
+		lockPath := kp.LockPath(kp.IntentPath(host, manifest.ID()))
 		err := replication.lock(lock, lockPath, false)
 
 		if err != nil {
@@ -354,7 +354,7 @@ func TestStopsIfLockDestroyed(t *testing.T) {
 	}
 
 	// Destroy lock holder so the next renewal will fail
-	lockPath := kp.LockPath(testNodes[0], manifest.ID())
+	lockPath := kp.LockPath(kp.IntentPath(testNodes[0], manifest.ID()))
 	_, id, err := store.LockHolder(lockPath)
 	if err != nil {
 		t.Fatalf("Unable to determine lock holder in order to destroy the lock: %s", err)

--- a/pkg/replication/replicator_test.go
+++ b/pkg/replication/replicator_test.go
@@ -26,7 +26,7 @@ func TestInitializeReplication(t *testing.T) {
 
 	// Confirm that the appropriate kv keys have been locked
 	for _, node := range testNodes {
-		lockPath := kp.LockPath(node, testPodId)
+		lockPath := kp.LockPath(kp.IntentPath(node, testPodId))
 		lockHolder, _, err := store.LockHolder(lockPath)
 		if err != nil {
 			t.Fatalf("Unexpected error checking for lock holder: %s", err)
@@ -77,7 +77,7 @@ func TestInitializeReplicationFailsIfLockExists(t *testing.T) {
 		t.Fatalf("Unable to set up competing lock: %s", err)
 	}
 	defer lock.Destroy()
-	lockPath := kp.LockPath(testNodes[0], testPodId)
+	lockPath := kp.LockPath(kp.IntentPath(testNodes[0], testPodId))
 	err = lock.Lock(lockPath)
 	if err != nil {
 		t.Fatalf("Unable to set up competing lock: %s", err)
@@ -115,7 +115,7 @@ func TestInitializeReplicationCanOverrideLocks(t *testing.T) {
 		t.Fatalf("Unable to set up competing lock: %s", err)
 	}
 	defer lock.Destroy()
-	lockPath := kp.LockPath(testNodes[0], testPodId)
+	lockPath := kp.LockPath(kp.IntentPath(testNodes[0], testPodId))
 	err = lock.Lock(lockPath)
 	if err != nil {
 		t.Fatalf("Unable to set up competing lock: %s", err)


### PR DESCRIPTION
None of this code has been tested yet, requesting review for concepts and structure.

There are a few goals being covered here:
- RCs should use their ID label to find their "current" nodes, rather than their set of pod labels. Otherwise it becomes impossible for two RCs to have the same set of pod labels.
- rcstore should be capable of taking locks on replication controllers. To avoid collisions, we move intent-tree locks to `/lock/intent/<node>/<pod>` and put the new locks under `/lock/replication_controller`. I would have also liked to do some refactors to lock and session management to make the API better (essentially I would have created a new package `store/lockstore` for it), but I don't have a good idea of how long that would take right now and I'm still getting familiar with the sessionmanager api.
- rcstore should be able to watch for new replication controllers. This inevitably requires a list operation so it might as well return the entire fields.RC object.

I think these changes are the key requirements to implement the rc farm (if nobody has any suggestions I'm going to call it the `RCManager`) which is in progress.