### PR TITLE
Update to go1.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.4.2
+  - 1.5.1
 
 before_install:
   - sudo apt-get update -qq

--- a/Rakefile
+++ b/Rakefile
@@ -41,7 +41,7 @@ end
 
 desc 'Install all built binaries'
 task :install do
-  e "go install -a -ldflags \"-X github.com/square/p2/pkg/version.VERSION $(git describe --tags)\" ./..."
+  e "go install -a -ldflags \"-X github.com/square/p2/pkg/version.VERSION=$(git describe --tags)\" ./..."
 end
 
 desc 'Package the installed P2 binaries into a Hoist artifact that runs as the preparer. The output tar is symlinked to builds/p2.tar.gz'


### PR DESCRIPTION
Silences a new linker warning for the -X flag:

```
$ rake install
go install -a -ldflags "-X github.com/square/p2/pkg/version.VERSION $(git describe --tags)" ./...
# github.com/square/p2/bin/p2-exec
link: warning: option -X github.com/square/p2/pkg/version.VERSION 0.0.10-49-gc46c850 may not work in future releases; use -X github.com/square/p2/pkg/version.VERSION=0.0.10-49-gc46c850
```