### PR TITLE
Create a directory (namespaced by manifest SHA) for env/ directory and config files when installing a

### DIFF
--- a/pkg/pods/manifest.go
+++ b/pkg/pods/manifest.go
@@ -59,9 +59,7 @@ type Manifest interface {
 	ID() string
 	RunAsUser() string
 	Write(out io.Writer) error
-	ConfigFileName() (string, error)
 	WriteConfig(out io.Writer) error
-	PlatformConfigFileName() (string, error)
 	WritePlatformConfig(out io.Writer) error
 	GetLaunchableStanzas() map[string]LaunchableStanza
 	GetConfig() map[interface{}]interface{}
@@ -298,22 +296,6 @@ func (manifest *manifest) SHA() (string, error) {
 	hasher := sha256.New()
 	hasher.Write(buf)
 	return hex.EncodeToString(hasher.Sum(nil)), nil
-}
-
-func (manifest *manifest) ConfigFileName() (string, error) {
-	sha, err := manifest.SHA()
-	if err != nil {
-		return "", err
-	}
-	return manifest.Id + "_" + sha + ".yaml", nil
-}
-
-func (manifest *manifest) PlatformConfigFileName() (string, error) {
-	sha, err := manifest.SHA()
-	if err != nil {
-		return "", err
-	}
-	return manifest.Id + "_" + sha + ".platform.yaml", nil
 }
 
 // Returns readers needed to verify the signature on the

--- a/pkg/preparer/orchestrate_test.go
+++ b/pkg/preparer/orchestrate_test.go
@@ -25,8 +25,10 @@ type TestPod struct {
 	currentManifest                                                      pods.Manifest
 	installed, uninstalled, launched, launchSuccess, halted, haltSuccess bool
 	installErr, uninstallErr, launchErr, haltError, currentManifestError error
-	configDir, envDir                                                    string
+	configPath, envDir                                                   string
 }
+
+var _ Pod = &TestPod{}
 
 func (t *TestPod) ManifestSHA() (string, error) {
 	return "abc123", nil
@@ -51,27 +53,27 @@ func (t *TestPod) Uninstall() error {
 	return t.uninstallErr
 }
 
-func (t *TestPod) Verify(manifest pods.Manifest, authPolicy auth.Policy) error {
+func (t *TestPod) Verify(_ pods.Manifest, authPolicy auth.Policy) error {
 	return nil
 }
 
-func (t *TestPod) Halt(manifest pods.Manifest) (bool, error) {
+func (t *TestPod) Halt(_ pods.Manifest) (bool, error) {
 	t.halted = true
 	return t.haltSuccess, t.haltError
 }
 
-func (t *TestPod) ConfigDir() string {
-	if t.configDir != "" {
-		return t.configDir
+func (t *TestPod) ConfigPath(_ pods.Manifest) (string, error) {
+	if t.configPath != "" {
+		return t.configPath, nil
 	}
-	return os.TempDir()
+	return "", util.Errorf("no config path defined for test pod")
 }
 
-func (t *TestPod) EnvDir() string {
+func (t *TestPod) EnvDir(_ pods.Manifest) (string, error) {
 	if t.envDir != "" {
-		return t.envDir
+		return t.envDir, nil
 	}
-	return os.TempDir()
+	return os.TempDir(), nil
 }
 
 func (t *TestPod) Path() string {


### PR DESCRIPTION
pod.

This prevents installing a new pod manifest to affect the environment or
config for a different pod which may still be running. The name of the
directory is the SHA of the pod manifest's contents.