### PR TITLE
Remove the necessity for LaunchAdapter by implementing launch.Launchable

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -27,7 +27,7 @@ type Launchable struct {
 	Id               string         // A unique identifier for this launchable, used when creating runit services
 	RunAs            string         // The user to assume when launching the executable
 	ConfigDir        string         // The value for chpst -e. See http://smarden.org/runit/chpst.8.html
-	Fetcher          uri.Fetcher    // Callback that downloads the file from the remote location.
+	Fetcher_         uri.Fetcher    // Callback that downloads the file from the remote location.
 	RootDir          string         // The root directory of the launchable, containing N:N>=1 installs.
 	P2exec           string         // The path to p2-exec
 	CgroupConfig     cgroups.Config // Cgroup parameters to use with p2-exec
@@ -35,24 +35,12 @@ type Launchable struct {
 	RestartTimeout   time.Duration  // How long to wait when restarting the services in this launchable.
 }
 
-// LaunchAdapter adapts a hoist.Launchable to the launch.Launchable interface.
-type LaunchAdapter struct {
-	*Launchable
+func (hl *Launchable) ID() string {
+	return hl.Id
 }
 
-func (a LaunchAdapter) ID() string {
-	return a.Launchable.Id
-}
-
-func (a LaunchAdapter) Fetcher() uri.Fetcher {
-	return a.Launchable.Fetcher
-}
-
-var _ launch.Launchable = &LaunchAdapter{}
-
-// If adapts the hoist Launchable to the launch.Launchable interface.
-func (hl *Launchable) If() launch.Launchable {
-	return LaunchAdapter{Launchable: hl}
+func (hl *Launchable) Fetcher() uri.Fetcher {
+	return hl.Fetcher_
 }
 
 func (hl *Launchable) Halt(serviceBuilder *runit.ServiceBuilder, sv *runit.SV) error {
@@ -267,7 +255,7 @@ func (hl *Launchable) Install() error {
 	}
 	defer os.Remove(artifactFile.Name())
 	defer artifactFile.Close()
-	remoteData, err := hl.Fetcher.Open(hl.Location)
+	remoteData, err := hl.Fetcher_.Open(hl.Location)
 	if err != nil {
 		return err
 	}

--- a/pkg/hoist/hoist_launchable_test.go
+++ b/pkg/hoist/hoist_launchable_test.go
@@ -33,7 +33,7 @@ func TestInstall(t *testing.T) {
 		Id:        "hello",
 		RunAs:     currentUser.Username,
 		ConfigDir: launchableHome,
-		Fetcher:   fetcher,
+		Fetcher_:  fetcher,
 		RootDir:   launchableHome,
 	}
 
@@ -64,7 +64,7 @@ func TestInstallDir(t *testing.T) {
 		Id:        "testLaunchable",
 		RunAs:     "testuser",
 		ConfigDir: tempDir,
-		Fetcher:   uri.DefaultFetcher,
+		Fetcher_:  uri.DefaultFetcher,
 		RootDir:   tempDir,
 	}
 

--- a/pkg/hoist/test_helper.go
+++ b/pkg/hoist/test_helper.go
@@ -20,7 +20,7 @@ func FakeHoistLaunchableForDir(dirName string) (*Launchable, *runit.ServiceBuild
 		Id:        "testPod__testLaunchable",
 		RunAs:     "testPod",
 		ConfigDir: tempDir,
-		Fetcher:   uri.DefaultFetcher,
+		Fetcher_:  uri.DefaultFetcher,
 		RootDir:   launchableInstallDir,
 		P2exec:    util.From(runtime.Caller(0)).ExpandPath("fake_p2-exec"),
 	}

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -548,7 +548,7 @@ func (pod *Pod) getLaunchable(launchableStanza LaunchableStanza, runAsUser strin
 			Id:               launchableId,
 			RunAs:            runAsUser,
 			ConfigDir:        pod.EnvDir(),
-			Fetcher:          uri.DefaultFetcher,
+			Fetcher_:         uri.DefaultFetcher,
 			RootDir:          launchableRootDir,
 			P2exec:           pod.P2exec,
 			RestartTimeout:   restartTimeout,
@@ -556,7 +556,7 @@ func (pod *Pod) getLaunchable(launchableStanza LaunchableStanza, runAsUser strin
 			CgroupConfigName: launchableStanza.LaunchableId,
 		}
 		ret.CgroupConfig.Name = ret.Id
-		return ret.If(), nil
+		return ret, nil
 	} else {
 		err := fmt.Errorf("launchable type '%s' is not supported yet", launchableStanza.LaunchableType)
 		pod.logLaunchableError(launchableStanza.LaunchableId, err, "Unknown launchable type")

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -49,7 +49,7 @@ func TestGetLaunchable(t *testing.T) {
 	Assert(t).AreNotEqual(0, len(launchableStanzas), "Expected there to be at least one launchable stanza in the test manifest")
 	for _, stanza := range launchableStanzas {
 		l, _ := pod.getLaunchable(stanza, "foouser")
-		launchable := l.(hoist.LaunchAdapter).Launchable
+		launchable := l.(*hoist.Launchable)
 		Assert(t).AreEqual("hello__hello", launchable.Id, "LaunchableId did not have expected value")
 		Assert(t).AreEqual("hoisted-hello_def456.tar.gz", launchable.Location, "Launchable location did not have expected value")
 		Assert(t).AreEqual("foouser", launchable.RunAs, "Launchable run as did not have expected username")
@@ -245,7 +245,7 @@ func TestBuildRunitServices(t *testing.T) {
 
 	Assert(t).IsNil(err, "Got an unexpected error when attempting to start runit services")
 
-	pod.buildRunitServices([]launch.Launchable{hl.If()})
+	pod.buildRunitServices([]launch.Launchable{hl})
 	f, err := os.Open(outFilePath)
 	defer f.Close()
 	bytes, err := ioutil.ReadAll(f)


### PR DESCRIPTION
in hoist.Launchable.

This has the benefit of allowing interface conversions from
launch.Launchable to hoist.Launchable directly instead of going through
hoist.LaunchAdapter