### PR TITLE
p2 log bridge

### DIFF
--- a/bin/p2-log-bridge/main.go
+++ b/bin/p2-log-bridge/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+
+	"github.com/square/p2/Godeps/_workspace/src/gopkg.in/alecthomas/kingpin.v2"
+	"github.com/square/p2/pkg/logbridge"
+	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/version"
+)
+
+var (
+	durableLogger = kingpin.Arg("exec", "An executable that logbridge will log to without dropping messages. If a write to STDIN of this program blocks, logbridge will block.").Required().String()
+)
+
+func main() {
+	kingpin.Version(version.VERSION)
+	kingpin.Parse()
+
+	loggerCmd := exec.Command(*durableLogger)
+	durablePipe, err := loggerCmd.StdinPipe()
+	if err != nil {
+		logging.DefaultLogger.WithError(err).Errorln("failed during logbridge setup")
+		os.Exit(1)
+	}
+
+	go handleSignals(durablePipe)
+
+	go func(r io.Reader, durableWriter io.Writer, nonDurableWriter io.Writer, logger logging.Logger) {
+		logbridge.Tee(r, durableWriter, nonDurableWriter, logger)
+	}(os.Stdin, durablePipe, os.Stdout, logging.DefaultLogger)
+
+	loggerCmd.Start()
+	err = loggerCmd.Wait()
+	if err != nil {
+		logging.DefaultLogger.WithError(err)
+		os.Exit(1)
+	}
+}
+
+// This is slightly naive, it could be more narrow in the signals it cares about
+func handleSignals(c io.Closer) {
+	signals := make(chan os.Signal, 2)
+	signal.Notify(signals)
+	<-signals
+	c.Close()
+}

--- a/pkg/logbridge/doc.go
+++ b/pkg/logbridge/doc.go
@@ -1,0 +1,11 @@
+/*
+This package implements a log bridge. It is a bridge in the literal sense - it
+will carry logs from one side to the other until it reaches its capacity. When
+the bridge is at its capacity, it will drop new entries instead of blocking.
+This behaviour is desirable because it makes this package safe to attach
+to the logging end of an executable
+
+A typical use for this package is to attach it to stdout of an executable
+and passing the results into your system's proprietary logging backend.
+*/
+package logbridge

