### PR TITLE
Use wrapper structs around typed errors

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -64,13 +64,13 @@ func (hl *Launchable) Halt(serviceBuilder *runit.ServiceBuilder, sv runit.SV) er
 	// since the output is more useful to the user, that's what we'll preserve
 	out, err := hl.disable()
 	if err != nil {
-		return launch.DisableError(util.Errorf("%s", out))
+		return launch.DisableError{util.Errorf("%s", out)}
 	}
 
 	// probably want to do something with output at some point
 	err = hl.stop(serviceBuilder, sv)
 	if err != nil {
-		return launch.StopError(err)
+		return launch.StopError{err}
 	}
 
 	err = hl.makeLast()
@@ -84,13 +84,13 @@ func (hl *Launchable) Halt(serviceBuilder *runit.ServiceBuilder, sv runit.SV) er
 func (hl *Launchable) Launch(serviceBuilder *runit.ServiceBuilder, sv runit.SV) error {
 	err := hl.start(serviceBuilder, sv)
 	if err != nil {
-		return launch.StartError(err)
+		return launch.StartError{err}
 	}
 
 	// same as disable
 	out, err := hl.enable()
 	if err != nil {
-		return launch.EnableError(util.Errorf("%s", out))
+		return launch.EnableError{util.Errorf("%s", out)}
 	}
 	return nil
 }

--- a/pkg/hoist/hoist_launchable_test.go
+++ b/pkg/hoist/hoist_launchable_test.go
@@ -268,6 +268,8 @@ func TestHaltWithFailingDisable(t *testing.T) {
 	Assert(t).IsNotNil(err, "Expected error while halting")
 	_, ok := err.(launch.DisableError)
 	Assert(t).IsTrue(ok, "Expected disable error to be returned")
+	_, ok = err.(launch.StopError)
+	Assert(t).IsFalse(ok, "Did not expect stop error to be returned")
 }
 
 func TestHaltWithPassingDisable(t *testing.T) {
@@ -290,6 +292,8 @@ func TestLaunchWithFailingEnable(t *testing.T) {
 	Assert(t).IsNotNil(err, "Expected error while launching")
 	_, ok := err.(launch.EnableError)
 	Assert(t).IsTrue(ok, "Expected enable error to be returned")
+	_, ok = err.(launch.StartError)
+	Assert(t).IsFalse(ok, "Did not expect start error to be returned")
 }
 
 func TestLaunchWithPassingEnable(t *testing.T) {
@@ -310,6 +314,8 @@ func TestHaltWithFailingStop(t *testing.T) {
 	Assert(t).IsNotNil(err, "Expected error while halting")
 	_, ok := err.(launch.StopError)
 	Assert(t).IsTrue(ok, "Expected stop error to be returned")
+	_, ok = err.(launch.DisableError)
+	Assert(t).IsFalse(ok, "Did not expect disable error to be returned")
 }
 
 func TestLaunchWithFailingStart(t *testing.T) {
@@ -321,6 +327,8 @@ func TestLaunchWithFailingStart(t *testing.T) {
 	Assert(t).IsNotNil(err, "Expected error while launching")
 	_, ok := err.(launch.StartError)
 	Assert(t).IsTrue(ok, "Expected start error to be returned")
+	_, ok = err.(launch.EnableError)
+	Assert(t).IsFalse(ok, "Did not expect enable error to be returned")
 }
 
 func TestOnceIfRestartNever(t *testing.T) {

--- a/pkg/launch/launchable.go
+++ b/pkg/launch/launchable.go
@@ -9,10 +9,21 @@ import (
 	"github.com/square/p2/pkg/uri"
 )
 
-type DisableError error
-type EnableError error
-type StartError error
-type StopError error
+type DisableError struct{ Inner error }
+
+func (e DisableError) Error() string { return e.Inner.Error() }
+
+type EnableError struct{ Inner error }
+
+func (e EnableError) Error() string { return e.Inner.Error() }
+
+type StartError struct{ Inner error }
+
+func (e StartError) Error() string { return e.Inner.Error() }
+
+type StopError struct{ Inner error }
+
+func (e StopError) Error() string { return e.Inner.Error() }
 
 // Launchable describes a type of app that can be downloaded and launched.
 type Launchable interface {

--- a/pkg/opencontainer/containers.go
+++ b/pkg/opencontainer/containers.go
@@ -232,7 +232,7 @@ func (l *Launchable) makeLast() error {
 func (l *Launchable) Launch(serviceBuilder *runit.ServiceBuilder, sv runit.SV) error {
 	err := l.start(serviceBuilder, sv)
 	if err != nil {
-		return launch.StartError(err)
+		return launch.StartError{err}
 	}
 	// No "enable" for OpenContainers
 	return nil
@@ -289,7 +289,7 @@ func (l *Launchable) Halt(serviceBuilder *runit.ServiceBuilder, sv runit.SV) err
 	// "disable" script not supported for containers
 	err := l.stop(serviceBuilder, sv)
 	if err != nil {
-		return launch.StopError(err)
+		return launch.StopError{err}
 	}
 
 	err = l.makeLast()


### PR DESCRIPTION
as observed by @bwester , the type aliasing doesn't work for interface type assertion. We need real structs to wrap around the errors. (cough sum type cough)