### PR TITLE
Pass multiple env dirs to p2-exec when launching a launchable.

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -143,7 +143,7 @@ func (hl *Launchable) InvokeBinScript(script string) (string, error) {
 	p2ExecArgs := p2exec.P2ExecArgs{
 		Command:          []string{cmdPath},
 		User:             hl.RunAs,
-		EnvDir:           hl.PodEnvDir,
+		EnvDirs:          []string{hl.PodEnvDir, hl.EnvDir()},
 		NoLimits:         hl.ExecNoLimit,
 		CgroupConfigName: hl.CgroupConfigName,
 		CgroupName:       cgroupName,
@@ -234,7 +234,7 @@ func (hl *Launchable) Executables(
 		p2ExecArgs := p2exec.P2ExecArgs{
 			Command:          []string{filepath.Join(serviceDir, service.Name())},
 			User:             hl.RunAs,
-			EnvDir:           hl.PodEnvDir,
+			EnvDirs:          []string{hl.PodEnvDir, hl.EnvDir()},
 			NoLimits:         hl.ExecNoLimit,
 			CgroupConfigName: hl.CgroupConfigName,
 			CgroupName:       hl.Id,

--- a/pkg/p2exec/p2_exec.go
+++ b/pkg/p2exec/p2_exec.go
@@ -4,7 +4,7 @@ package p2exec
 // applicable flags
 type P2ExecArgs struct {
 	User             string
-	EnvDir           string
+	EnvDirs          []string
 	NoLimits         bool
 	CgroupName       string
 	CgroupConfigName string
@@ -22,8 +22,8 @@ func (args P2ExecArgs) CommandLine() []string {
 		cmd = append(cmd, "-u", args.User)
 	}
 
-	if args.EnvDir != "" {
-		cmd = append(cmd, "-e", args.EnvDir)
+	for _, envDir := range args.EnvDirs {
+		cmd = append(cmd, "-e", envDir)
 	}
 
 	if args.CgroupConfigName != "" {

--- a/pkg/p2exec/p2_exec_test.go
+++ b/pkg/p2exec/p2_exec_test.go
@@ -20,12 +20,12 @@ func TestBuildWithArgs(t *testing.T) {
 		Command:          []string{"script"},
 		NoLimits:         true,
 		User:             "some_user",
-		EnvDir:           "some_dir",
+		EnvDirs:          []string{"some_dir", "other_dir"},
 		CgroupConfigName: "some_cgroup_config_name",
 		CgroupName:       "cgroup_name",
 	}
 
-	expected = "-n -u some_user -e some_dir -l some_cgroup_config_name -c cgroup_name script"
+	expected = "-n -u some_user -e some_dir -e other_dir -l some_cgroup_config_name -c cgroup_name script"
 	actual = strings.Join(args.CommandLine(), " ")
 	if actual != expected {
 		t.Errorf("Expected args.BuildWithArgs() to return '%s', was '%s'", expected, actual)


### PR DESCRIPTION
This allows us to utilize the launchable-specific env directory and
export the variables within it to the launched process(es)