### PR TITLE
Orchestrator-related refactors round 2

### DIFF
--- a/pkg/kp/constants.go
+++ b/pkg/kp/constants.go
@@ -9,7 +9,7 @@ const (
 	REALITY_TREE string = "reality"
 	HOOK_TREE    string = "hooks"
 	LOCK_TREE    string = "lock"
-	RC_TREE      string = "replication_controller"
+	RC_TREE      string = "replication_controllers"
 )
 
 func IntentPath(args ...string) string {

--- a/pkg/kp/rcstore/consul_store.go
+++ b/pkg/kp/rcstore/consul_store.go
@@ -58,7 +58,7 @@ func (s *consulStore) Create(manifest pods.Manifest, nodeSelector labels.Selecto
 	}
 
 	rc := fields.RC{
-		Id:              id,
+		ID:              id,
 		Manifest:        manifest,
 		NodeSelector:    nodeSelector,
 		PodLabels:       podLabels,
@@ -220,7 +220,7 @@ func (s *consulStore) Watch(rc *fields.RC, quit <-chan struct{}) (<-chan struct{
 			case <-quit:
 				return
 			case <-time.After(1 * time.Second):
-				pairs, meta, err := s.kv.List(kp.RCPath(rc.Id.String()), &api.QueryOptions{
+				pairs, meta, err := s.kv.List(kp.RCPath(rc.ID.String()), &api.QueryOptions{
 					WaitIndex: curIndex,
 				})
 				if err != nil {
@@ -230,7 +230,7 @@ func (s *consulStore) Watch(rc *fields.RC, quit <-chan struct{}) (<-chan struct{
 
 					rcMap := s.kvpsToRcs(pairs)
 
-					if newRc, ok := rcMap[rc.Id]; ok {
+					if newRc, ok := rcMap[rc.ID]; ok {
 						*rc = *newRc
 						updated <- struct{}{}
 					}
@@ -344,7 +344,7 @@ func (s *consulStore) kvpsToRcs(kvps api.KVPairs) map[fields.ID]*fields.RC {
 // If forEachLabel encounters any error applying the function, it returns that error immediately.
 // The function is not further applied to subsequent labels on an error.
 func (s *consulStore) forEachLabel(rc fields.RC, f func(id, k, v string) error) error {
-	id := rc.Id.String()
+	id := rc.ID.String()
 	// As of this writing the only label we want is the pod ID.
 	// There may be more in the future.
 	return f(id, "pod_id", rc.Manifest.ID())

--- a/pkg/kp/rcstore/consul_store.go
+++ b/pkg/kp/rcstore/consul_store.go
@@ -1,10 +1,8 @@
 package rcstore
 
 import (
-	"bytes"
+	"encoding/json"
 	"fmt"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/api"
@@ -24,39 +22,65 @@ type kvPair struct {
 
 type consulKV interface {
 	Get(key string, opts *api.QueryOptions) (*api.KVPair, *api.QueryMeta, error)
-	Keys(prefix string, separator string, opts *api.QueryOptions) ([]string, *api.QueryMeta, error)
 	List(prefix string, opts *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error)
-	Put(pair *api.KVPair, opts *api.WriteOptions) (*api.WriteMeta, error)
+	CAS(pair *api.KVPair, opts *api.WriteOptions) (bool, *api.WriteMeta, error)
+	DeleteCAS(pair *api.KVPair, opts *api.WriteOptions) (bool, *api.WriteMeta, error)
 	Acquire(pair *api.KVPair, opts *api.WriteOptions) (bool, *api.WriteMeta, error)
-	DeleteTree(prefix string, opts *api.WriteOptions) (*api.WriteMeta, error)
 }
 
 type consulStore struct {
 	applicator labels.Applicator
 	kv         consulKV
 	logger     logging.Logger
+	retries    int
+}
+
+// TODO: combine with similar CASError type in pkg/labels
+type CASError string
+
+func (e CASError) Error() string {
+	return fmt.Sprintf("Could not check-and-set key %q", string(e))
 }
 
 var _ Store = &consulStore{}
 
-func NewConsul(client *api.Client) *consulStore {
+func NewConsul(client *api.Client, retries int, logger logging.Logger) *consulStore {
 	return &consulStore{
-		// TODO: Should the number of retries be configurable?
-		applicator: labels.NewConsulApplicator(client, 3),
+		retries:    retries,
+		applicator: labels.NewConsulApplicator(client, retries),
 		kv:         client.KV(),
-		logger:     logging.DefaultLogger,
+		logger:     logger,
 	}
 }
 
 func (s *consulStore) Create(manifest pods.Manifest, nodeSelector labels.Selector, podLabels labels.Set) (fields.RC, error) {
-	id := fields.ID(uuid.New())
-
-	buf := bytes.Buffer{}
-	err := manifest.Write(&buf)
+	rc, err := s.innerCreate(manifest, nodeSelector, podLabels)
+	for i := 0; i < s.retries; i++ {
+		if _, ok := err.(CASError); ok {
+			rc, err = s.innerCreate(manifest, nodeSelector, podLabels)
+		} else {
+			break
+		}
+	}
 	if err != nil {
 		return fields.RC{}, err
 	}
 
+	// labels do not need to be retried, consul applicator does that itself
+	err = s.forEachLabel(rc, func(id, k, v string) error {
+		return s.applicator.SetLabel(labels.RC, rc.ID.String(), k, v)
+	})
+	if err != nil {
+		return fields.RC{}, err
+	}
+
+	return rc, nil
+}
+
+// these parts of Create may require a retry
+func (s *consulStore) innerCreate(manifest pods.Manifest, nodeSelector labels.Selector, podLabels labels.Set) (fields.RC, error) {
+	id := fields.ID(uuid.New())
+	rcp := kp.RCPath(id.String())
 	rc := fields.RC{
 		ID:              id,
 		Manifest:        manifest,
@@ -66,59 +90,46 @@ func (s *consulStore) Create(manifest pods.Manifest, nodeSelector labels.Selecto
 		Disabled:        false,
 	}
 
-	err = s.forEachLabel(rc, func(id, k, v string) error {
-		return s.applicator.SetLabel(labels.RC, id, k, v)
-	})
-
-	// TODO: If the `put` operations fail, we have already labeled the RC,
-	// yet the RC will not exist in the backing Consul KV store.
-	// The labels may have to be cleaned up.
-
-	err = s.put(id, []kvPair{
-		kvPair{key: "disabled", value: []byte("false")},
-		kvPair{key: "node_selector", value: []byte(nodeSelector.String())},
-		kvPair{key: "pod_labels", value: []byte(podLabels.String())},
-		kvPair{key: "pod_manifest", value: buf.Bytes()},
-		kvPair{key: "replicas_desired", value: []byte("0")},
-	})
-
+	jsonRC, err := json.Marshal(rc)
 	if err != nil {
 		return fields.RC{}, err
 	}
+	success, _, err := s.kv.CAS(&api.KVPair{
+		Key:   rcp,
+		Value: jsonRC,
+		// the chance of the UUID already existing is vanishingly small, but
+		// technically not impossible, so we should use the CAS index to guard
+		// against duplicate UUIDs
+		ModifyIndex: 0,
+	}, nil)
 
+	if err != nil {
+		return fields.RC{}, kp.NewKVError("cas", rcp, err)
+	}
+	if !success {
+		return fields.RC{}, CASError(rcp)
+	}
 	return rc, nil
 }
 
 func (s *consulStore) Get(id fields.ID) (fields.RC, error) {
-	listed, _, err := s.kv.List(kp.RCPath(id.String()), nil)
+	kvp, _, err := s.kv.Get(kp.RCPath(id.String()), nil)
 	if err != nil {
+		return fields.RC{}, err
+	}
+	if kvp == nil {
+		// ID didn't exist
 		return fields.RC{}, nil
 	}
-
-	rcMap := s.kvpsToRcs(listed)
-
-	rc, ok := rcMap[id]
-	if !ok {
-		return fields.RC{}, fmt.Errorf("No such replication controller %s", id)
-	}
-
-	return *rc, nil
+	return s.kvpToRC(kvp)
 }
 
 func (s *consulStore) List() ([]fields.RC, error) {
 	listed, _, err := s.kv.List(kp.RC_TREE, nil)
 	if err != nil {
-		return []fields.RC{}, nil
+		return nil, err
 	}
-
-	rcMap := s.kvpsToRcs(listed)
-	rcs := make([]fields.RC, 0)
-
-	for _, rc := range rcMap {
-		rcs = append(rcs, *rc)
-	}
-
-	return rcs, nil
+	return s.kvpsToRCs(listed)
 }
 
 func (s *consulStore) WatchNew(quit <-chan struct{}) (<-chan []fields.RC, <-chan error) {
@@ -143,18 +154,39 @@ func (s *consulStore) WatchNew(quit <-chan struct{}) (<-chan []fields.RC, <-chan
 					errCh <- err
 				} else {
 					currentIndex = meta.LastIndex
-					rcMap := s.kvpsToRcs(listed)
-					rcs := make([]fields.RC, 0, len(rcMap))
-					for _, rc := range rcMap {
-						rcs = append(rcs, *rc)
+					out, err := s.kvpsToRCs(listed)
+					if err != nil {
+						errCh <- err
+					} else {
+						outCh <- out
 					}
-					outCh <- rcs
 				}
 			}
 		}
 	}()
 
 	return outCh, errCh
+}
+
+func (s *consulStore) kvpToRC(kvp *api.KVPair) (fields.RC, error) {
+	rc := fields.RC{
+		// cannot unmarshal into a nil interface - have to initialize to something
+		Manifest: pods.NewManifestBuilder().GetManifest(),
+	}
+	err := json.Unmarshal(kvp.Value, &rc)
+	return rc, err
+}
+
+func (s *consulStore) kvpsToRCs(l api.KVPairs) ([]fields.RC, error) {
+	ret := make([]fields.RC, 0, len(l))
+	for _, kvp := range l {
+		rc, err := s.kvpToRC(kvp)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, rc)
+	}
+	return ret, nil
 }
 
 // TODO: refactor pkg/kp/lock.go and pkg/kp/session.go into their own package,
@@ -171,39 +203,92 @@ func (s *consulStore) Lock(id fields.ID, session string) (bool, error) {
 }
 
 func (s *consulStore) Disable(id fields.ID) error {
-	if err := s.verifyExists(id); err != nil {
-		return err
-	}
-	return s.putOne(id, "disabled", []byte("true"))
+	return s.retryMutate(id, func(rc fields.RC) fields.RC {
+		rc.Disabled = true
+		return rc
+	})
 }
 
 func (s *consulStore) SetDesiredReplicas(id fields.ID, n int) error {
-	if err := s.verifyExists(id); err != nil {
-		return err
-	}
-	return s.putOne(id, "replicas_desired", []byte(strconv.Itoa(n)))
+	return s.retryMutate(id, func(rc fields.RC) fields.RC {
+		rc.ReplicasDesired = n
+		return rc
+	})
 }
 
 func (s *consulStore) Delete(id fields.ID) error {
-	rc, err := s.Get(id)
+	return s.retryMutate(id, nil)
+}
+
+// TODO: this function is almost a verbatim copy of pkg/labels retryMutate, can
+// we find some way to combine them?
+func (s *consulStore) retryMutate(id fields.ID, mutator func(fields.RC) fields.RC) error {
+	err := s.mutateRc(id, mutator)
+	for i := 0; i < s.retries; i++ {
+		if _, ok := err.(CASError); ok {
+			err = s.mutateRc(id, mutator)
+		} else {
+			break
+		}
+	}
+	return err
+}
+
+// performs a safe (ie check-and-set) mutation of the rc with the given id,
+// using the given function
+// pass nil function to delete
+func (s *consulStore) mutateRc(id fields.ID, mutator func(fields.RC) fields.RC) error {
+	rcp := kp.RCPath(id.String())
+	kvp, meta, err := s.kv.Get(rcp, nil)
 	if err != nil {
 		return err
 	}
-
-	if rc.ReplicasDesired != 0 {
-		return fmt.Errorf("Replication controller %s has %d desired replicas, must be 0 before can be deleted", id, rc.ReplicasDesired)
+	if kvp == nil {
+		return fmt.Errorf("replication controller %s does not exist", id)
 	}
 
-	_, err = s.kv.DeleteTree(kp.RCPath(id.String()), nil)
+	rc, err := s.kvpToRC(kvp)
 	if err != nil {
 		return err
 	}
+	newKVP := &api.KVPair{
+		Key:         rcp,
+		ModifyIndex: meta.LastIndex,
+	}
 
-	// TODO: If this fails, then we have some dangling labels.
-	// Perhaps they can be cleaned up later.
-	return s.forEachLabel(rc, func(id, k, _ string) error {
-		return s.applicator.RemoveLabel(labels.RC, id, k)
-	})
+	var success bool
+	if mutator != nil {
+		newRC := mutator(rc)
+		b, err := json.Marshal(newRC)
+		if err != nil {
+			return err
+		}
+		newKVP.Value = b
+		success, _, err = s.kv.CAS(newKVP, nil)
+	} else {
+		// special logic for the delete case
+		if rc.ReplicasDesired != 0 {
+			return fmt.Errorf("replication controller %s has %d desired replicas (must reduce to 0 before deleting)", id, rc.ReplicasDesired)
+		}
+
+		// TODO: If this fails, then we have some dangling labels.
+		// Perhaps they can be cleaned up later.
+		err = s.forEachLabel(rc, func(id, k, _ string) error {
+			return s.applicator.RemoveLabel(labels.RC, id, k)
+		})
+		if err != nil {
+			return err
+		}
+		success, _, err = s.kv.DeleteCAS(newKVP, nil)
+	}
+
+	if err != nil {
+		return err
+	}
+	if !success {
+		return CASError(rcp)
+	}
+	return nil
 }
 
 func (s *consulStore) Watch(rc *fields.RC, quit <-chan struct{}) (<-chan struct{}, <-chan error) {
@@ -220,18 +305,25 @@ func (s *consulStore) Watch(rc *fields.RC, quit <-chan struct{}) (<-chan struct{
 			case <-quit:
 				return
 			case <-time.After(1 * time.Second):
-				pairs, meta, err := s.kv.List(kp.RCPath(rc.ID.String()), &api.QueryOptions{
+				kvp, meta, err := s.kv.Get(kp.RCPath(rc.ID.String()), &api.QueryOptions{
 					WaitIndex: curIndex,
 				})
 				if err != nil {
 					errors <- err
 				} else {
 					curIndex = meta.LastIndex
+					if kvp == nil {
+						// seems this RC got deleted from under us. quitting
+						// would be unexpected, so we'll just wait for it to
+						// reappear in consul
+						continue
+					}
 
-					rcMap := s.kvpsToRcs(pairs)
-
-					if newRc, ok := rcMap[rc.ID]; ok {
-						*rc = *newRc
+					newRC, err := s.kvpToRC(kvp)
+					if err != nil {
+						errors <- err
+					} else {
+						*rc = newRC
 						updated <- struct{}{}
 					}
 				}
@@ -240,104 +332,6 @@ func (s *consulStore) Watch(rc *fields.RC, quit <-chan struct{}) (<-chan struct{
 	}()
 
 	return updated, errors
-}
-
-func (s *consulStore) putOne(id fields.ID, key string, value []byte) error {
-	p := &api.KVPair{Key: kp.RCPath(id.String(), key), Value: value}
-	_, err := s.kv.Put(p, nil)
-	return err
-}
-
-// consulPut attempts to put multiple KV Pairs into consul, returning an error if any fail.
-// For now, this performs no CAS or other locking.
-// It is assumed that only one process will be writing to an RC at a time.
-func (s *consulStore) put(id fields.ID, pairs []kvPair) error {
-	for _, pair := range pairs {
-		if err := s.putOne(id, pair.key, pair.value); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (s *consulStore) verifyExists(id fields.ID) error {
-	keys, _, err := s.kv.Keys(kp.RCPath(id.String()), "", nil)
-	if err != nil {
-		return err
-	}
-	if len(keys) == 0 {
-		return fmt.Errorf("No such replication controller %s", id)
-	}
-	return nil
-}
-
-func (s *consulStore) kvpsToRcs(kvps api.KVPairs) map[fields.ID]*fields.RC {
-	rcs := make(map[fields.ID]*fields.RC)
-
-	for _, kvp := range kvps {
-		// The key will be of the form replication_controllers/ID/rckey
-		parts := strings.SplitN(kvp.Key, "/", 3)
-		if len(parts) < 3 {
-			s.logger.NoFields().Infof("Ignoring unexpected key %s", kvp.Key)
-			continue
-		}
-		id := fields.ID(parts[1])
-		if _, ok := rcs[id]; !ok {
-			rcs[id] = &fields.RC{Id: id}
-		}
-
-		switch parts[2] {
-
-		case "disabled":
-			rcs[id].Disabled = string(kvp.Value) == "true"
-
-		case "node_selector":
-			nodeSelector, err := labels.Parse(string(kvp.Value))
-			if err == nil {
-				rcs[id].NodeSelector = nodeSelector
-			} else {
-				s.logger.WithError(err).Warnf("%s: Can't unmarshal %s, ignoring", parts[2], kvp.Value)
-			}
-
-		case "pod_labels":
-			// I don't think there's a way to parse a selector string into a label set, so we have to do it ourselves?!
-			labels := make(labels.Set)
-			splits := strings.Split(string(kvp.Value), ",")
-			for i, split := range splits {
-				parts := strings.SplitN(split, "=", 2)
-				if len(parts) < 2 {
-					s.logger.NoFields().Warnf(
-						"%s: Can't unmarshal part %d (%s) out of %d (%s), ignoring",
-						parts[2], i, split, len(splits), kvp.Value,
-					)
-					continue
-				}
-				labels[parts[0]] = parts[1]
-			}
-			rcs[id].PodLabels = labels
-
-		case "pod_manifest":
-			manifest, err := pods.ManifestFromBytes(kvp.Value)
-			if err == nil {
-				rcs[id].Manifest = manifest
-			} else {
-				s.logger.WithError(err).Warnf("%s: Can't unmarshal %s, ignoring", parts[2], kvp.Value)
-			}
-
-		case "replicas_desired":
-			i, err := strconv.Atoi(string(kvp.Value))
-			if err == nil {
-				rcs[id].ReplicasDesired = i
-			} else {
-				s.logger.WithError(err).Warnf("%s: Can't unmarshal %s, ignoring", parts[2], kvp.Value)
-			}
-
-		default:
-			s.logger.NoFields().Infof("Ignoring unexpcted key %s", kvp.Key)
-		}
-	}
-
-	return rcs
 }
 
 // forEachLabel Attempts to apply the supplied function to labels of the replication controller.

--- a/pkg/kp/rcstore/fake_store.go
+++ b/pkg/kp/rcstore/fake_store.go
@@ -38,7 +38,7 @@ func (s *fakeStore) Create(manifest pods.Manifest, nodeSelector labels.Selector,
 
 	entry := fakeEntry{
 		RC: fields.RC{
-			Id:              id,
+			ID:              id,
 			Manifest:        manifest,
 			NodeSelector:    nodeSelector,
 			PodLabels:       podLabels,
@@ -136,7 +136,7 @@ func (s *fakeStore) Delete(id fields.ID) error {
 
 func (s *fakeStore) Watch(rc *fields.RC, quit <-chan struct{}) (<-chan struct{}, <-chan error) {
 	updatesOut := make(chan struct{})
-	entry, ok := s.rcs[rc.Id]
+	entry, ok := s.rcs[rc.ID]
 	if !ok {
 		errors := make(chan error, 1)
 		errors <- util.Errorf("Nonexistent RC")

--- a/pkg/labels/consul_applicator.go
+++ b/pkg/labels/consul_applicator.go
@@ -18,7 +18,7 @@ type CASError struct {
 }
 
 func (e CASError) Error() string {
-	return fmt.Sprintf("Could not compare-and-set key %q", e.Key)
+	return fmt.Sprintf("Could not check-and-set key %q", e.Key)
 }
 
 type consulKV interface {

--- a/pkg/rc/fields/fields.go
+++ b/pkg/rc/fields/fields.go
@@ -12,7 +12,7 @@ func (id ID) String() string {
 }
 
 type RC struct {
-	Id              ID
+	ID              ID
 	Manifest        pods.Manifest
 	NodeSelector    labels.Selector
 	PodLabels       labels.Set

--- a/pkg/rc/fields/fields.go
+++ b/pkg/rc/fields/fields.go
@@ -1,6 +1,8 @@
 package fields
 
 import (
+	"encoding/json"
+
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/pods"
 )
@@ -19,3 +21,74 @@ type RC struct {
 	ReplicasDesired int
 	Disabled        bool
 }
+
+type jsonRC struct {
+	ID              ID
+	Manifest        string
+	NodeSelector    string
+	PodLabels       labels.Set
+	ReplicasDesired int
+	Disabled        bool
+}
+
+// the RC struct contains interfaces (pods.Manifest, labels.Selector), and
+// unmarshaling into a nil, non-empty interface is impossible (unless the value
+// is a JSON null), because the unmarshaler doesn't know what structure to
+// allocate there
+// we own pods.Manifest, but we don't own labels.Selector, so we have to
+// implement the json marshaling here to wrap around the interface values
+func (rc RC) MarshalJSON() ([]byte, error) {
+	var manifest []byte
+	var err error
+	if rc.Manifest != nil {
+		manifest, err = rc.Manifest.Marshal()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var nodeSel string
+	if rc.NodeSelector != nil {
+		nodeSel = rc.NodeSelector.String()
+	}
+
+	return json.Marshal(jsonRC{
+		ID:              rc.ID,
+		Manifest:        string(manifest),
+		NodeSelector:    nodeSel,
+		PodLabels:       rc.PodLabels,
+		ReplicasDesired: rc.ReplicasDesired,
+		Disabled:        rc.Disabled,
+	})
+}
+
+var _ json.Marshaler = RC{}
+
+func (rc *RC) UnmarshalJSON(b []byte) error {
+	var jrc jsonRC
+	if err := json.Unmarshal(b, &jrc); err != nil {
+		return err
+	}
+
+	m, err := pods.ManifestFromBytes([]byte(jrc.Manifest))
+	if err != nil {
+		return err
+	}
+
+	nodeSel, err := labels.Parse(jrc.NodeSelector)
+	if err != nil {
+		return err
+	}
+
+	*rc = RC{
+		ID:              jrc.ID,
+		Manifest:        m,
+		NodeSelector:    nodeSel,
+		PodLabels:       jrc.PodLabels,
+		ReplicasDesired: jrc.ReplicasDesired,
+		Disabled:        rc.Disabled,
+	}
+	return nil
+}
+
+var _ json.Unmarshaler = &RC{}

--- a/pkg/rc/fields/fields_test.go
+++ b/pkg/rc/fields/fields_test.go
@@ -1,0 +1,32 @@
+package fields_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "github.com/square/p2/Godeps/_workspace/src/github.com/anthonybishopric/gotcha"
+	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/rc/fields"
+)
+
+func TestJSONMarshal(t *testing.T) {
+	mb := pods.NewManifestBuilder()
+	mb.SetID("hello")
+	m := mb.GetManifest()
+
+	f := &fields.RC{
+		ID:       "hello",
+		Manifest: m,
+	}
+
+	b, err := json.Marshal(f)
+	Assert(t).IsNil(err, "should have marshaled")
+	Assert(t).AreEqual(string(b),
+		`{"ID":"hello","Manifest":"id: hello\nlaunchables: {}\nconfig: {}\n","NodeSelector":"","PodLabels":null,"ReplicasDesired":0,"Disabled":false}`,
+		"should have marshaled to equal values")
+
+	err = json.Unmarshal(b, f)
+	Assert(t).IsNil(err, "should have unmarshaled")
+	Assert(t).AreEqual(f.ID.String(), "hello", "should have unmarshaled to hello")
+	Assert(t).AreEqual(f.Manifest.ID(), "hello", "should have unmarshaled manifest to hello")
+}

--- a/pkg/rc/replication_controller.go
+++ b/pkg/rc/replication_controller.go
@@ -19,7 +19,7 @@ const (
 )
 
 type ReplicationController interface {
-	Id() fields.ID
+	ID() fields.ID
 
 	// WatchDesires causes the replication controller to watch for any changes to its desired state.
 	// It is expected that a replication controller is aware of a backing rcstore against which to perform this watch.
@@ -75,8 +75,8 @@ func New(
 	}
 }
 
-func (rc *replicationController) Id() fields.ID {
-	return rc.RC.Id
+func (rc *replicationController) ID() fields.ID {
+	return rc.RC.ID
 }
 
 func (rc *replicationController) WatchDesires(quit <-chan struct{}) <-chan error {
@@ -184,7 +184,7 @@ func (rc *replicationController) eligibleNodes() ([]string, error) {
 }
 
 func (rc *replicationController) CurrentNodes() ([]string, error) {
-	selector := labels.Everything().Add(rcIdLabel, labels.EqualsOperator, []string{rc.Id().String()})
+	selector := labels.Everything().Add(rcIdLabel, labels.EqualsOperator, []string{rc.ID().String()})
 
 	pods, err := rc.podApplicator.GetMatches(selector, labels.POD)
 	if err != nil {
@@ -220,7 +220,7 @@ func (rc *replicationController) forEachLabel(node string, f func(id, k, v strin
 	if err := f(id, podIdLabel, rc.Manifest.ID()); err != nil {
 		return err
 	}
-	return f(id, rcIdLabel, rc.Id().String())
+	return f(id, rcIdLabel, rc.ID().String())
 }
 
 func (rc *replicationController) schedule(node string) error {

--- a/pkg/rc/replication_controller_test.go
+++ b/pkg/rc/replication_controller_test.go
@@ -102,7 +102,7 @@ func TestCantSchedule(t *testing.T) {
 	quit := make(chan struct{})
 	errors := rc.WatchDesires(quit)
 
-	rcStore.SetDesiredReplicas(rc.Id(), 1)
+	rcStore.SetDesiredReplicas(rc.ID(), 1)
 
 	select {
 	case <-errors:
@@ -125,7 +125,7 @@ func TestSchedule(t *testing.T) {
 	quit := make(chan struct{})
 	rc.WatchDesires(quit)
 
-	rcStore.SetDesiredReplicas(rc.Id(), 1)
+	rcStore.SetDesiredReplicas(rc.ID(), 1)
 	numNodes := waitForNodes(t, rc, 1)
 	Assert(t).AreEqual(numNodes, 1, "took too long to schedule")
 
@@ -150,7 +150,7 @@ func TestSchedulePartial(t *testing.T) {
 	quit := make(chan struct{})
 	errors := rc.WatchDesires(quit)
 
-	rcStore.SetDesiredReplicas(rc.Id(), 2)
+	rcStore.SetDesiredReplicas(rc.ID(), 2)
 	numNodes := waitForNodes(t, rc, 1)
 	Assert(t).AreEqual(numNodes, 1, "took too long to schedule")
 
@@ -182,11 +182,11 @@ func TestScheduleTwice(t *testing.T) {
 	quit := make(chan struct{})
 	rc.WatchDesires(quit)
 
-	rcStore.SetDesiredReplicas(rc.Id(), 1)
+	rcStore.SetDesiredReplicas(rc.ID(), 1)
 	numNodes := waitForNodes(t, rc, 1)
 	Assert(t).AreEqual(numNodes, 1, "took too long to schedule first")
 
-	rcStore.SetDesiredReplicas(rc.Id(), 2)
+	rcStore.SetDesiredReplicas(rc.ID(), 2)
 	numNodes = waitForNodes(t, rc, 2)
 	Assert(t).AreEqual(numNodes, 2, "took too long to schedule second")
 
@@ -218,7 +218,7 @@ func TestUnschedule(t *testing.T) {
 	quit := make(chan struct{})
 	rc.WatchDesires(quit)
 
-	rcStore.SetDesiredReplicas(rc.Id(), 1)
+	rcStore.SetDesiredReplicas(rc.ID(), 1)
 	numNodes := waitForNodes(t, rc, 1)
 	Assert(t).AreEqual(numNodes, 1, "took too long to schedule")
 
@@ -226,7 +226,7 @@ func TestUnschedule(t *testing.T) {
 	Assert(t).AreEqual(len(scheduled), 1, "expected a pod to have been labeled")
 	Assert(t).AreEqual(len(kp.manifests), 1, "expected a manifest to have been scheduled")
 
-	rcStore.SetDesiredReplicas(rc.Id(), 0)
+	rcStore.SetDesiredReplicas(rc.ID(), 0)
 	numNodes = waitForNodes(t, rc, 0)
 	Assert(t).AreEqual(numNodes, 0, "took too long to unschedule")
 


### PR DESCRIPTION
Replication controllers are stored in a single key now with CAS mutation. The similarity to the pkg/labels API is remarkable.

Might have other stuff incoming on this PR. Have not tested yet, but am about to do so.