### PR TITLE
Rolling update farms

### DIFF
--- a/bin/p2-rctl/main.go
+++ b/bin/p2-rctl/main.go
@@ -277,6 +277,7 @@ func (r RCtl) RollingUpdate(oldID, newID string, want, need int, deletes bool) {
 	if session == "" {
 		r.logger.NoFields().Fatalln("Could not acquire session")
 	}
+	lock := r.kps.NewUnmanagedLock(session, "")
 
 	u := roll.NewUpdate(roll_fields.Update{
 		OldRC:           rc_fields.ID(oldID),
@@ -284,7 +285,7 @@ func (r RCtl) RollingUpdate(oldID, newID string, want, need int, deletes bool) {
 		DesiredReplicas: want,
 		MinimumReplicas: need,
 		DeletePods:      deletes,
-	}, r.kps, r.rcs, r.hcheck, r.labeler, r.sched, r.logger, session)
+	}, r.kps, r.rcs, r.hcheck, r.labeler, r.sched, r.logger, lock)
 
 	if err := u.Prepare(); err != nil {
 		r.logger.WithError(err).Fatalln("Could not prepare update")

--- a/pkg/kp/constants.go
+++ b/pkg/kp/constants.go
@@ -10,6 +10,7 @@ const (
 	HOOK_TREE    string = "hooks"
 	LOCK_TREE    string = "lock"
 	RC_TREE      string = "replication_controllers"
+	ROLL_TREE    string = "rolls"
 )
 
 func IntentPath(args ...string) string {
@@ -30,4 +31,8 @@ func LockPath(args ...string) string {
 
 func RCPath(args ...string) string {
 	return strings.Join(append([]string{RC_TREE}, args...), "/")
+}
+
+func RollPath(args ...string) string {
+	return strings.Join(append([]string{ROLL_TREE}, args...), "/")
 }

--- a/pkg/kp/kv.go
+++ b/pkg/kp/kv.go
@@ -45,6 +45,7 @@ type Store interface {
 	LockHolder(key string) (string, string, error)
 	DestroyLockHolder(id string) error
 	NewLock(name string, renewalCh <-chan time.Time) (Lock, chan error, error)
+	NewUnmanagedLock(session, name string) Lock
 	NewHealthManager(node string, logger logging.Logger) HealthManager
 }
 

--- a/pkg/kp/rcstore/consul_store.go
+++ b/pkg/kp/rcstore/consul_store.go
@@ -186,25 +186,6 @@ func (s *consulStore) kvpsToRCs(l api.KVPairs) ([]fields.RC, error) {
 	return ret, nil
 }
 
-// TODO: refactor pkg/kp/lock.go and pkg/kp/session.go into their own package,
-// and use that instead of c+ping it here
-// we are intentionally not using kp.Lock, because kp.Lock manages its own
-// session and therefore it cannot cooperate with kp.ConsulSessionManager
-func (s *consulStore) lock(id fields.ID, session, lockType string) (bool, error) {
-	success, _, err := s.kv.Acquire(&api.KVPair{
-		Key:     kp.LockPath(kp.RCPath(id.String(), lockType)),
-		Value:   []byte(session),
-		Session: session,
-	}, nil)
-	return success, err
-}
-func (s *consulStore) LockWrite(id fields.ID, session string) (bool, error) {
-	return s.lock(id, session, "write")
-}
-func (s *consulStore) LockRead(id fields.ID, session string) (bool, error) {
-	return s.lock(id, session, "read")
-}
-
 func (s *consulStore) Disable(id fields.ID) error {
 	return s.retryMutate(id, func(rc fields.RC) (fields.RC, error) {
 		rc.Disabled = true

--- a/pkg/kp/rcstore/fake_store.go
+++ b/pkg/kp/rcstore/fake_store.go
@@ -78,29 +78,6 @@ func (s *fakeStore) WatchNew(quit <-chan struct{}) (<-chan []fields.RC, <-chan e
 	return nil, nil
 }
 
-func (s *fakeStore) LockWrite(id fields.ID, session string) (bool, error) {
-	entry, ok := s.rcs[id]
-	if !ok {
-		return false, util.Errorf("Nonexistent rc")
-	}
-	if entry.lockedWrite == "" {
-		entry.lockedWrite = session
-		return true, nil
-	}
-	return false, nil
-}
-func (s *fakeStore) LockRead(id fields.ID, session string) (bool, error) {
-	entry, ok := s.rcs[id]
-	if !ok {
-		return false, util.Errorf("Nonexistent rc")
-	}
-	if entry.lockedRead == "" {
-		entry.lockedRead = session
-		return true, nil
-	}
-	return false, nil
-}
-
 func (s *fakeStore) Disable(id fields.ID) error {
 	entry, ok := s.rcs[id]
 	if !ok {

--- a/pkg/kp/rcstore/store.go
+++ b/pkg/kp/rcstore/store.go
@@ -23,22 +23,6 @@ type Store interface {
 	// channel.
 	WatchNew(quit <-chan struct{}) (<-chan []fields.RC, <-chan error)
 
-	// Use the given session string (which uniquely identifies the lock holder)
-	// to acquire a lock on the specified replication controller. If the lock
-	// was successfully claimed, return (true, nil). If the request completed
-	// but the lock was already held, return (false, nil). Otherwise return an
-	// appropriate error.
-	//
-	// The lock will be taken against an ephemeral key, so it is safe to use a
-	// session that deletes its keys on invalidation.
-	//
-	// The separate locks are for one reader (who watches the RC and acts when
-	// it changes) and one writer (who mutates the RC to cause those changes).
-	// Each lock may be held by one, and only one, party (readers cannot share
-	// the read lock).
-	LockWrite(id fields.ID, session string) (bool, error)
-	LockRead(id fields.ID, session string) (bool, error)
-
 	// Set the desired replica count for the given RC to the given integer.
 	SetDesiredReplicas(fields.ID, int) error
 	// Add the given integer to the given RC's replica count (bounding at zero).

--- a/pkg/kp/rollstore/store.go
+++ b/pkg/kp/rollstore/store.go
@@ -1,0 +1,141 @@
+package rollstore
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/api"
+
+	"github.com/square/p2/pkg/kp"
+	rcf "github.com/square/p2/pkg/rc/fields"
+	rollf "github.com/square/p2/pkg/roll/fields"
+)
+
+// Store persists Updates into Consul. Updates are uniquely identified by their
+// new RC's ID.
+type Store interface {
+	// retrieve this Update
+	Get(rcf.ID) (rollf.Update, error)
+	// put this Update into the store. Updates are immutable - if another Update
+	// exists with this newRC ID, an error is returned
+	Put(rollf.Update) error
+	// delete this Update from the store
+	Delete(rcf.ID) error
+	// take a lock on this ID. Before taking ownership of an Update, its new RC
+	// ID, and old RC ID if any, should both be locked. If the error return is
+	// nil, then the boolean indicates whether the lock was successfully taken.
+	Lock(rcf.ID, string) (bool, error)
+	// Watch for changes to the store and generate a list of Updates for each
+	// change. This function does not block.
+	Watch(<-chan struct{}) (<-chan []rollf.Update, <-chan error)
+}
+
+type consulStore struct {
+	kv *api.KV
+}
+
+var _ Store = consulStore{}
+
+func NewConsul(c *api.Client) Store {
+	return consulStore{c.KV()}
+}
+
+func (s consulStore) Get(id rcf.ID) (rollf.Update, error) {
+	key := kp.RollPath(id.String())
+	kvp, _, err := s.kv.Get(key, nil)
+	if err != nil {
+		return rollf.Update{}, kp.NewKVError("get", key, err)
+	}
+
+	var ret rollf.Update
+	err = json.Unmarshal(kvp.Value, &ret)
+	if err != nil {
+		return rollf.Update{}, err
+	}
+	return ret, nil
+}
+
+func (s consulStore) Put(u rollf.Update) error {
+	b, err := json.Marshal(u)
+	if err != nil {
+		return err
+	}
+
+	key := kp.RollPath(u.NewRC.String())
+	success, _, err := s.kv.CAS(&api.KVPair{
+		Key:   kp.RollPath(u.NewRC.String()),
+		Value: b,
+		// it must not already exist
+		ModifyIndex: 0,
+	}, nil)
+	if err != nil {
+		return kp.NewKVError("cas", key, err)
+	}
+	if !success {
+		return fmt.Errorf("update with new RC ID %s already exists", u.NewRC)
+	}
+	return nil
+}
+
+func (s consulStore) Delete(id rcf.ID) error {
+	key := kp.RollPath(id.String())
+	_, err := s.kv.Delete(key, nil)
+	if err != nil {
+		return kp.NewKVError("delete", key, err)
+	}
+	return nil
+}
+
+func (s consulStore) Lock(id rcf.ID, session string) (bool, error) {
+	key := kp.LockPath(kp.RollPath(id.String()))
+	success, _, err := s.kv.Acquire(&api.KVPair{
+		Key:     key,
+		Value:   []byte(session),
+		Session: session,
+	}, nil)
+	if err != nil {
+		return false, kp.NewKVError("acquire", key, err)
+	}
+	return success, nil
+}
+
+func (s consulStore) Watch(quit <-chan struct{}) (<-chan []rollf.Update, <-chan error) {
+	outCh := make(chan []rollf.Update)
+	errCh := make(chan error)
+
+	go func() {
+		defer close(outCh)
+		defer close(errCh)
+		var currentIndex uint64 = 0
+		for {
+			select {
+			case <-quit:
+				return
+			case <-time.After(1 * time.Second):
+				listed, meta, err := s.kv.List(kp.ROLL_TREE, &api.QueryOptions{
+					WaitIndex: currentIndex,
+				})
+				if err != nil {
+					errCh <- kp.NewKVError("list", kp.ROLL_TREE, err)
+				} else {
+					currentIndex = meta.LastIndex
+
+					out := make([]rollf.Update, 0, len(listed))
+					for _, kvp := range listed {
+						var next rollf.Update
+						err = json.Unmarshal(kvp.Value, &next)
+						if err != nil {
+							errCh <- err
+						} else {
+							out = append(out, next)
+						}
+					}
+					outCh <- out
+				}
+			}
+		}
+	}()
+
+	return outCh, errCh
+}

--- a/pkg/roll/farm.go
+++ b/pkg/roll/farm.go
@@ -1,0 +1,203 @@
+package roll
+
+import (
+	"github.com/square/p2/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+
+	"github.com/square/p2/pkg/health/checker"
+	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/kp/rcstore"
+	"github.com/square/p2/pkg/kp/rollstore"
+	"github.com/square/p2/pkg/labels"
+	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/rc"
+	"github.com/square/p2/pkg/rc/fields"
+	roll_fields "github.com/square/p2/pkg/roll/fields"
+)
+
+type Factory interface {
+	New(roll_fields.Update, logging.Logger, kp.Lock) Update
+}
+
+type UpdateFactory struct {
+	KPStore       kp.Store
+	RCStore       rcstore.Store
+	HealthChecker checker.ConsulHealthChecker
+	Labeler       labels.Applicator
+	Scheduler     rc.Scheduler
+}
+
+func (f UpdateFactory) New(u roll_fields.Update, l logging.Logger, lock kp.Lock) Update {
+	return NewUpdate(u, f.KPStore, f.RCStore, f.HealthChecker, f.Labeler, f.Scheduler, l, lock)
+}
+
+// The Farm is responsible for spawning and reaping rolling updates as they are
+// added to and deleted from Consul. Multiple farms can exist simultaneously,
+// but each one must hold a different Consul session. This ensures that the
+// farms do not instantiate the same rolling update multiple times.
+type Farm struct {
+	factory  Factory
+	kps      kp.Store
+	rls      rollstore.Store
+	sessions <-chan string
+
+	children map[fields.ID]childRU
+	lock     *kp.Lock
+
+	logger logging.Logger
+}
+
+type childRU struct {
+	ru   Update
+	quit chan<- struct{}
+}
+
+func NewFarm(
+	factory Factory,
+	kps kp.Store,
+	rls rollstore.Store,
+	sessions <-chan string,
+	logger logging.Logger,
+) *Farm {
+	return &Farm{
+		factory:  factory,
+		kps:      kps,
+		rls:      rls,
+		sessions: sessions,
+		logger:   logger,
+		children: make(map[fields.ID]childRU),
+	}
+}
+
+// Start is a blocking function that monitors Consul for updates. The Farm will
+// attempt to claim updates as they appear and, if successful, will start
+// goroutines for those updatesto do their job. Closing the quit channel will
+// cause this function to return, releasing all locks it holds.
+//
+// Start is not safe for concurrent execution. Do not execute multiple
+// concurrent instances of Start.
+func (rlf *Farm) Start(quit <-chan struct{}) {
+	subQuit := make(chan struct{})
+	defer close(subQuit)
+	rlWatch, rlErr := rlf.rls.Watch(subQuit)
+
+START_LOOP:
+	for {
+		select {
+		case <-quit:
+			rlf.logger.NoFields().Infoln("Halt requested, releasing updates")
+			rlf.releaseChildren()
+			return
+		case session := <-rlf.sessions:
+			if session == "" {
+				// our session has expired, we must assume our locked children
+				// have all been released and that someone else may have
+				// claimed them by now
+				rlf.logger.NoFields().Errorln("Session expired, releasing updates")
+				rlf.lock = nil
+				rlf.releaseChildren()
+			} else {
+				// a new session has been acquired - only happens after an
+				// expiration message, so len(children)==0
+				rlf.logger.WithField("session", session).Infoln("Acquired new session")
+				lock := rlf.kps.NewUnmanagedLock(session, "")
+				rlf.lock = &lock
+				// TODO: restart the watch so that you get updates right away?
+			}
+		case err := <-rlErr:
+			rlf.logger.WithError(err).Errorln("Could not read consul updates")
+		case rlFields := <-rlWatch:
+			rlf.logger.WithField("n", len(rlFields)).Debugln("Received update update")
+			if rlf.lock == nil {
+				// we can't claim new nodes because our session is invalidated.
+				// raise an error and ignore this update
+				rlf.logger.NoFields().Warnln("Received update update, but do not have session to acquire locks")
+				continue
+			}
+
+			// track which children were found in the returned set
+			foundChildren := make(map[fields.ID]struct{})
+			for _, rlField := range rlFields {
+				rlLogger := rlf.logger.SubLogger(logrus.Fields{
+					"ru_id": rlField.NewRC,
+				})
+				if _, ok := rlf.children[rlField.NewRC]; ok {
+					// this one is already ours, skip
+					rlLogger.NoFields().Debugln("Got update already owned by self")
+					foundChildren[rlField.NewRC] = struct{}{}
+					continue
+				}
+
+				err := rlf.lock.Lock(kp.LockPath(kp.RollPath(rlField.NewRC.String())))
+				if _, ok := err.(kp.AlreadyLockedError); ok {
+					// someone else must have gotten it first - log and move to
+					// the next one
+					rlLogger.NoFields().Debugln("Lock on update was denied")
+					continue
+				} else if err != nil {
+					rlLogger.NoFields().Errorln("Got error while locking update - session may be expired")
+					// stop processing this update and go back to the select
+					// chances are this error is a network problem or session
+					// expiry, and all the others in this update would also fail
+					continue START_LOOP
+				}
+
+				// at this point the ru is ours, time to spin it up
+				rlLogger.NoFields().Infoln("Acquired lock on new update, spawning")
+
+				newChild := rlf.factory.New(rlField, rlLogger, *rlf.lock)
+				childQuit := make(chan struct{})
+				rlf.children[rlField.NewRC] = childRU{ru: newChild, quit: childQuit}
+				foundChildren[rlField.NewRC] = struct{}{}
+
+				go func(id fields.ID) {
+					err := newChild.Prepare()
+					if err != nil {
+						rlLogger.WithError(err).Errorln("Could not prepare update")
+						return
+					}
+					err = newChild.Run(childQuit)
+					if err != nil {
+						rlLogger.WithError(err).Errorln("Could not complete update")
+						return
+					}
+					err = rlf.rls.Delete(id)
+					if err != nil {
+						rlLogger.WithError(err).Errorln("Could not remove completed update")
+					}
+				}(rlField.NewRC) // do not close over rlField, it's a loop variable
+			}
+
+			// now remove any children that were not found in the result set
+			rlf.logger.NoFields().Debugln("Pruning updates that have disappeared")
+			for id := range rlf.children {
+				if _, ok := foundChildren[id]; !ok {
+					rlf.releaseChild(id)
+				}
+			}
+		}
+	}
+}
+
+// close one child
+func (rlf *Farm) releaseChild(id fields.ID) {
+	rlf.logger.WithField("ru_id", id).Infoln("Releasing update")
+	close(rlf.children[id].quit)
+	delete(rlf.children, id)
+
+	// if our lock is active, attempt to gracefully release it
+	if rlf.lock != nil {
+		err := rlf.lock.Unlock(kp.LockPath(kp.RollPath(id.String())))
+		if err != nil {
+			rlf.logger.WithField("ru_id", id).Warnln("Could not release update lock")
+		}
+	}
+}
+
+// close all children
+func (rlf *Farm) releaseChildren() {
+	for id := range rlf.children {
+		// it's safe to delete this element during iteration,
+		// because we have already iterated over it
+		rlf.releaseChild(id)
+	}
+}


### PR DESCRIPTION
Fixes various lock-related things in rolling updates and RCs. Implements farm for rolling updates and associated p2-rctl commands. Verified in staging.