### PR TITLE
Move post-activate output to logrus field

### DIFF
--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -157,7 +157,7 @@ func (pod *Pod) Launch(manifest Manifest) (bool, error) {
 			successes = append(successes, false)
 		} else {
 			if out != "" {
-				pod.logInfo(out)
+				pod.logger.WithField("output", out).Infoln("Successfully post-activated")
 			}
 			successes = append(successes, true)
 		}


### PR DESCRIPTION
This shouldn't be in the logrus message in the first place; parametric data should be in fields.