### PR TITLE
Make hoist.Launchable.fetcher an unexported field

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -27,7 +27,7 @@ type Launchable struct {
 	Id               string         // A unique identifier for this launchable, used when creating runit services
 	RunAs            string         // The user to assume when launching the executable
 	ConfigDir        string         // The value for chpst -e. See http://smarden.org/runit/chpst.8.html
-	Fetcher          uri.Fetcher    // Callback that downloads the file from the remote location.
+	fetcher          uri.Fetcher    // Callback that downloads the file from the remote location.
 	RootDir          string         // The root directory of the launchable, containing N:N>=1 installs.
 	P2exec           string         // The path to p2-exec
 	CgroupConfig     cgroups.Config // Cgroup parameters to use with p2-exec
@@ -45,7 +45,7 @@ func (a LaunchAdapter) ID() string {
 }
 
 func (a LaunchAdapter) Fetcher() uri.Fetcher {
-	return a.Launchable.Fetcher
+	return a.Launchable.fetcher
 }
 
 var _ launch.Launchable = &LaunchAdapter{}
@@ -267,7 +267,7 @@ func (hl *Launchable) Install() error {
 	}
 	defer os.Remove(artifactFile.Name())
 	defer artifactFile.Close()
-	remoteData, err := hl.Fetcher.Open(hl.Location)
+	remoteData, err := hl.fetcher.Open(hl.Location)
 	if err != nil {
 		return err
 	}
@@ -357,4 +357,8 @@ func (hl *Launchable) flipSymlink(newLinkPath string) error {
 func (hl *Launchable) InstallDir() string {
 	launchableName := hl.Version()
 	return filepath.Join(hl.RootDir, "installs", launchableName)
+}
+
+func (hl *Launchable) SetFetcher(fetcher uri.Fetcher) {
+	hl.fetcher = fetcher
 }

--- a/pkg/hoist/hoist_launchable_test.go
+++ b/pkg/hoist/hoist_launchable_test.go
@@ -33,7 +33,7 @@ func TestInstall(t *testing.T) {
 		Id:        "hello",
 		RunAs:     currentUser.Username,
 		ConfigDir: launchableHome,
-		Fetcher:   fetcher,
+		fetcher:   fetcher,
 		RootDir:   launchableHome,
 	}
 
@@ -64,7 +64,7 @@ func TestInstallDir(t *testing.T) {
 		Id:        "testLaunchable",
 		RunAs:     "testuser",
 		ConfigDir: tempDir,
-		Fetcher:   uri.DefaultFetcher,
+		fetcher:   uri.DefaultFetcher,
 		RootDir:   tempDir,
 	}
 

--- a/pkg/hoist/test_helper.go
+++ b/pkg/hoist/test_helper.go
@@ -20,7 +20,7 @@ func FakeHoistLaunchableForDir(dirName string) (*Launchable, *runit.ServiceBuild
 		Id:        "testPod__testLaunchable",
 		RunAs:     "testPod",
 		ConfigDir: tempDir,
-		Fetcher:   uri.DefaultFetcher,
+		fetcher:   uri.DefaultFetcher,
 		RootDir:   launchableInstallDir,
 		P2exec:    util.From(runtime.Caller(0)).ExpandPath("fake_p2-exec"),
 	}

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -548,13 +548,13 @@ func (pod *Pod) getLaunchable(launchableStanza LaunchableStanza, runAsUser strin
 			Id:               launchableId,
 			RunAs:            runAsUser,
 			ConfigDir:        pod.EnvDir(),
-			Fetcher:          uri.DefaultFetcher,
 			RootDir:          launchableRootDir,
 			P2exec:           pod.P2exec,
 			RestartTimeout:   restartTimeout,
 			CgroupConfig:     launchableStanza.CgroupConfig,
 			CgroupConfigName: launchableStanza.LaunchableId,
 		}
+		ret.SetFetcher(uri.DefaultFetcher)
 		ret.CgroupConfig.Name = ret.Id
 		return ret.If(), nil
 	} else {


### PR DESCRIPTION
This allows an interface conversion from launch.Launchable to
hoist.Launchable. The naming clash between the Fetcher() function on the
launch.Launchable() interface and the field on hoist.Launchable
prevented this previously.