### PR TITLE
Use "cgroup.procs" for cgroup membership

### DIFF
--- a/bin/p2-exec/main.go
+++ b/bin/p2-exec/main.go
@@ -190,7 +190,7 @@ func cgEnter(platconf, launchableName, cgroupName string) error {
 	} else if err != nil {
 		return util.Errorf("Could not set cgroup parameters: %s", err)
 	}
-	return cg.AddPID(cgConfig.Name, os.Getpid())
+	return cg.AddPID(cgConfig.Name, 0)
 }
 
 // generalized code to remove rlimits on both darwin and linux

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -173,11 +173,11 @@ func (subsys Subsystems) Write(config Config) error {
 }
 
 func (subsys Subsystems) AddPID(name string, pid int) error {
-	err := appendIntToFile(filepath.Join(subsys.Memory, name, "tasks"), pid)
+	err := appendIntToFile(filepath.Join(subsys.Memory, name, "cgroup.procs"), pid)
 	if err != nil {
 		return err
 	}
-	return appendIntToFile(filepath.Join(subsys.CPU, name, "tasks"), pid)
+	return appendIntToFile(filepath.Join(subsys.CPU, name, "cgroup.procs"), pid)
 }
 
 func appendIntToFile(filename string, data int) error {


### PR DESCRIPTION
This commit changes p2-exec to use a different method for changing its cgroup
membership: it will write "0" to the cgroup's "cgroup.procs" file. Writing to
this file will change membership for the current thread group (e.g., the entire
process) instead of an individual thread. This may be a fix for a bug wherein a
launched service is observed to be running in the root cgroup.