### PR TITLE
remove deadlock case

### DIFF
--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -81,7 +81,7 @@ func (p *Preparer) WatchForPodManifestsForNode(quitAndAck chan struct{}) {
 		case intentResults := <-podChan:
 			realityResults, _, err := p.store.ListPods(kp.RealityPath(p.node))
 			if err != nil {
-				errChan <- err
+				p.Logger.WithError(err).Errorln("Could not check reality")
 			} else {
 				// if the preparer's own ID is missing from the intent set, we
 				// assume it was damaged and discard it


### PR DESCRIPTION
When receiving an error reading from reality in certain cases, we would block forever. This explains why during a Consul reset, a number of preparers would suddenly hang forever. Follow up work should alter the status checker to perform a liveness check of the various routines we care about.