### PR TITLE
write an 'env' dir in the launchable root with LAUNCHABLE_HOME var

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -27,7 +27,7 @@ type Launchable struct {
 	Location         string              // A URL where we can download the artifact from.
 	Id               string              // A unique identifier for this launchable, used when creating runit services
 	RunAs            string              // The user to assume when launching the executable
-	ConfigDir        string              // The value for chpst -e. See http://smarden.org/runit/chpst.8.html
+	PodEnvDir        string              // The value for chpst -e. See http://smarden.org/runit/chpst.8.html
 	Fetcher          uri.Fetcher         // Callback that downloads the file from the remote location.
 	RootDir          string              // The root directory of the launchable, containing N:N>=1 installs.
 	P2Exec           string              // Struct that can be used to build a p2-exec invocation with appropriate flags
@@ -143,7 +143,7 @@ func (hl *Launchable) InvokeBinScript(script string) (string, error) {
 	p2ExecArgs := p2exec.P2ExecArgs{
 		Command:          []string{cmdPath},
 		User:             hl.RunAs,
-		EnvDir:           hl.ConfigDir,
+		EnvDir:           hl.PodEnvDir,
 		NoLimits:         hl.ExecNoLimit,
 		CgroupConfigName: hl.CgroupConfigName,
 		CgroupName:       cgroupName,
@@ -234,7 +234,7 @@ func (hl *Launchable) Executables(
 		p2ExecArgs := p2exec.P2ExecArgs{
 			Command:          []string{filepath.Join(serviceDir, service.Name())},
 			User:             hl.RunAs,
-			EnvDir:           hl.ConfigDir,
+			EnvDir:           hl.PodEnvDir,
 			NoLimits:         hl.ExecNoLimit,
 			CgroupConfigName: hl.CgroupConfigName,
 			CgroupName:       hl.Id,
@@ -357,6 +357,14 @@ func (hl *Launchable) flipSymlink(newLinkPath string) error {
 	}
 
 	return os.Rename(tempLinkPath, newLinkPath)
+}
+
+func (hl *Launchable) EnvDir() string {
+	return filepath.Join(hl.RootDir, "env")
+}
+
+func (hl *Launchable) Path() string {
+	return hl.RootDir
 }
 
 func (hl *Launchable) InstallDir() string {

--- a/pkg/hoist/hoist_launchable_test.go
+++ b/pkg/hoist/hoist_launchable_test.go
@@ -32,7 +32,7 @@ func TestInstall(t *testing.T) {
 		Location:  testLocation,
 		Id:        "hello",
 		RunAs:     currentUser.Username,
-		ConfigDir: launchableHome,
+		PodEnvDir: launchableHome,
 		Fetcher:   fetcher,
 		RootDir:   launchableHome,
 	}
@@ -63,7 +63,7 @@ func TestInstallDir(t *testing.T) {
 		Location:  testLocation,
 		Id:        "testLaunchable",
 		RunAs:     "testuser",
-		ConfigDir: tempDir,
+		PodEnvDir: tempDir,
 		Fetcher:   uri.DefaultFetcher,
 		RootDir:   tempDir,
 	}

--- a/pkg/hoist/test_helper.go
+++ b/pkg/hoist/test_helper.go
@@ -19,7 +19,7 @@ func FakeHoistLaunchableForDir(dirName string) (*Launchable, *runit.ServiceBuild
 		Location:  "testLaunchable.tar.gz",
 		Id:        "testPod__testLaunchable",
 		RunAs:     "testPod",
-		ConfigDir: tempDir,
+		PodEnvDir: tempDir,
 		Fetcher:   uri.DefaultFetcher,
 		RootDir:   launchableInstallDir,
 		P2Exec:    util.From(runtime.Caller(0)).ExpandPath("fake_p2-exec"),
@@ -44,8 +44,8 @@ func FakeHoistLaunchableForDir(dirName string) (*Launchable, *runit.ServiceBuild
 }
 
 func CleanupFakeLaunchable(h *Launchable, s *runit.ServiceBuilder) {
-	if os.TempDir() != h.ConfigDir {
-		os.RemoveAll(h.ConfigDir)
+	if os.TempDir() != h.PodEnvDir {
+		os.RemoveAll(h.PodEnvDir)
 	}
 	if os.TempDir() != s.RunitRoot {
 		os.RemoveAll(s.RunitRoot)

--- a/pkg/launch/launchable.go
+++ b/pkg/launch/launchable.go
@@ -33,6 +33,11 @@ type Launchable interface {
 	ID() string
 	// InstallDir is the directory where this launchable is or will be placed.
 	InstallDir() string
+	// EnvDir is the directory in which launchable environment variables
+	// will be expressed as files
+	EnvDir() string
+	// The root directory for the launchable.
+	Path() string
 	// Executables gets a list of the commands that are part of this launchable.
 	Executables(serviceBuilder *runit.ServiceBuilder) ([]Executable, error)
 	// Installed returns true if this launchable is already installed.

--- a/pkg/opencontainer/containers.go
+++ b/pkg/opencontainer/containers.go
@@ -88,6 +88,14 @@ func (l *Launchable) Fetcher() uri.Fetcher {
 	return uri.DefaultFetcher
 }
 
+func (l *Launchable) EnvDir() string {
+	return filepath.Join(l.RootDir, "env")
+}
+
+func (l *Launchable) Path() string {
+	return l.RootDir
+}
+
 // InstallDir is the directory where this launchable should be installed.
 func (l *Launchable) InstallDir() string {
 	launchableName := l.Version()


### PR DESCRIPTION
this will allow us to export an environment variable to launched
processes that will allow them to find the root of the launchable
easily.