--- a/pkg/logbridge/logbridge.go
+++ b/pkg/logbridge/logbridge.go
@@ -1,0 +1,109 @@
+package logbridge
+
+import (
+	"bufio"
+	"io"
+	"time"
+
+	"github.com/square/p2/pkg/logging"
+)
+
+// Copy implements a buffered copy operation between dest and src.
+// It returns the number of dropped messages as a result of insufficient
+// capacity
+func LossyCopy(dest io.Writer, src io.Reader, capacity int, logger logging.Logger) {
+	lines := make(chan []byte, capacity)
+
+	go lossyCopy(src, lines, logger)
+
+	var n int
+	var err error
+	for line := range lines {
+		n, err = writeWithRetry(dest, line, logger)
+		if err != nil {
+			logger.WithError(err).WithField("dropped line", line).WithField("retried", isRetriable(err)).WithField("bytes written", n).Errorln("Encountered a non-recoverable error. Proceeding.")
+		}
+	}
+}
+
+// This function will scan lines from src and send them on the lines channel,
+// except when the channel is full in which case it will skip the line
+func lossyCopy(src io.Reader, lines chan []byte, logger logging.Logger) {
+	defer close(lines)
+
+	droppedLines := 0
+	scanner := bufio.NewScanner(src)
+	var line []byte
+	for scanner.Scan() {
+		line = scanner.Bytes() // consume a line regardless of the state of the writer
+		select {
+		case lines <- line:
+		default:
+			droppedLines++
+
+			warningMessage := "Dropped was dropped due to full capacity. If this occurs frequently, consider increasing the capacity of this logbridge."
+			logger.WithField("dropped line", line).Errorln(warningMessage)
+			if droppedLines%10 == 0 {
+				select {
+				case lines <- []byte(warningMessage):
+				case <-time.After(100 * time.Millisecond):
+					// best effort warning of dropped messages. If this doesn't suceed expediently, forget it and get back to work
+				}
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		logger.WithError(err).Errorln("Encountered error while reading from src. Proceeding.")
+	}
+}
+
+// Tee will copy to faithfulWriter without dropping messages, it will copy
+// through a buffer to better handle mismatched latencies. Lines written to
+// lossyWriter will be copied in a best effort way with respect to latency and
+// buffered through a go channel.
+func Tee(r io.Reader, durableWriter io.Writer, lossyWriter io.Writer, logger logging.Logger) {
+	tr := io.TeeReader(r, bufio.NewWriterSize(durableWriter, 1<<10))
+
+	LossyCopy(lossyWriter, tr, 1<<10, logger)
+}
+
+// This is an error wrapper type that may be used to denote an error is retriable
+// RetriableError is exported so clients of this package can express their
+// error semantics to this package
+type retriableError struct {
+	err error
+}
+
+func NewRetriableError(err error) retriableError {
+	return retriableError{err}
+}
+
+func (r retriableError) Error() string {
+	return r.err.Error()
+}
+
+func isRetriable(err error) bool {
+	_, ok := err.(retriableError)
+	return ok
+}
+
+var backoff = func(i int) time.Duration {
+	return time.Duration(1 << uint(i) * time.Second)
+}
+
+func writeWithRetry(w io.Writer, line []byte, logger logging.Logger) (int, error) {
+	var err error
+	var n int
+	totalAttempts := 5
+
+	for attempt := 1; attempt <= totalAttempts; attempt++ {
+		n, err = w.Write(line)
+		if err == nil || !isRetriable(err) {
+			return n, err
+		}
+		logger.WithError(err).Errorf("Retriable error, retry %d of %d", attempt, totalAttempts)
+		time.Sleep(backoff(attempt))
+	}
+
+	return n, err
+}

--- a/pkg/logbridge/logbridge_test.go
+++ b/pkg/logbridge/logbridge_test.go
@@ -1,0 +1,180 @@
+package logbridge
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/square/p2/pkg/logging"
+)
+
+const newLine = byte(10)
+
+type TrackingWriter struct {
+	numWrites int
+}
+
+func (tw *TrackingWriter) Write(p []byte) (int, error) {
+	tw.numWrites++
+	return len(p), nil
+}
+
+func TestLogBridge(t *testing.T) {
+	type testCase struct {
+		inputSize      int
+		bridgeCapacity int
+		expected       int
+	}
+
+	testCases := []testCase{
+		{inputSize: 0, bridgeCapacity: 0, expected: 0},
+		{inputSize: 10, bridgeCapacity: 10, expected: 10},
+		{inputSize: 100, bridgeCapacity: 10, expected: 10},
+		{inputSize: 10, bridgeCapacity: 100, expected: 10},
+	}
+
+	for i, testCase := range testCases {
+		t.Logf("test case %d", i)
+		input := make([]byte, 0, 2*testCase.inputSize)
+		for i := 0; i < testCase.inputSize; i++ {
+			input = append(input, byte('a'), newLine)
+		}
+
+		reader := bytes.NewReader(input)
+		writer := &TrackingWriter{}
+
+		LossyCopy(writer, reader, testCase.bridgeCapacity, logging.DefaultLogger)
+		if writer.numWrites < testCase.expected {
+			t.Errorf("Writer did not receive enough writes, got %d expected: %d", writer.numWrites, testCase.inputSize)
+		}
+	}
+}
+
+// This writer becomes latent after receiving capacity writes.
+type LatentWriter struct {
+	capacity int
+	writes   int
+}
+
+func (sw *LatentWriter) Write(p []byte) (n int, err error) {
+	if sw.writes > sw.capacity {
+		time.Sleep(10 * time.Millisecond)
+	}
+	sw.writes++
+
+	return len(p), nil
+}
+
+func TestLogBridgeLogDrop(t *testing.T) {
+	bridgeCapacity := 3
+	input := []byte{
+		byte('a'), newLine,
+		byte('b'), newLine,
+		byte('c'), newLine,
+		byte('d'), newLine,
+		byte('e'), newLine,
+		byte('f'), newLine}
+	reader := bytes.NewReader(input)
+	writer := &LatentWriter{}
+
+	LossyCopy(writer, reader, bridgeCapacity, logging.DefaultLogger)
+
+	if writer.writes < bridgeCapacity {
+		t.Errorf("Expected at least %d messages to succeed under writer latency, got %d.", bridgeCapacity, writer.writes)
+	}
+}
+
+// This writer returns errors of type (*ErrorWriter).err after numSuccess calls to Write
+type errorWriter struct {
+	numSuccess int
+	writes     int
+	bytes      []byte
+}
+
+type transientErrorWriter struct {
+	numSuccess int
+	writes     int
+	bytes      []byte
+}
+
+func (ew *errorWriter) Write(p []byte) (n int, err error) {
+	if ew.writes > ew.numSuccess {
+		return 0, errors.New("boom")
+	}
+
+	ew.writes++
+
+	ew.bytes = append(ew.bytes, p...)
+
+	return len(p), nil
+}
+
+func (tew *transientErrorWriter) Write(p []byte) (n int, err error) {
+	tew.writes++
+
+	if tew.writes > tew.numSuccess && tew.writes%2 == 0 {
+		return 0, NewRetriableError(errors.New("boom"))
+	}
+
+	tew.bytes = append(tew.bytes, p...)
+	return len(p), nil
+}
+
+func TestErrorCases(t *testing.T) {
+	input := []byte{
+		byte('a'), newLine,
+		byte('b'), newLine,
+		byte('c'), newLine,
+		byte('d'), newLine,
+		byte('e'), newLine,
+		byte('f'), newLine}
+	bridgeCapacity := 6
+
+	// we're testing errors and want the tests to be fast
+	backoff = func(_ int) time.Duration { return time.Duration(0 * time.Millisecond) }
+
+	retriableErrorWriter := &transientErrorWriter{
+		numSuccess: 2,
+	}
+
+	errorWriter := &errorWriter{
+		numSuccess: 4,
+	}
+
+	reader := bytes.NewReader(input)
+	LossyCopy(errorWriter, reader, bridgeCapacity, logging.DefaultLogger)
+
+	if len(errorWriter.bytes) >= len(input) {
+		t.Errorf("Expected non-retriable error to cause line to be skipped.")
+	}
+
+	reader = bytes.NewReader(input)
+	LossyCopy(retriableErrorWriter, reader, bridgeCapacity, logging.DefaultLogger)
+
+	if len(retriableErrorWriter.bytes) != bridgeCapacity {
+		t.Errorf("Expected bridge to successfully retry writes that result in error. Expected %d Got %d", bridgeCapacity, len(retriableErrorWriter.bytes))
+	}
+}
+
+func TestIsRetriable(t *testing.T) {
+	type testCase struct {
+		err         error
+		expectation bool
+	}
+
+	testCases := []testCase{
+		{errors.New("an error"), false},
+		{errors.New("an error"), false},
+		{&retriableError{errors.New("an error")}, false},
+		{retriableError{errors.New("an error")}, true},
+		{NewRetriableError(errors.New("an error")), true},
+	}
+
+	for i, testCase := range testCases {
+		actual := isRetriable(testCase.err)
+		if actual != testCase.expectation {
+			t.Errorf("test case %d: expected %b got %b", i, testCase.expectation, actual)
+		}
+	}
+}

--- a/pkg/pods/manifest_test.go
+++ b/pkg/pods/manifest_test.go
@@ -105,7 +105,7 @@ func TestPodManifestCanBeWritten(t *testing.T) {
 
 func TestPodManifestCanWriteItsConfigStanzaSeparately(t *testing.T) {
 	config := testPod()
-	manifest, err := ManifestFromBytes(bytes.NewBufferString(config).Bytes())
+	manifest, err := ManifestFromBytes([]byte(config))
 	Assert(t).IsNil(err, "should not have erred when building manifest")
 
 	buff := bytes.Buffer{}
@@ -149,13 +149,13 @@ func TestNilPodManifestHasEmptySHA(t *testing.T) {
 
 func TestRunAs(t *testing.T) {
 	config := testPod()
-	manifest, err := ManifestFromBytes(bytes.NewBufferString(config).Bytes())
+	manifest, err := ManifestFromBytes([]byte(config))
 	Assert(t).IsNil(err, "should not have erred when building manifest")
 
 	Assert(t).AreEqual(manifest.RunAsUser(), manifest.ID(), "RunAsUser() didn't match expectations")
 
 	config += `run_as: specialuser`
-	manifest, err = ManifestFromBytes(bytes.NewBufferString(config).Bytes())
+	manifest, err = ManifestFromBytes([]byte(config))
 	Assert(t).IsNil(err, "should not have erred when building manifest")
 	Assert(t).AreEqual(manifest.RunAsUser(), "specialuser", "RunAsUser() didn't match expectations")
 }

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -36,6 +36,7 @@ var (
 const DEFAULT_PATH = "/data/pods"
 
 var DefaultP2Exec = "/usr/local/bin/p2-exec"
+var defaultLogExec = []string{"chpst", "-unobody", "svlogd", "-tt", "./main"}
 
 func init() {
 	Log = logging.NewLogger(logrus.Fields{})
@@ -53,6 +54,7 @@ type Pod struct {
 	ServiceBuilder *runit.ServiceBuilder
 	P2Exec         string
 	DefaultTimeout time.Duration // this is the default timeout for stopping and restarting services in this pod
+	LogExec        runit.LogExec // this is exposed to support a gradual rollout of p2-log-bridge
 }
 
 func NewPod(id string, path string) *Pod {
@@ -641,4 +643,11 @@ func (p *Pod) logLaunchableWarning(launchableId string, err error, message strin
 
 func (p *Pod) logInfo(message string) {
 	p.logger.WithFields(logrus.Fields{}).Info(message)
+}
+
+func (p *Pod) logExec() runit.LogExec {
+	if len(p.LogExec) == 0 {
+		return defaultLogExec
+	}
+	return p.LogExec
 }

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -266,12 +266,14 @@ func TestBuildRunitServices(t *testing.T) {
 	bytes, err := ioutil.ReadAll(f)
 	Assert(t).IsNil(err, "Got an unexpected error reading the servicebuilder yaml file")
 
-	expectedMap := map[string]interface{}{
-		executables[0].Service.Name: map[string]interface{}{
-			"run": executables[0].Exec,
+	expectedMap := map[string]runit.ServiceTemplate{
+		executables[0].Service.Name: runit.ServiceTemplate{
+			Run: executables[0].Exec,
+			Log: defaultLogExec,
 		},
-		executables[1].Service.Name: map[string]interface{}{
-			"run": executables[1].Exec,
+		executables[1].Service.Name: runit.ServiceTemplate{
+			Run: executables[1].Exec,
+			Log: defaultLogExec,
 		},
 	}
 	expected, err := yaml.Marshal(expectedMap)

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -258,8 +258,9 @@ func TestBuildRunitServices(t *testing.T) {
 	outFilePath := filepath.Join(serviceBuilder.ConfigRoot, "testPod.yaml")
 
 	Assert(t).IsNil(err, "Got an unexpected error when attempting to start runit services")
+	testManifest := &manifest{RestartPolicy: runit.RestartPolicyAlways}
+	pod.buildRunitServices([]launch.Launchable{hl.If()}, testManifest)
 
-	pod.buildRunitServices([]launch.Launchable{hl.If()}, runit.RestartPolicyAlways)
 	f, err := os.Open(outFilePath)
 	defer f.Close()
 	bytes, err := ioutil.ReadAll(f)

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -16,6 +16,8 @@ import (
 // Used because the preparer special-cases itself in a few places.
 const POD_ID = "p2-preparer"
 
+var logBridgeExec = []string{"/usr/local/bin/p2-log-bridge", "start"}
+
 type Pod interface {
 	hooks.Pod
 	Launch(pods.Manifest) (bool, error)
@@ -169,6 +171,11 @@ func (p *Preparer) handlePods(podChan <-chan ManifestPair, quit <-chan struct{})
 				// TODO better solution: force the preparer to have a 0s default timeout, prevent KILLs
 				if pod.Id == POD_ID {
 					pod.DefaultTimeout = time.Duration(0)
+				}
+				for _, testPodId := range p.logExecTestGroup {
+					if pod.Id == testPodId {
+						pod.LogExec = logBridgeExec
+					}
 				}
 
 				// podChan is being fed values gathered from a kp.Watch() in

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -47,6 +47,7 @@ type Preparer struct {
 	caFile                 string
 	authPolicy             auth.Policy
 	maxLaunchableDiskUsage size.ByteCount
+	logExecTestGroup       []string
 }
 
 type PreparerConfig struct {
@@ -66,6 +67,7 @@ type PreparerConfig struct {
 	ExtraLogDestinations   []LogDestination       `yaml:"extra_log_destinations,omitempty"`
 	LogLevel               string                 `yaml:"log_level,omitempty"`
 	MaxLaunchableDiskUsage string                 `yaml:"max_launchable_disk_usage"`
+	LogExecTestGroup       []string               `yaml:"log_exec_test_group",omitempty`
 
 	// Params defines a collection of miscellaneous runtime parameters defined throughout the
 	// source files.
@@ -350,5 +352,6 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 		authPolicy:             authPolicy,
 		caFile:                 consulCAFile,
 		maxLaunchableDiskUsage: maxLaunchableDiskUsage,
+		logExecTestGroup:       preparerConfig.LogExecTestGroup,
 	}, nil
 }

--- a/pkg/runit/servicebuilder.go
+++ b/pkg/runit/servicebuilder.go
@@ -30,8 +30,9 @@ import (
 	"github.com/square/p2/Godeps/_workspace/src/gopkg.in/yaml.v2"
 )
 
-// This is in the runit package to avoid import cycles, it should probably move somewhere else
+// These are in the runit package to avoid import cycles.
 type RestartPolicy string
+type LogExec []string
 
 const (
 	RestartPolicyAlways RestartPolicy = "always"

--- a/pkg/runit/servicebuilder_test.go
+++ b/pkg/runit/servicebuilder_test.go
@@ -16,6 +16,7 @@ import (
 var fakeTemplate map[string]ServiceTemplate = map[string]ServiceTemplate{
 	"foo": ServiceTemplate{
 		Run: []string{"foo", "one", "two"},
+		Log: []string{"log", "three", "four"},
 	},
 }
 


### PR DESCRIPTION
A generic bridge from an io.Reader to an io.Writer. This also allows us to configure a log executable on a per pod basis. Internally, we'll use this to catch logs from stdout and route them into our logging infrastructure.

Please pay special attention to style, logging convention and testing convention. This is my first PR into this repo.