### PR TITLE
Generic prefix watcher

### DIFF
--- a/pkg/kp/consulutil/safe.go
+++ b/pkg/kp/consulutil/safe.go
@@ -1,0 +1,43 @@
+package consulutil
+
+import (
+	"errors"
+
+	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/api"
+)
+
+// CanceledError signifies that the Consul operation was explicitly canceled.
+var CanceledError = errors.New("Consul operation canceled")
+
+// ConsulLister is a portion of the interface for api.KV
+type ConsulLister interface {
+	List(prefix string, opts *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error)
+}
+
+type listReply struct {
+	pairs     api.KVPairs
+	queryMeta *api.QueryMeta
+	err       error
+}
+
+// SafeList performs a KV List operation that can be canceled. When the "done" channel is
+// closed, CanceledError will be immediately returned. (The HTTP RPC can't be canceled,
+// but it will be ignored.)
+func SafeList(
+	clientKV ConsulLister,
+	done <-chan struct{},
+	prefix string,
+	options *api.QueryOptions,
+) (api.KVPairs, *api.QueryMeta, error) {
+	resultChan := make(chan listReply, 1)
+	go func() {
+		pairs, queryMeta, err := clientKV.List(prefix, options)
+		resultChan <- listReply{pairs, queryMeta, err}
+	}()
+	select {
+	case <-done:
+		return nil, nil, CanceledError
+	case r := <-resultChan:
+		return r.pairs, r.queryMeta, r.err
+	}
+}

