### PR TITLE
Emit KVErrors directly from SafeList()

### DIFF
--- a/bin/p2-inspect/main.go
+++ b/bin/p2-inspect/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/square/p2/pkg/health/checker"
 	"github.com/square/p2/pkg/inspect"
 	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/kp/flags"
 	"github.com/square/p2/pkg/version"
 )
@@ -28,7 +29,7 @@ func main() {
 	intents, _, err := store.ListPods(kp.INTENT_TREE)
 	if err != nil {
 		message := "Could not list intent kvpairs: %s"
-		if kvErr, ok := err.(kp.KVError); ok {
+		if kvErr, ok := err.(consulutil.KVError); ok {
 			log.Fatalf(message, kvErr.UnsafeError)
 		} else {
 			log.Fatalf(message, err)
@@ -37,7 +38,7 @@ func main() {
 	realities, _, err := store.ListPods(kp.REALITY_TREE)
 	if err != nil {
 		message := "Could not list reality kvpairs: %s"
-		if kvErr, ok := err.(kp.KVError); ok {
+		if kvErr, ok := err.(consulutil.KVError); ok {
 			log.Fatalf(message, kvErr.UnsafeError)
 		} else {
 			log.Fatalf(message, err)

--- a/pkg/health/checker/checker.go
+++ b/pkg/health/checker/checker.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/square/p2/pkg/health"
 	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/kp/consulutil"
 
 	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/api"
 )
@@ -90,7 +91,7 @@ func (c consulHealthChecker) WatchService(
 				WaitIndex: curIndex,
 			})
 			if err != nil {
-				errCh <- kp.NewKVError("list", kp.HealthPath(serviceID, ""), err)
+				errCh <- consulutil.NewKVError("list", kp.HealthPath(serviceID, ""), err)
 			} else {
 				out := make(map[string]health.Result)
 				for _, result := range results {

--- a/pkg/kp/consulutil/safe.go
+++ b/pkg/kp/consulutil/safe.go
@@ -2,9 +2,71 @@ package consulutil
 
 import (
 	"errors"
+	"fmt"
+	"path/filepath"
+	"runtime"
 
 	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/api"
+
+	"github.com/square/p2/pkg/util/param"
 )
+
+// Show detailed error messages from Consul (use only when debugging)
+var showConsulErrors = param.Bool("show_consul_errors_unsafe", false)
+
+// KVError encapsulates an error in a Store operation. Errors returned from the
+// Consul API cannot be exposed because they may contain the URL of the request,
+// which includes an ACL token as a query parameter.
+type KVError struct {
+	Op          string
+	Key         string
+	UnsafeError error
+	filename    string
+	function    string
+	lineNumber  int
+}
+
+// Error implements the error and "pkg/util".CallsiteError interfaces.
+func (err KVError) Error() string {
+	cerr := ""
+	if *showConsulErrors {
+		cerr = fmt.Sprintf(": %s", err.UnsafeError)
+	}
+	return fmt.Sprintf("%s failed for path %s%s", err.Op, err.Key, cerr)
+}
+
+// LineNumber implements the "pkg/util".CallsiteError interface.
+func (err KVError) LineNumber() int {
+	return err.lineNumber
+}
+
+// Filename implements the "pkg/util".CallsiteError interface.
+func (err KVError) Filename() string {
+	return err.filename
+}
+
+// Function implements the "pkg/util".CallsiteError interface.
+func (err KVError) Function() string {
+	return err.function
+}
+
+// NewKVError constructs a new KVError to wrap errors from Consul.
+func NewKVError(op string, key string, unsafeError error) KVError {
+	var function string
+	// Skip one stack frame to get the file & line number of caller.
+	pc, file, line, ok := runtime.Caller(1)
+	if ok {
+		function = runtime.FuncForPC(pc).Name()
+	}
+	return KVError{
+		Op:          op,
+		Key:         key,
+		UnsafeError: unsafeError,
+		filename:    filepath.Base(file),
+		function:    function,
+		lineNumber:  line,
+	}
+}
 
 // CanceledError signifies that the Consul operation was explicitly canceled.
 var CanceledError = errors.New("Consul operation canceled")

--- a/pkg/kp/consulutil/safe.go
+++ b/pkg/kp/consulutil/safe.go
@@ -84,7 +84,7 @@ type listReply struct {
 
 // SafeList performs a KV List operation that can be canceled. When the "done" channel is
 // closed, CanceledError will be immediately returned. (The HTTP RPC can't be canceled,
-// but it will be ignored.)
+// but it will be ignored.) Errors from Consul will be wrapped in a KVError value.
 func SafeList(
 	clientKV ConsulLister,
 	done <-chan struct{},
@@ -94,6 +94,9 @@ func SafeList(
 	resultChan := make(chan listReply, 1)
 	go func() {
 		pairs, queryMeta, err := clientKV.List(prefix, options)
+		if err != nil {
+			err = NewKVError("list", prefix, err)
+		}
 		resultChan <- listReply{pairs, queryMeta, err}
 	}()
 	select {

--- a/pkg/kp/healthmanager.go
+++ b/pkg/kp/healthmanager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/api"
 
 	"github.com/square/p2/pkg/health"
+	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/util/limit"
 	"github.com/square/p2/pkg/util/param"
@@ -258,7 +259,7 @@ func processHealthUpdater(
 				go sendHealthUpdate(writeLogger, w, nil, false, func() error {
 					_, err := client.KV().Delete(key, nil)
 					if err != nil {
-						return NewKVError("delete", key, err)
+						return consulutil.NewKVError("delete", key, err)
 					}
 					return nil
 				})
@@ -287,7 +288,7 @@ func processHealthUpdater(
 					go sendHealthUpdate(writeLogger, w, localHealth, doThrottle, func() error {
 						ok, _, err := client.KV().Acquire(kv, nil)
 						if err != nil {
-							return NewKVError("acquire", kv.Key, err)
+							return consulutil.NewKVError("acquire", kv.Key, err)
 						}
 						if !ok {
 							return fmt.Errorf("write denied")
@@ -298,7 +299,7 @@ func processHealthUpdater(
 					go sendHealthUpdate(writeLogger, w, localHealth, doThrottle, func() error {
 						_, err := client.KV().Put(kv, nil)
 						if err != nil {
-							return NewKVError("put", kv.Key, err)
+							return consulutil.NewKVError("put", kv.Key, err)
 						}
 						return nil
 					})

--- a/pkg/kp/kv.go
+++ b/pkg/kp/kv.go
@@ -6,8 +6,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/api"
@@ -16,14 +14,10 @@ import (
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/util"
-	"github.com/square/p2/pkg/util/param"
 )
 
 // Healthcheck TTL
 const TTL = 60 * time.Second
-
-// Show detailed error messages from Consul (use only when debugging)
-var showConsulErrors = param.Bool("show_consul_errors_unsafe", false)
 
 type ManifestResult struct {
 	Manifest pods.Manifest
@@ -108,57 +102,6 @@ func NewConsulStore(client *api.Client) Store {
 	}
 }
 
-// KVError encapsulates an error in a Store operation. Errors returned from the
-// Consul API cannot be exposed because they may contain the URL of the request,
-// which includes an ACL token as a query parameter.
-type KVError struct {
-	Op          string
-	Key         string
-	UnsafeError error
-	filename    string
-	function    string
-	lineNumber  int
-}
-
-var _ util.CallsiteError = KVError{}
-
-func (err KVError) Error() string {
-	cerr := ""
-	if *showConsulErrors {
-		cerr = fmt.Sprintf(": %s", err.UnsafeError)
-	}
-	return fmt.Sprintf("%s failed for path %s%s", err.Op, err.Key, cerr)
-}
-
-func (err KVError) Filename() string {
-	return err.filename
-}
-
-func (err KVError) Function() string {
-	return err.function
-}
-
-func (err KVError) LineNumber() int {
-	return err.lineNumber
-}
-
-func NewKVError(op string, key string, unsafeError error) KVError {
-	var function string
-	// Skip one stack frame to get the file & line number of caller.
-	pc, file, line, ok := runtime.Caller(1)
-	if ok {
-		function = runtime.FuncForPC(pc).Name()
-	}
-	return KVError{
-		Op:          op,
-		Key:         key,
-		UnsafeError: unsafeError,
-		filename:    filepath.Base(file),
-		function:    function,
-		lineNumber:  line,
-	}
-}
-
 func (c consulStore) PutHealth(res WatchResult) (time.Time, time.Duration, error) {
 	key := HealthPath(res.Service, res.Node)
 
@@ -180,7 +123,7 @@ func (c consulStore) PutHealth(res WatchResult) (time.Time, time.Duration, error
 		retDur = writeMeta.RequestTime
 	}
 	if err != nil {
-		return now, retDur, NewKVError("put", key, err)
+		return now, retDur, consulutil.NewKVError("put", key, err)
 	}
 	return now, retDur, nil
 }
@@ -190,16 +133,16 @@ func (c consulStore) GetHealth(service, node string) (WatchResult, error) {
 	key := HealthPath(service, node)
 	res, _, err := c.client.KV().Get(key, nil)
 	if err != nil {
-		return WatchResult{}, NewKVError("get", key, err)
+		return WatchResult{}, consulutil.NewKVError("get", key, err)
 	} else if res == nil {
 		return WatchResult{}, nil
 	}
 	err = json.Unmarshal(res.Value, healthRes)
 	if err != nil {
-		return WatchResult{}, NewKVError("get", key, err)
+		return WatchResult{}, consulutil.NewKVError("get", key, err)
 	}
 	if healthRes.IsStale() {
-		return *healthRes, NewKVError("get", key, fmt.Errorf("stale health entry"))
+		return *healthRes, consulutil.NewKVError("get", key, fmt.Errorf("stale health entry"))
 	}
 	return *healthRes, nil
 }
@@ -209,7 +152,7 @@ func (c consulStore) GetServiceHealth(service string) (map[string]WatchResult, e
 	key := HealthPath(service, "")
 	res, _, err := c.client.KV().List(key, nil)
 	if err != nil {
-		return healthRes, NewKVError("list", key, err)
+		return healthRes, consulutil.NewKVError("list", key, err)
 	} else if res == nil {
 		return healthRes, nil
 	}
@@ -217,7 +160,7 @@ func (c consulStore) GetServiceHealth(service string) (map[string]WatchResult, e
 		watch := &WatchResult{}
 		err = json.Unmarshal(kvp.Value, watch)
 		if err != nil {
-			return healthRes, NewKVError("get", key, err)
+			return healthRes, consulutil.NewKVError("get", key, err)
 		}
 		// maps key to result (eg /health/hello/nodename)
 		healthRes[kvp.Key] = *watch
@@ -245,7 +188,7 @@ func (c consulStore) SetPod(key string, manifest pods.Manifest) (time.Duration, 
 		retDur = writeMeta.RequestTime
 	}
 	if err != nil {
-		return retDur, NewKVError("put", key, err)
+		return retDur, consulutil.NewKVError("put", key, err)
 	}
 	return retDur, nil
 }
@@ -255,7 +198,7 @@ func (c consulStore) SetPod(key string, manifest pods.Manifest) (time.Duration, 
 func (c consulStore) DeletePod(key string) (time.Duration, error) {
 	writeMeta, err := c.client.KV().Delete(key, nil)
 	if err != nil {
-		return 0, NewKVError("delete", key, err)
+		return 0, consulutil.NewKVError("delete", key, err)
 	}
 	return writeMeta.RequestTime, nil
 }
@@ -266,7 +209,7 @@ func (c consulStore) DeletePod(key string) (time.Duration, error) {
 func (c consulStore) Pod(key string) (pods.Manifest, time.Duration, error) {
 	kvPair, writeMeta, err := c.client.KV().Get(key, nil)
 	if err != nil {
-		return nil, 0, NewKVError("get", key, err)
+		return nil, 0, consulutil.NewKVError("get", key, err)
 	}
 	if kvPair == nil {
 		return nil, writeMeta.RequestTime, pods.NoCurrentManifest
@@ -282,7 +225,7 @@ func (c consulStore) Pod(key string) (pods.Manifest, time.Duration, error) {
 func (c consulStore) ListPods(keyPrefix string) ([]ManifestResult, time.Duration, error) {
 	kvPairs, queryMeta, err := c.client.KV().List(keyPrefix, nil)
 	if err != nil {
-		return nil, 0, NewKVError("list", keyPrefix, err)
+		return nil, 0, consulutil.NewKVError("list", keyPrefix, err)
 	}
 	var ret []ManifestResult
 
@@ -314,7 +257,7 @@ func (c consulStore) WatchPods(keyPrefix string, quitChan <-chan struct{}, errCh
 			select {
 			case <-quitChan:
 				return
-			case errChan <- NewKVError("list", keyPrefix, err):
+			case errChan <- consulutil.NewKVError("list", keyPrefix, err):
 			}
 		}
 	}()
@@ -358,7 +301,7 @@ func (c consulStore) WatchPods(keyPrefix string, quitChan <-chan struct{}, errCh
 func (c consulStore) Ping() error {
 	_, qm, err := c.client.Catalog().Nodes(&api.QueryOptions{RequireConsistent: true})
 	if err != nil {
-		return NewKVError("ping", "/catalog/nodes", err)
+		return consulutil.NewKVError("ping", "/catalog/nodes", err)
 	}
 	if qm == nil || !qm.KnownLeader {
 		return util.Errorf("No known leader")

--- a/pkg/kp/lock.go
+++ b/pkg/kp/lock.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/api"
+
+	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/util"
 )
 
@@ -91,7 +93,7 @@ func (c consulStore) NewUnmanagedLock(session, name string) Lock {
 func (c consulStore) LockHolder(key string) (string, string, error) {
 	kvp, _, err := c.client.KV().Get(key, nil)
 	if err != nil {
-		return "", "", NewKVError("get", key, err)
+		return "", "", consulutil.NewKVError("get", key, err)
 	}
 	if kvp == nil || kvp.Session == "" {
 		return "", "", nil
@@ -120,7 +122,7 @@ func (l Lock) Lock(key string) error {
 	}, nil)
 
 	if err != nil {
-		return NewKVError("acquire lock", key, err)
+		return consulutil.NewKVError("acquire lock", key, err)
 	}
 	if success {
 		return nil
@@ -133,7 +135,7 @@ func (l Lock) Lock(key string) error {
 func (l Lock) Unlock(key string) error {
 	kvp, meta, err := l.client.KV().Get(key, nil)
 	if err != nil {
-		return NewKVError("get", key, err)
+		return consulutil.NewKVError("get", key, err)
 	}
 	if kvp == nil {
 		return nil
@@ -147,7 +149,7 @@ func (l Lock) Unlock(key string) error {
 		ModifyIndex: meta.LastIndex,
 	}, nil)
 	if err != nil {
-		return NewKVError("deletecas", key, err)
+		return consulutil.NewKVError("deletecas", key, err)
 	}
 	if !success {
 		// the key has been mutated since we checked it - probably someone

--- a/pkg/kp/rcstore/consul_store.go
+++ b/pkg/kp/rcstore/consul_store.go
@@ -10,6 +10,7 @@ import (
 	klabels "github.com/square/p2/Godeps/_workspace/src/k8s.io/kubernetes/pkg/labels"
 
 	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/rc/fields"
@@ -107,7 +108,7 @@ func (s *consulStore) innerCreate(manifest pods.Manifest, nodeSelector klabels.S
 	}, nil)
 
 	if err != nil {
-		return fields.RC{}, kp.NewKVError("cas", rcp, err)
+		return fields.RC{}, consulutil.NewKVError("cas", rcp, err)
 	}
 	if !success {
 		return fields.RC{}, CASError(rcp)


### PR DESCRIPTION
Changes SafeList() to only return errors that have already been wrapped in the
KVError type. This greatly simplifies error handling around the WatchPrefix()
function.

To do this, I had to move the KVError type into the "consulutil" package to avoid
a circular import.