### PR TITLE
Handle errors inside Update.Run

### DIFF
--- a/pkg/kp/rcstore/consul_store.go
+++ b/pkg/kp/rcstore/consul_store.go
@@ -15,6 +15,11 @@ import (
 	"github.com/square/p2/pkg/rc/fields"
 )
 
+const (
+	// This label is applied to an RC, to identify the ID of its pod manifest.
+	PodIDLabel = "pod_id"
+)
+
 type kvPair struct {
 	key   string
 	value []byte
@@ -347,5 +352,5 @@ func (s *consulStore) forEachLabel(rc fields.RC, f func(id, k, v string) error) 
 	id := rc.ID.String()
 	// As of this writing the only label we want is the pod ID.
 	// There may be more in the future.
-	return f(id, "pod_id", rc.Manifest.ID())
+	return f(id, PodIDLabel, rc.Manifest.ID())
 }

--- a/pkg/rc/replication_controller.go
+++ b/pkg/rc/replication_controller.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	rcIdLabel  = "replication_controller_id"
-	podIdLabel = "pod_id"
+	// This label is applied to pods owned by an RC.
+	RCIDLabel = "replication_controller_id"
 )
 
 type ReplicationController interface {
@@ -188,7 +188,7 @@ func (rc *replicationController) eligibleNodes() ([]string, error) {
 }
 
 func (rc *replicationController) CurrentNodes() ([]string, error) {
-	selector := klabels.Everything().Add(rcIdLabel, klabels.EqualsOperator, []string{rc.ID().String()})
+	selector := klabels.Everything().Add(RCIDLabel, klabels.EqualsOperator, []string{rc.ID().String()})
 
 	pods, err := rc.podApplicator.GetMatches(selector, labels.POD)
 	if err != nil {
@@ -208,7 +208,7 @@ func (rc *replicationController) CurrentNodes() ([]string, error) {
 }
 
 // forEachLabel Attempts to apply the supplied function to all user-supplied labels
-// and the reserved labels podIdLabel and rcIdLabel.
+// and the reserved labels.
 // If forEachLabel encounters any error applying the function, it returns that error immediately.
 // The function is not further applied to subsequent labels on an error.
 func (rc *replicationController) forEachLabel(node string, f func(id, k, v string) error) error {
@@ -221,10 +221,7 @@ func (rc *replicationController) forEachLabel(node string, f func(id, k, v strin
 		}
 	}
 	// our reserved labels.
-	if err := f(id, podIdLabel, rc.Manifest.ID()); err != nil {
-		return err
-	}
-	return f(id, rcIdLabel, rc.ID().String())
+	return f(id, RCIDLabel, rc.ID().String())
 }
 
 func (rc *replicationController) schedule(node string) error {

--- a/pkg/replication/replication_test.go
+++ b/pkg/replication/replication_test.go
@@ -278,7 +278,6 @@ func TestStopsIfLockDestroyed(t *testing.T) {
 			t.Fatalf("Did not get expected lock renewal error within timeout")
 		}
 	}()
-	failIfErrors(errCh, doneCh, t)
 	imitatePreparers(server, doneCh)
 
 	go func() {

--- a/pkg/roll/farm.go
+++ b/pkg/roll/farm.go
@@ -152,10 +152,9 @@ START_LOOP:
 				foundChildren[rlField.NewRC] = struct{}{}
 
 				go func(id fields.ID) {
-					for err := range newChild.Run(childQuit) {
-						if err != nil {
-							rlLogger.WithError(err).Errorln("Error during update")
-						}
+					if !newChild.Run(childQuit) {
+						// returned false, farm must have asked us to quit
+						return
 					}
 					// our lock on this RU won't be released until it's deleted,
 					// so if we fail to delete it, we have to retry


### PR DESCRIPTION
See commit message. This simplifies the semantics of the function a bit and avoids potential races against program exit (where the program might live long enough to accidentally delete an update that wasn't finished yet, if asked to quit the update on termination). Particularly cc @bwester since I went over this code with you and you might be better positioned to review it.