### PR TITLE
Release RC write locks on Run() termination

### DIFF
--- a/pkg/kp/rcstore/consul_store.go
+++ b/pkg/kp/rcstore/consul_store.go
@@ -167,10 +167,7 @@ func (s *consulStore) WatchNew(quit <-chan struct{}) (<-chan []fields.RC, <-chan
 }
 
 func (s *consulStore) kvpToRC(kvp *api.KVPair) (fields.RC, error) {
-	rc := fields.RC{
-		// cannot unmarshal into a nil interface - have to initialize to something
-		Manifest: pods.NewManifestBuilder().GetManifest(),
-	}
+	rc := fields.RC{}
 	err := json.Unmarshal(kvp.Value, &rc)
 	return rc, err
 }

--- a/pkg/rc/farm.go
+++ b/pkg/rc/farm.go
@@ -106,7 +106,8 @@ START_LOOP:
 			foundChildren := make(map[fields.ID]struct{})
 			for _, rcField := range rcFields {
 				rcLogger := rcf.logger.SubLogger(logrus.Fields{
-					"rc_id": rcField.ID,
+					"rc":  rcField.ID,
+					"pod": rcField.Manifest.ID(),
 				})
 				if _, ok := rcf.children[rcField.ID]; ok {
 					// this one is already ours, skip
@@ -165,7 +166,7 @@ START_LOOP:
 
 // close one child
 func (rcf *Farm) releaseChild(id fields.ID) {
-	rcf.logger.WithField("rc_id", id).Infoln("Releasing replication controller")
+	rcf.logger.WithField("rc", id).Infoln("Releasing replication controller")
 	close(rcf.children[id].quit)
 	delete(rcf.children, id)
 
@@ -173,7 +174,7 @@ func (rcf *Farm) releaseChild(id fields.ID) {
 	if rcf.lock != nil {
 		err := rcf.lock.Unlock(kp.LockPath(kp.RCPath(id.String())))
 		if err != nil {
-			rcf.logger.WithField("rc_id", id).Warnln("Could not release replication controller lock")
+			rcf.logger.WithField("rc", id).Warnln("Could not release replication controller lock")
 		}
 	}
 }

--- a/pkg/rc/fields/fields.go
+++ b/pkg/rc/fields/fields.go
@@ -87,7 +87,7 @@ func (rc *RC) UnmarshalJSON(b []byte) error {
 		NodeSelector:    nodeSel,
 		PodLabels:       jrc.PodLabels,
 		ReplicasDesired: jrc.ReplicasDesired,
-		Disabled:        rc.Disabled,
+		Disabled:        jrc.Disabled,
 	}
 	return nil
 }

--- a/pkg/roll/farm.go
+++ b/pkg/roll/farm.go
@@ -118,7 +118,7 @@ START_LOOP:
 			foundChildren := make(map[fields.ID]struct{})
 			for _, rlField := range rlFields {
 				rlLogger := rlf.logger.SubLogger(logrus.Fields{
-					"ru_id": rlField.NewRC,
+					"ru": rlField.NewRC,
 				})
 				if _, ok := rlf.children[rlField.NewRC]; ok {
 					// this one is already ours, skip
@@ -180,7 +180,7 @@ START_LOOP:
 
 // close one child
 func (rlf *Farm) releaseChild(id fields.ID) {
-	rlf.logger.WithField("ru_id", id).Infoln("Releasing update")
+	rlf.logger.WithField("ru", id).Infoln("Releasing update")
 	close(rlf.children[id].quit)
 	delete(rlf.children, id)
 
@@ -188,7 +188,7 @@ func (rlf *Farm) releaseChild(id fields.ID) {
 	if rlf.lock != nil {
 		err := rlf.lock.Unlock(kp.LockPath(kp.RollPath(id.String())))
 		if err != nil {
-			rlf.logger.WithField("ru_id", id).Warnln("Could not release update lock")
+			rlf.logger.WithField("ru", id).Warnln("Could not release update lock")
 		}
 	}
 }


### PR DESCRIPTION
If a rolling update is deleted from Consul, the farm automatically
releases the lock that it took on that update, under /locks/rolls/id.
But the update itself also claimed locks on the two RCs it was using.
Those locks also have to be released, or otherwise the update cannot
be Prepare()d by someone else.

To fix this, we make Update.Run() a long-lived function with an error
channel return (instead of bailing on the first error). Then, when Run()
terminates, we release the locks claimed by Prepare(). The caller would
have to call Prepare() again before resuming Run().