### PR TITLE
Rename Fetcher() on launch.Launchable to GetFetcher()

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -44,7 +44,7 @@ func (a LaunchAdapter) ID() string {
 	return a.Launchable.Id
 }
 
-func (a LaunchAdapter) Fetcher() uri.Fetcher {
+func (a LaunchAdapter) GetFetcher() uri.Fetcher {
 	return a.Launchable.Fetcher
 }
 

--- a/pkg/launch/launchable.go
+++ b/pkg/launch/launchable.go
@@ -26,8 +26,10 @@ type Launchable interface {
 	Executables(serviceBuilder *runit.ServiceBuilder) ([]Executable, error)
 	// Installed returns true if this launchable is already installed.
 	Installed() bool
-	// Fetcher returns a uri.Fetcher that is capable of fetching the launchable files.
-	Fetcher() uri.Fetcher
+	// GetFetcher returns a uri.Fetcher that is capable of fetching the launchable files.
+	// It is prefixed with Get (non-idiomatic) to avoid a name collision with the Fetcher
+	// field in hoist.Launchable which prevents interface conversions.
+	GetFetcher() uri.Fetcher
 
 	// Install acquires the launchable and makes it ready to be launched.
 	Install() error

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -396,7 +396,7 @@ func (pod *Pod) Verify(manifest Manifest, authPolicy auth.Policy) error {
 
 		// Retrieve the digest data
 		launchableDigest, err := digest.ParseUris(
-			launchable.Fetcher(),
+			launchable.GetFetcher(),
 			stanza.DigestLocation,
 			stanza.DigestSignatureLocation,
 		)


### PR DESCRIPTION
This allows interface conversions from launch.Launchable to
hoist.Launchable. Previously this was impossible because
hoist.Launchable exports a field named Fetcher which collides with the
function name