### PR TITLE
Add a EnvPath() function to HookEnv

### DIFF
--- a/pkg/hooks/hook_env.go
+++ b/pkg/hooks/hook_env.go
@@ -18,7 +18,7 @@ func CurrentEnv() *HookEnv {
 type HookEnv struct{}
 
 func (h *HookEnv) Manifest() (pods.Manifest, error) {
-	path := os.Getenv("HOOKED_POD_MANIFEST")
+	path := os.Getenv(HOOKED_POD_MANIFEST_ENV_VAR)
 	if path == "" {
 		return nil, util.Errorf("No manifest exported")
 	}
@@ -26,11 +26,11 @@ func (h *HookEnv) Manifest() (pods.Manifest, error) {
 }
 
 func (h *HookEnv) Pod() (*pods.Pod, error) {
-	id := os.Getenv("HOOKED_POD_ID")
+	id := os.Getenv(HOOKED_POD_ID_ENV_VAR)
 	if id == "" {
 		return nil, util.Errorf("Did not provide a pod ID to use")
 	}
-	path := os.Getenv("HOOKED_POD_HOME")
+	path := os.Getenv(HOOKED_POD_HOME_ENV_VAR)
 	if path == "" {
 		return nil, util.Errorf("No pod home given for pod ID %s", id)
 	}
@@ -39,11 +39,15 @@ func (h *HookEnv) Pod() (*pods.Pod, error) {
 }
 
 func (h *HookEnv) Config() (*config.Config, error) {
-	return config.LoadConfigFile(os.Getenv("HOOKED_CONFIG_PATH"))
+	return config.LoadConfigFile(os.Getenv(HOOKED_CONFIG_PATH_ENV_VAR))
 }
 
 func (h *HookEnv) Event() (HookType, error) {
-	return AsHookType(os.Getenv("HOOK_EVENT"))
+	return AsHookType(os.Getenv(HOOK_EVENT_ENV_VAR))
+}
+
+func (h *HookEnv) EnvPath() string {
+	return os.Getenv(HOOKED_ENV_PATH_ENV_VAR)
 }
 
 func (h *HookEnv) ExitUnlessEvent(types ...HookType) HookType {

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -15,6 +15,16 @@ import (
 
 var DEFAULT_PATH = "/usr/local/p2hooks.d"
 
+const (
+	HOOK_ENV_VAR                = "HOOK"
+	HOOK_EVENT_ENV_VAR          = "HOOK_EVENT"
+	HOOKED_POD_ID_ENV_VAR       = "HOOKED_POD_ID"
+	HOOKED_POD_HOME_ENV_VAR     = "HOOKED_POD_HOME"
+	HOOKED_POD_MANIFEST_ENV_VAR = "HOOKED_POD_MANIFEST"
+	HOOKED_CONFIG_PATH_ENV_VAR  = "HOOKED_CONFIG_PATH"
+	HOOKED_ENV_PATH_ENV_VAR     = "HOOKED_ENV_PATH"
+)
+
 type Pod interface {
 	ConfigDir() string
 	EnvDir() string
@@ -131,13 +141,13 @@ func (h *HookDir) runHooks(dirpath string, hType HookType, pod Pod, podManifest 
 	}
 
 	hookEnvironment := []string{
-		fmt.Sprintf("HOOK=%s", path.Base(dirpath)),
-		fmt.Sprintf("HOOK_EVENT=%s", hType.String()),
-		fmt.Sprintf("HOOKED_POD_ID=%s", podManifest.ID()),
-		fmt.Sprintf("HOOKED_POD_HOME=%s", pod.Path()),
-		fmt.Sprintf("HOOKED_POD_MANIFEST=%s", tmpManifestFile.Name()),
-		fmt.Sprintf("HOOKED_CONFIG_PATH=%s", path.Join(pod.ConfigDir(), configFileName)),
-		fmt.Sprintf("HOOKED_ENV_PATH=%s", pod.EnvDir()),
+		fmt.Sprintf("%s=%s", HOOK_ENV_VAR, path.Base(dirpath)),
+		fmt.Sprintf("%s=%s", HOOK_EVENT_ENV_VAR, hType.String()),
+		fmt.Sprintf("%s=%s", HOOKED_POD_ID_ENV_VAR, podManifest.ID()),
+		fmt.Sprintf("%s=%s", HOOKED_POD_HOME_ENV_VAR, pod.Path()),
+		fmt.Sprintf("%s=%s", HOOKED_POD_MANIFEST_ENV_VAR, tmpManifestFile.Name()),
+		fmt.Sprintf("%s=%s", HOOKED_CONFIG_PATH_ENV_VAR, path.Join(pod.ConfigDir(), configFileName)),
+		fmt.Sprintf("%s=%s", HOOKED_ENV_PATH_ENV_VAR, pod.EnvDir()),
 	}
 
 	return runDirectory(dirpath, hookEnvironment, logger)


### PR DESCRIPTION
This makes it easier for hooks to locate a pod's env directory via
environment variables. It is essential for hooks to compute a pod's env
directory in this manner so that hooks will maintain compatibility with
a preparer change that moves the env directory