### PR TITLE
Make the -n flag to p2-exec configurable via hoist.Launchable struct

### DIFF
--- a/pkg/hoist/test_helper.go
+++ b/pkg/hoist/test_helper.go
@@ -22,7 +22,7 @@ func FakeHoistLaunchableForDir(dirName string) (*Launchable, *runit.ServiceBuild
 		ConfigDir: tempDir,
 		Fetcher:   uri.DefaultFetcher,
 		RootDir:   launchableInstallDir,
-		P2exec:    util.From(runtime.Caller(0)).ExpandPath("fake_p2-exec"),
+		P2Exec:    util.From(runtime.Caller(0)).ExpandPath("fake_p2-exec"),
 	}
 
 	curUser, err := user.Current()

--- a/pkg/p2exec/p2_exec.go
+++ b/pkg/p2exec/p2_exec.go
@@ -1,0 +1,37 @@
+package p2exec
+
+// Struct that can be used to build an invocation of p2-exec with any
+// applicable flags
+type P2ExecArgs struct {
+	User             string
+	EnvDir           string
+	NoLimits         bool
+	CgroupName       string
+	CgroupConfigName string
+	Command          string
+}
+
+func (args P2ExecArgs) CommandLine() []string {
+	var cmd []string
+	if args.NoLimits {
+		cmd = append(cmd, "-n")
+	}
+
+	if args.User != "" {
+		cmd = append(cmd, "-u", args.User)
+	}
+
+	if args.EnvDir != "" {
+		cmd = append(cmd, "-e", args.EnvDir)
+	}
+
+	if args.CgroupConfigName != "" {
+		cmd = append(cmd, "-l", args.CgroupConfigName)
+	}
+
+	if args.CgroupName != "" {
+		cmd = append(cmd, "-c", args.CgroupName)
+	}
+
+	return append(cmd, args.Command)
+}

--- a/pkg/p2exec/p2_exec_test.go
+++ b/pkg/p2exec/p2_exec_test.go
@@ -1,0 +1,33 @@
+package p2exec
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildWithArgs(t *testing.T) {
+	args := P2ExecArgs{
+		Command: "script",
+	}
+
+	expected := "script"
+	actual := strings.Join(args.CommandLine(), " ")
+	if actual != expected {
+		t.Errorf("Expected args.BuildWithArgs() to return '%s', was '%s'", expected, actual)
+	}
+
+	args = P2ExecArgs{
+		Command:          "script",
+		NoLimits:         true,
+		User:             "some_user",
+		EnvDir:           "some_dir",
+		CgroupConfigName: "some_cgroup_config_name",
+		CgroupName:       "cgroup_name",
+	}
+
+	expected = "-n -u some_user -e some_dir -l some_cgroup_config_name -c cgroup_name script"
+	actual = strings.Join(args.CommandLine(), " ")
+	if actual != expected {
+		t.Errorf("Expected args.BuildWithArgs() to return '%s', was '%s'", expected, actual)
+	}
+}

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -44,7 +44,7 @@ type Pod struct {
 	logger         logging.Logger
 	SV             *runit.SV
 	ServiceBuilder *runit.ServiceBuilder
-	P2exec         string
+	P2Exec         string
 	DefaultTimeout time.Duration // this is the default timeout for stopping and restarting services in this pod
 }
 
@@ -55,7 +55,7 @@ func NewPod(id string, path string) *Pod {
 		logger:         Log.SubLogger(logrus.Fields{"pod": id}),
 		SV:             runit.DefaultSV,
 		ServiceBuilder: runit.DefaultBuilder,
-		P2exec:         DefaultP2Exec,
+		P2Exec:         DefaultP2Exec,
 		DefaultTimeout: 60 * time.Second,
 	}
 }
@@ -550,7 +550,8 @@ func (pod *Pod) getLaunchable(launchableStanza LaunchableStanza, runAsUser strin
 			ConfigDir:        pod.EnvDir(),
 			Fetcher:          uri.DefaultFetcher,
 			RootDir:          launchableRootDir,
-			P2exec:           pod.P2exec,
+			P2Exec:           pod.P2Exec,
+			ExecNoLimit:      true,
 			RestartTimeout:   restartTimeout,
 			CgroupConfig:     launchableStanza.CgroupConfig,
 			CgroupConfigName: launchableStanza.LaunchableId,

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -53,6 +53,7 @@ func TestGetLaunchable(t *testing.T) {
 		Assert(t).AreEqual("hello__hello", launchable.Id, "LaunchableId did not have expected value")
 		Assert(t).AreEqual("hoisted-hello_def456.tar.gz", launchable.Location, "Launchable location did not have expected value")
 		Assert(t).AreEqual("foouser", launchable.RunAs, "Launchable run as did not have expected username")
+		Assert(t).IsTrue(launchable.ExecNoLimit, "GetLaunchable() should always set ExecNoLimit to true for hoist launchables")
 	}
 }
 


### PR DESCRIPTION
This allows code utilizing the hoist.Launchable struct as a library to
determine whether p2-exec commands run with the -n (no-limit) flag. This
is useful because the -n flag requires root privileges.