### PR TITLE
Modify the LAUNCHABLE_HOME variable to be LAUNCHABLE_ROOT

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -363,10 +363,6 @@ func (hl *Launchable) EnvDir() string {
 	return filepath.Join(hl.RootDir, "env")
 }
 
-func (hl *Launchable) Path() string {
-	return hl.RootDir
-}
-
 func (hl *Launchable) InstallDir() string {
 	launchableName := hl.Version()
 	return filepath.Join(hl.RootDir, "installs", launchableName)

--- a/pkg/launch/launchable.go
+++ b/pkg/launch/launchable.go
@@ -36,8 +36,6 @@ type Launchable interface {
 	// EnvDir is the directory in which launchable environment variables
 	// will be expressed as files
 	EnvDir() string
-	// The root directory for the launchable.
-	Path() string
 	// Executables gets a list of the commands that are part of this launchable.
 	Executables(serviceBuilder *runit.ServiceBuilder) ([]Executable, error)
 	// Installed returns true if this launchable is already installed.

--- a/pkg/opencontainer/containers.go
+++ b/pkg/opencontainer/containers.go
@@ -92,10 +92,6 @@ func (l *Launchable) EnvDir() string {
 	return filepath.Join(l.RootDir, "env")
 }
 
-func (l *Launchable) Path() string {
-	return l.RootDir
-}
-
 // InstallDir is the directory where this launchable should be installed.
 func (l *Launchable) InstallDir() string {
 	launchableName := l.Version()

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -438,7 +438,7 @@ func (pod *Pod) Verify(manifest Manifest, authPolicy auth.Policy) error {
 //
 // 3) writes an "env" directory for each launchable. The "env" directory
 // contains environment files specific to a launchable (such as
-// LAUNCHABLE_HOME)
+// LAUNCHABLE_ROOT)
 //
 // We may wish to provide a "config" directory per launchable at some point as
 // well, so that launchables can have different config namespaces
@@ -513,7 +513,7 @@ func (pod *Pod) setupConfig(manifest Manifest, launchables []launch.Launchable) 
 		if err != nil {
 			return util.Errorf("Could not create the environment dir for pod %s launchable %s: %s", manifest.ID(), launchable.ID(), err)
 		}
-		err = writeEnvFile(launchable.EnvDir(), "LAUNCHABLE_HOME", launchable.Path(), uid, gid)
+		err = writeEnvFile(launchable.EnvDir(), "LAUNCHABLE_ROOT", launchable.InstallDir(), uid, gid)
 		if err != nil {
 			return err
 		}

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -143,9 +143,9 @@ config:
 	Assert(t).AreEqual(platformConfigPath, string(platEnv), "The env path to platform config didn't match")
 
 	for _, launchable := range launchables {
-		launchableHomeEnv, err := ioutil.ReadFile(filepath.Join(launchable.EnvDir(), "LAUNCHABLE_HOME"))
-		Assert(t).IsNil(err, "should not have erred reading the launchable home env file")
-		Assert(t).AreEqual(launchable.Path(), string(launchableHomeEnv), "The launchable home path did not match expected")
+		launchableRootEnv, err := ioutil.ReadFile(filepath.Join(launchable.EnvDir(), "LAUNCHABLE_ROOT"))
+		Assert(t).IsNil(err, "should not have erred reading the launchable root env file")
+		Assert(t).AreEqual(launchable.InstallDir(), string(launchableRootEnv), "The launchable root path did not match expected")
 	}
 }
 


### PR DESCRIPTION
The variable used to point to the top level directory for a launchable,
e.g. /data/pods/<pod>/<launchable> in a default preparer configuration.
It's more useful to have a variable that tells the launchable where it
has been installed, e.g.
/data/pods/<pod>/<launchable>/installs/<launchable>_<version>/