### PR TITLE
Fix double-launch bug

### DIFF
--- a/pkg/preparer/orchestrate_test.go
+++ b/pkg/preparer/orchestrate_test.go
@@ -170,6 +170,10 @@ func (f *FakeStore) SetPod(string, pods.Manifest) (time.Duration, error) {
 	return 0, nil
 }
 
+func (f *FakeStore) Pod(key string) (pods.Manifest, time.Duration, error) {
+	return nil, 0, fmt.Errorf("not implemented")
+}
+
 func (f *FakeStore) DeletePod(string) (time.Duration, error) {
 	return 0, nil
 }


### PR DESCRIPTION
Adds a quick fix for a bug in which app will be installed twice. More details
are in the patch itself.

Tested manually by watching scheduling a manifest, waiting for the preparer to
pick it up, then scheduling the same thing again. This procedure is sufficient
to get the earlier version to install twice. With this change, it doesn't.