--- a/pkg/kp/consulutil/watch.go
+++ b/pkg/kp/consulutil/watch.go
@@ -1,0 +1,165 @@
+package consulutil
+
+import (
+	"time"
+
+	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/api"
+)
+
+// WatchPrefix watches a Consul prefix for changes to any keys that have the prefix. When
+// anything changes, all Key/Value pairs having that prefix will be written to the
+// provided channel.
+//
+// Errors will sent on the given output channel but do not otherwise affect execution. The
+// given output stream will become owned by this function call, and this call will close
+// it when the function ends. This function will run until explicitly canceled by closing
+// the "done" channel. Data is written to the output channel synchronously, so readers
+// must consume the data or this method will block.
+func WatchPrefix(
+	prefix string,
+	clientKV ConsulLister,
+	outPairs chan<- api.KVPairs,
+	done <-chan struct{},
+	outErrors chan<- error,
+) {
+	defer close(outPairs)
+	var currentIndex uint64
+	timer := time.NewTimer(time.Duration(0))
+
+	for {
+		select {
+		case <-done:
+			return
+		case <-timer.C:
+		}
+		timer.Reset(250 * time.Millisecond) // upper bound on request rate
+		pairs, queryMeta, err := SafeList(clientKV, done, prefix, &api.QueryOptions{
+			WaitIndex: currentIndex,
+		})
+		switch err {
+		case CanceledError:
+			return
+		case nil:
+			currentIndex = queryMeta.LastIndex
+			select {
+			case <-done:
+			case outPairs <- pairs:
+			}
+		default:
+			select {
+			case <-done:
+			case outErrors <- err:
+			}
+			timer.Reset(2 * time.Second) // backoff
+		}
+	}
+}
+
+type NewKeyHandler func(key string) chan<- *api.KVPair
+
+type keyMeta struct {
+	created    uint64
+	modified   uint64
+	subscriber chan<- *api.KVPair
+}
+
+// WatchNewKeys watches for changes to a list of Key/Value pairs and lets each key be
+// handled individually though a subscription-like interface.
+//
+// This function models a key's lifetime in the following way. When a key is first seen,
+// the given NewKeyHandler function will be run, which may return a channel. When the
+// key's value changes, new K/V updates are sent to the key's notification channel. When
+// the key is deleted, `nil` is sent. After being deleted or if the watcher is asked to
+// exit, a key's channel will be closed, to notify the receiver that no further updates
+// are coming.
+//
+// WatchNewKeys doesn't watch a prefix itself--the caller should arrange a suitable input
+// stream of K/V pairs, probably from WatchPrefix(). This function runs until the input
+// stream closes. Closing "done" will asynchronously cancel the watch and cause it to
+// eventually exit.
+func WatchNewKeys(pairsChan <-chan api.KVPairs, onNewKey NewKeyHandler, done <-chan struct{}) {
+	keys := make(map[string]*keyMeta)
+
+	defer func() {
+		for _, keyMeta := range keys {
+			if keyMeta.subscriber != nil {
+				close(keyMeta.subscriber)
+			}
+		}
+	}()
+
+	for {
+		var pairs api.KVPairs
+		var ok bool
+		select {
+		case <-done:
+			return
+		case pairs, ok = <-pairsChan:
+			if !ok {
+				return
+			}
+		}
+
+		visited := make(map[string]bool)
+
+		// Scan for new and changed keys
+		for _, pair := range pairs {
+			visited[pair.Key] = true
+			if keyMeta, ok := keys[pair.Key]; ok {
+				if keyMeta.created == pair.CreateIndex {
+					// Existing key that was seen before
+					if keyMeta.subscriber != nil && keyMeta.modified != pair.ModifyIndex {
+						// It's changed!
+						keyMeta.modified = pair.ModifyIndex
+						select {
+						case <-done:
+							return
+						case keyMeta.subscriber <- pair:
+						}
+					}
+					continue
+				} else {
+					// This key was deleted and recreated between queries
+					if keyMeta.subscriber != nil {
+						select {
+						case <-done:
+							return
+						case keyMeta.subscriber <- nil:
+						}
+						close(keyMeta.subscriber)
+					}
+					// Fall through to re-create this key
+				}
+			}
+			// Found a new key
+			keyMeta := &keyMeta{
+				created:    pair.CreateIndex,
+				modified:   pair.ModifyIndex,
+				subscriber: onNewKey(pair.Key),
+			}
+			keys[pair.Key] = keyMeta
+			if keyMeta.subscriber != nil {
+				select {
+				case <-done:
+					return
+				case keyMeta.subscriber <- pair:
+				}
+			}
+		}
+
+		// Scan for deleted keys
+		for key, keyMeta := range keys {
+			if !visited[key] {
+				if keyMeta.subscriber != nil {
+					select {
+					case <-done:
+						return
+					case keyMeta.subscriber <- nil:
+					}
+					close(keyMeta.subscriber)
+				}
+				delete(keys, key)
+			}
+		}
+	}
+}

