### PR TITLE
Let tgz extractor preserve tar ownership info

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -281,9 +281,10 @@ func (hl *Launchable) Install() error {
 		return err
 	}
 
-	err = gzip.ExtractTarGz(hl.RunAs, artifactFile, hl.Version(), hl.InstallDir())
+	err = gzip.ExtractTarGz(hl.RunAs, artifactFile, hl.InstallDir())
 	if err != nil {
 		os.RemoveAll(hl.InstallDir())
+		return util.Errorf("extracting %s: %s", hl.Version(), err)
 	}
 	return err
 }


### PR DESCRIPTION
Changes the ExtractTarGz() function to create each file with its original
owner, as recorded in the TAR file, when no owner is specified. This will
be used when extracting container filesystems.