### PR TITLE
Extract status server, enable socket status reporting

### DIFF
--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -36,18 +36,6 @@ type Store interface {
 	WatchPods(string, <-chan struct{}, chan<- error, chan<- []kp.ManifestResult)
 }
 
-type Preparer struct {
-	node         string
-	store        Store
-	hooks        Hooks
-	hookListener HookListener
-	Logger       logging.Logger
-	podRoot      string
-	caFile       string
-	authPolicy   auth.Policy
-	consulHealth bool
-}
-
 func (p *Preparer) WatchForHooks(quit chan struct{}) {
 	hookErrCh := make(chan error)
 	hookQuitCh := make(chan struct{})

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -35,6 +35,18 @@ type LogDestination struct {
 	Path string          `yaml:"path"`
 }
 
+type Preparer struct {
+	node         string
+	store        Store
+	hooks        Hooks
+	hookListener HookListener
+	Logger       logging.Logger
+	podRoot      string
+	caFile       string
+	authPolicy   auth.Policy
+	consulHealth bool
+}
+
 type PreparerConfig struct {
 	NodeName             string                 `yaml:"node_name"`
 	ConsulAddress        string                 `yaml:"consul_address"`
@@ -48,6 +60,7 @@ type PreparerConfig struct {
 	NoConsulHealth       bool                   `yaml:"no_consul_health,omitempty"`
 	PodRoot              string                 `yaml:"pod_root,omitempty"`
 	StatusPort           int                    `yaml:"status_port"`
+	StatusSocket         string                 `yaml:"status_socket"`
 	Auth                 map[string]interface{} `yaml:"auth,omitempty"`
 	ExtraLogDestinations []LogDestination       `yaml:"extra_log_destinations,omitempty"`
 	WriteKVHealth        bool                   `yaml:"write_kv_health,omitempty"`

--- a/pkg/preparer/status.go
+++ b/pkg/preparer/status.go
@@ -1,0 +1,91 @@
+package preparer
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+
+	"github.com/square/p2/pkg/logging"
+)
+
+type StatusServer struct {
+	listener net.Listener
+	server   *http.Server
+	logger   *logging.Logger
+	Exit     chan error
+}
+
+func (s *StatusServer) Close() error {
+	return s.listener.Close()
+}
+
+var NoServerConfigured = fmt.Errorf("No status server was configured")
+
+func NewStatusServer(statusPort int, statusSocket string, logger *logging.Logger) (*StatusServer, error) {
+	server := http.Server{}
+	statusServer := &StatusServer{
+		server: &server,
+		logger: logger,
+		Exit:   make(chan error),
+	}
+	var listener net.Listener
+	var err error
+
+	if statusPort != 0 {
+		listener, err = statusServer.listenOnPort(statusPort)
+		if err != nil {
+			return nil, err
+		}
+	} else if statusSocket != "" {
+		listener, err = statusServer.listenOnSocket(statusSocket)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		return nil, NoServerConfigured
+	}
+
+	statusServer.listener = listener
+
+	return statusServer, nil
+}
+
+func (s *StatusServer) Serve() {
+	defer s.Close()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/_status", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "p2-preparer OK")
+	})
+
+	s.server.Handler = mux
+	err := s.server.Serve(s.listener)
+	s.logger.WithError(err).Warnln("Status server exited!")
+	s.Exit <- err
+	close(s.Exit)
+}
+
+func (s *StatusServer) listenOnPort(statusPort int) (net.Listener, error) {
+	s.logger.WithField("port", statusPort).Infof("Reporting status on port %d", statusPort)
+	return net.Listen("tcp", fmt.Sprintf(":%d", statusPort))
+}
+
+func (s *StatusServer) listenOnSocket(socket string) (net.Listener, error) {
+	if _, err := os.Stat(socket); err == nil {
+		s.logger.WithField("socket", socket).Warningln("Previous socket was not removed, removing")
+		err = os.Remove(socket)
+		if err != nil {
+			s.logger.WithError(err).Fatalln("Could not remove existing socket!")
+		}
+	}
+	s.logger.WithField("socket", socket).Infof("Reporting status on socket %s", socket)
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		return nil, err
+	}
+	err = os.Chmod(socket, 0777)
+	if err != nil {
+		return nil, err
+	}
+	return listener, nil
+}


### PR DESCRIPTION
Allows the preparer to publish its status on a socket instead of a port. 