--- a/pkg/kp/consulutil/watch_test.go
+++ b/pkg/kp/consulutil/watch_test.go
@@ -1,0 +1,432 @@
+package consulutil
+
+import (
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/api"
+	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/testutil"
+)
+
+// PairRecord is a record of a single update to the Consul KV store
+type PairRecord struct {
+	// "create", "update", "delete", or "close"
+	Change string
+	// k/v details
+	Key   string
+	Value string
+}
+
+func (r PairRecord) IsCreate(key string) bool {
+	return r.Change == "create" && r.Key == key
+}
+
+func (r PairRecord) IsUpdate(pair *api.KVPair) bool {
+	return r.Change == "update" && r.Key == pair.Key && r.Value == string(pair.Value)
+}
+
+func (r PairRecord) IsDelete(key string) bool {
+	return r.Change == "delete" && r.Key == key
+}
+
+func (r PairRecord) IsClose(key string) bool {
+	return r.Change == "close" && r.Key == key
+}
+
+type PairRecords []PairRecord
+
+// Filter returns a slice of records for the given key
+func (rs PairRecords) Filter(key string) PairRecords {
+	newRs := make(PairRecords, 0)
+	for _, r := range rs {
+		if r.Key == key {
+			newRs = append(newRs, r)
+		}
+	}
+	return newRs
+}
+
+// PairRecorder can subscribe to a watch stream and record all notifications it receives.
+type PairRecorder struct {
+	T       *testing.T
+	Mutex   sync.Mutex
+	Cond    *sync.Cond
+	Records []PairRecord
+}
+
+func NewRecorder(t *testing.T) *PairRecorder {
+	p := &PairRecorder{
+		T:       t,
+		Records: make([]PairRecord, 0),
+	}
+	p.Cond = sync.NewCond(&p.Mutex)
+	return p
+}
+
+func (p *PairRecorder) WaitFor(length int) PairRecords {
+	p.Mutex.Lock()
+	defer p.Mutex.Unlock()
+	for len(p.Records) < length {
+		p.Cond.Wait()
+	}
+	return PairRecords(p.Records[:])
+}
+
+func (p *PairRecorder) RecordList() PairRecords {
+	p.Mutex.Lock()
+	defer p.Mutex.Unlock()
+	return PairRecords(p.Records[:])
+}
+
+func (p *PairRecorder) Append(change, key string, value []byte) {
+	p.Mutex.Lock()
+	defer p.Mutex.Unlock()
+	p.Records = append(p.Records, PairRecord{change, key, string(value)})
+	p.Cond.Broadcast()
+}
+
+// Handler is a NewKeyHandler that will process new keys and arrange for their values to
+// be recorded.
+func (p *PairRecorder) Handler(key string) chan<- *api.KVPair {
+	p.T.Logf("%s create", key)
+	p.Append("create", key, nil)
+	updates := make(chan *api.KVPair)
+	go func() {
+		for pair := range updates {
+			if pair != nil {
+				p.T.Logf("%s = %s", key, string(pair.Value))
+				p.Append("update", key, pair.Value)
+			} else {
+				p.T.Logf("%s delete", key)
+				p.Append("delete", key, nil)
+			}
+		}
+		p.T.Logf("%s done", key)
+		p.Append("close", key, nil)
+	}()
+	return updates
+}
+
+func kvToMap(pairs api.KVPairs) map[string]string {
+	m := make(map[string]string)
+	for _, pair := range pairs {
+		m[pair.Key] = string(pair.Value)
+	}
+	return m
+}
+
+func kvMatch(m map[string]string, pair *api.KVPair) bool {
+	val, ok := m[pair.Key]
+	return ok && val == string(pair.Value)
+}
+
+func getPorts(t *testing.T, count int) []int {
+	ports := make([]int, count)
+	for i := 0; i < count; i++ {
+		l, err := net.Listen("tcp", "localhost:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer l.Close()
+		_, portStr, err := net.SplitHostPort(l.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		ports[i], err = strconv.Atoi(portStr)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return ports
+}
+
+func testLogger(t *testing.T) chan<- error {
+	c := make(chan error)
+	go func() {
+		for err := range c {
+			t.Log(err)
+		}
+	}()
+	return c
+}
+
+// TestWatchPrefix verifies some basic operations of the WatchPrefix() funciton. It should
+// find existing data, send new updates when the data changes, and ignore changes outside
+// its prefix.
+func TestWatchPrefix(t *testing.T) {
+	// Set up a real Consul server
+	if testing.Short() {
+		t.Skip("skipping test dependent on consul because of short mode")
+	}
+	defer func() {
+		if t.Skipped() {
+			t.Error("failing skipped test")
+		}
+	}()
+	server := testutil.NewTestServerConfig(t, func(c *testutil.TestServerConfig) {
+		ports := getPorts(t, 6)
+		c.Ports = &testutil.TestPortConfig{
+			DNS:     ports[0],
+			HTTP:    ports[1],
+			RPC:     ports[2],
+			SerfLan: ports[3],
+			SerfWan: ports[4],
+			Server:  ports[5],
+		}
+	})
+	defer server.Stop()
+	client, err := api.NewClient(&api.Config{
+		Address: server.HTTPAddr,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	defer func() {
+		if done != nil {
+			close(done)
+		}
+	}()
+	pairsChan := make(chan api.KVPairs)
+	kv1a := &api.KVPair{Key: "prefix/hello", Value: []byte("world")}
+	kv1b := &api.KVPair{Key: "prefix/hello", Value: []byte("computer")}
+	kv2a := &api.KVPair{Key: "prefix/test", Value: []byte("foo")}
+	kv3a := &api.KVPair{Key: "something", Value: []byte("different")}
+
+	// Process existing data
+	client.KV().Put(kv1a, nil)
+	go WatchPrefix("prefix/", client.KV(), pairsChan, done, testLogger(t))
+	pairs := kvToMap(<-pairsChan)
+	if !kvMatch(pairs, kv1a) {
+		t.Error("existing data not recognized")
+	}
+
+	// Get an updates when the data changes (create, modify, delete)
+	client.KV().Put(kv1b, nil)
+	pairs = kvToMap(<-pairsChan)
+	if !kvMatch(pairs, kv1b) {
+		t.Error("value not updated")
+	}
+	client.KV().Put(kv2a, nil)
+	pairs = kvToMap(<-pairsChan)
+	if !kvMatch(pairs, kv2a) {
+		t.Error("did not find new value")
+	}
+	if !kvMatch(pairs, kv1b) {
+		t.Error("old value disappeared")
+	}
+	client.KV().Delete(kv1a.Key, nil)
+	pairs = kvToMap(<-pairsChan)
+	if _, ok := pairs[kv1a.Key]; ok {
+		t.Error("did not register deletion")
+	}
+
+	// The watcher should ignore kv3a, which is outside its prefix
+	client.KV().Put(kv3a, nil)
+	client.KV().Delete(kv2a.Key, nil)
+	pairs = kvToMap(<-pairsChan)
+	if _, ok := pairs[kv3a.Key]; ok {
+		t.Error("found a key with the wrong prefix")
+	}
+	close(done)
+	done = nil
+	for p := range pairsChan {
+		pairs = kvToMap(p)
+		if _, ok := pairs[kv3a.Key]; ok {
+			t.Error("found a key with the wrong prefix")
+		}
+	}
+}
+
+// TestWatchNewKeysSimple is a simple test for WatchNewKeys() basic functionality. Create
+// a key, change it, then delete it.
+func TestWatchNewKeysSimple(t *testing.T) {
+	t.Parallel()
+	pairsInput := make(chan api.KVPairs)
+	defer close(pairsInput)
+	recorder := NewRecorder(t)
+	go WatchNewKeys(pairsInput, recorder.Handler, nil)
+	pairsInput <- api.KVPairs{}
+	key := "hello"
+	kv1 := &api.KVPair{Key: key, Value: []byte("world"), CreateIndex: 1, ModifyIndex: 1}
+	kv2 := &api.KVPair{Key: key, Value: []byte("computer"), CreateIndex: 1, ModifyIndex: 2}
+
+	// Create a key
+	pairsInput <- api.KVPairs{kv1} // put hello
+	rs := recorder.WaitFor(2)
+	if !rs[0].IsCreate(key) || !rs[1].IsUpdate(kv1) {
+		t.Error("unexpected record sequence")
+	}
+
+	// Change the key
+	pairsInput <- api.KVPairs{kv2} // put hello
+	rs = recorder.WaitFor(3)
+	if !rs[2].IsUpdate(kv2) {
+		t.Error("unexpected record sequence")
+	}
+
+	// Delete the key
+	pairsInput <- api.KVPairs{} // delete hello
+	rs = recorder.WaitFor(5)
+	if !rs[3].IsDelete(key) || !rs[4].IsClose(key) {
+		t.Error("unexpected record sequence")
+	}
+
+	t.Log("full record sequence", recorder.RecordList())
+}
+
+// TestWatchNewKeysIgnore verifies that the watcher can handle keys that are ignored.
+func TestWatchNewKeysIgnore(t *testing.T) {
+	t.Parallel()
+	var newKeyCounter int
+	pairsInput := make(chan api.KVPairs)
+	done := make(chan struct{})
+	defer close(done)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		WatchNewKeys(
+			pairsInput,
+			func(key string) chan<- *api.KVPair {
+				t.Log("new key:", key)
+				newKeyCounter++
+				return nil
+			},
+			done,
+		)
+		wg.Done()
+	}()
+	pairsInput <- api.KVPairs{}
+	kv1a := &api.KVPair{Key: "foo", Value: []byte("A"), CreateIndex: 1, ModifyIndex: 1}
+	kv1b := &api.KVPair{Key: "foo", Value: []byte("B"), CreateIndex: 1, ModifyIndex: 2}
+	kv2a := &api.KVPair{Key: "bar", Value: []byte("A"), CreateIndex: 3, ModifyIndex: 3}
+
+	// Perform a batch of writes
+	pairsInput <- api.KVPairs{kv1a}       // New key
+	pairsInput <- api.KVPairs{kv1b}       // Update should have no effect
+	pairsInput <- api.KVPairs{kv1b, kv2a} // Another new key
+	close(pairsInput)
+
+	// Wait for updates to be noticed
+	wg.Wait()
+	if newKeyCounter != 2 {
+		t.Errorf("writes had 2 new keys, found %d", newKeyCounter)
+	}
+}
+
+// TestWatchNewKeysMulti writes to two different keys and verifies that their update
+// notifications are independent.
+func TestWatchNewKeysMulti(t *testing.T) {
+	t.Parallel()
+	pairsInput := make(chan api.KVPairs)
+	defer close(pairsInput)
+	recorder := NewRecorder(t)
+	go WatchNewKeys(pairsInput, recorder.Handler, nil)
+	pairsInput <- api.KVPairs{}
+	key1 := "foo"
+	key2 := "bar"
+	kv1a := &api.KVPair{Key: key1, Value: []byte("1A"), CreateIndex: 1, ModifyIndex: 1}
+	kv1b := &api.KVPair{Key: key1, Value: []byte("1B"), CreateIndex: 1, ModifyIndex: 2}
+	kv1c := &api.KVPair{Key: key1, Value: []byte("1C"), CreateIndex: 1, ModifyIndex: 3}
+	kv2a := &api.KVPair{Key: key2, Value: []byte("2A"), CreateIndex: 4, ModifyIndex: 4}
+	kv2b := &api.KVPair{Key: key2, Value: []byte("2B"), CreateIndex: 4, ModifyIndex: 5}
+	kv2c := &api.KVPair{Key: key2, Value: []byte("2C"), CreateIndex: 4, ModifyIndex: 6}
+
+	pairsInput <- api.KVPairs{kv1a}       // put foo=1A
+	pairsInput <- api.KVPairs{kv1b}       // put foo=1B
+	pairsInput <- api.KVPairs{kv1b, kv2a} // put bar=2A
+
+	rs := recorder.WaitFor(5)
+	rs1 := rs.Filter(key1)
+	rs2 := rs.Filter(key2)
+	t.Log("rs1", rs1)
+	t.Log("rs2", rs2)
+	if !(len(rs1) == 3 && rs1[0].IsCreate(key1) && rs1[1].IsUpdate(kv1a) && rs1[2].IsUpdate(kv1b)) ||
+		!(len(rs2) == 2 && rs2[0].IsCreate(key2) && rs2[1].IsUpdate(kv2a)) {
+		t.Error("unexpected record sequence")
+	}
+
+	pairsInput <- api.KVPairs{kv1c, kv2a} // put foo=1C
+	pairsInput <- api.KVPairs{kv1c, kv2b} // put bar=2B
+	pairsInput <- api.KVPairs{kv2b}       // delete foo
+	pairsInput <- api.KVPairs{kv2c}       // put bar=2C
+
+	rs = recorder.WaitFor(10)
+	rs1 = rs.Filter(key1)
+	rs2 = rs.Filter(key2)
+	t.Log("rs1", rs1)
+	t.Log("rs2", rs2)
+	if !(len(rs1) == 6 && rs1[3].IsUpdate(kv1c) && rs1[4].IsDelete(key1) && rs1[5].IsClose(key1)) ||
+		!(len(rs2) == 4 && rs2[2].IsUpdate(kv2b) && rs2[3].IsUpdate(kv2c)) {
+		t.Error("unexpected record sequence")
+	}
+
+	t.Log("full record sequence", recorder.RecordList())
+}
+
+// TestWatchNewKeysExit verifies that the watcher is capable of exiting early and that it
+// will notify its subscribers.
+func TestWatchNewKeysExit(t *testing.T) {
+	t.Parallel()
+	pairsInput := make(chan api.KVPairs)
+	recorder := NewRecorder(t)
+	done := make(chan struct{})
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		WatchNewKeys(pairsInput, recorder.Handler, done)
+		wg.Done()
+	}()
+	pairsInput <- api.KVPairs{}
+	key1 := "foo"
+	kv1a := &api.KVPair{Key: key1, Value: []byte("1A"), CreateIndex: 1, ModifyIndex: 1}
+
+	pairsInput <- api.KVPairs{kv1a}
+	rs := recorder.WaitFor(2)
+	if !rs[0].IsCreate(key1) || !rs[1].IsUpdate(kv1a) {
+		t.Errorf("error creating key")
+	}
+
+	// Ask the watcher to exit, eventually
+	close(done)
+
+	// Because the watcher is asynchronous, it might need to consume more input before
+	// exiting. In practice, the "done" signal should also stop the producer.
+	exiting := make(chan struct{})
+	defer close(exiting)
+	go func() {
+		for {
+			select {
+			case pairsInput <- api.KVPairs{kv1a}: // no change
+			case <-exiting:
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+	rs = recorder.WaitFor(3)
+	if !rs[2].IsClose(key1) {
+		t.Errorf("subscriber did not receive close notification")
+	}
+}
+
+// TestWatchNewKeysExistingData verifies that the watcher will find existing keys (i.e.,
+// when its first input is nonempty) and report them as new data.
+func TestWatchNewKeysExistingData(t *testing.T) {
+	t.Parallel()
+	pairsInput := make(chan api.KVPairs)
+	recorder := NewRecorder(t)
+	go WatchNewKeys(pairsInput, recorder.Handler, nil)
+	kv1a := &api.KVPair{Key: "test", Value: []byte("1A"), CreateIndex: 1, ModifyIndex: 1}
+
+	pairsInput <- api.KVPairs{kv1a}
+
+	rs := recorder.WaitFor(2)
+	if !rs[0].IsCreate("test") || !rs[1].IsUpdate(kv1a) {
+		t.Error("error picking up existing data")
+	}
+}

--- a/pkg/preparer/listener.go
+++ b/pkg/preparer/listener.go
@@ -49,7 +49,7 @@ func (l *HookListener) Sync(quit <-chan struct{}, errCh chan<- error) {
 		select {
 		case <-quit:
 			l.Logger.NoFields().Infoln("Terminating hook listener")
-			watcherQuit <- struct{}{}
+			close(watcherQuit)
 			return
 		case err := <-watcherErrCh:
 			l.Logger.WithError(err).Errorln("Error while watching pods")


### PR DESCRIPTION
There are already several implementations of code that watches Consul for a list of keys and does something with the changed ones.  Each implementation has its own quirks in how it polls Consul (unnecessary) and its own way of processing the results into specific object types (necessary).  The intent of this PR was to write a more uniform, robust implementation of this procedure that could be re-used by other methods inside `pkg/kp/...` and still allow them to add type-specific behavior.

The changes to `"pkg/kp".consulStore.WatchPods()` is illustrative of the kind of change that I intent to make on other stores.  It doesn't reduce the line count, but I think the result is more robust and has cleaner separation into generic and type-specific parts.

The PR isn't quite complete in that I haven't used the new methods to replace all the users I wanted to replace—it turns out that they are quite complicated.  Still, it'll be useful to get some feedback on this code, which seems like it's fairly clean and stable.