### PR TITLE
add byte string converter

### DIFF
--- a/pkg/util/size/bytes.go
+++ b/pkg/util/size/bytes.go
@@ -1,0 +1,70 @@
+// Package size provides a converter between a string representation of a size and
+// a number of bytes, and reverse.
+package size
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type ByteCount float64
+
+const (
+	Byte ByteCount = 1 << (10 * iota)
+	Kibibyte
+	Mebibyte
+	Gibibyte
+	Tebibyte
+)
+
+var byteStringPattern = regexp.MustCompile(`(?i)^\s*(\-?[\d\.]+)\s*([TGMK]b?|B|)\s*$`)
+
+func (b ByteCount) String() string {
+	var ret string
+	switch {
+	case b >= Tebibyte:
+		ret = fmt.Sprintf("%7.1fT", b/Tebibyte)
+	case b >= Gibibyte:
+		ret = fmt.Sprintf("%7.1fG", b/Gibibyte)
+	case b >= Mebibyte:
+		ret = fmt.Sprintf("%7.1fM", b/Mebibyte)
+	case b >= Kibibyte:
+		ret = fmt.Sprintf("%7.1fK", b/Kibibyte)
+	default:
+		return fmt.Sprintf("%dB", int64(b))
+	}
+	return strings.TrimSpace(ret)
+}
+
+// Parse a string containing a string representation of a byte count.
+func Parse(sizeStr string) (ByteCount, error) {
+	if !byteStringPattern.MatchString(sizeStr) {
+		return 0, fmt.Errorf("Invalid byte representation provided: %s", sizeStr)
+	}
+
+	subs := byteStringPattern.FindStringSubmatch(sizeStr)
+
+	size, err := strconv.ParseFloat(string(subs[1]), 64)
+	if err != nil {
+		return 0, fmt.Errorf("Invalid byte representation %s provided, got error: %s", sizeStr, err)
+	}
+
+	unit := strings.ToUpper(string(subs[2]))
+
+	switch unit {
+	case "B", "":
+		size = size * float64(Byte)
+	case "KB", "K":
+		size = size * float64(Kibibyte)
+	case "MB", "M":
+		size = size * float64(Mebibyte)
+	case "GB", "G":
+		size = size * float64(Gibibyte)
+	case "TB", "T":
+		size = size * float64(Tebibyte)
+	}
+
+	return ByteCount(size), nil
+}

--- a/pkg/util/size/bytes_test.go
+++ b/pkg/util/size/bytes_test.go
@@ -1,0 +1,49 @@
+package size
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/square/p2/Godeps/_workspace/src/github.com/anthonybishopric/gotcha"
+)
+
+func TestSizeParsing(t *testing.T) {
+	tests := map[string]ByteCount{
+		"1":        Byte,
+		"10":       ByteCount(10),
+		"80B":      ByteCount(80),
+		"0.001K":   0.001 * Kibibyte,
+		"10G":      10 * Gibibyte,
+		"100.5 MB": 100.5 * Mebibyte,
+		"80T":      80 * Tebibyte,
+		"zilch":    ByteCount(-1),
+		"1000BB":   ByteCount(-1),
+		"1.0.0.0K": ByteCount(-1),
+	}
+
+	for str, expected := range tests {
+		actual, err := Parse(str)
+		if expected == ByteCount(-1) {
+			Assert(t).IsNotNil(err, fmt.Sprintf("Should have erred parsing size %s", str))
+		} else {
+			Assert(t).AreEqual(expected, actual, fmt.Sprintf("Sizes did not match for string %s", str))
+		}
+	}
+}
+
+func TestSizeString(t *testing.T) {
+	tests := map[ByteCount]string{
+		Byte:             "1B",
+		ByteCount(10):    "10B",
+		ByteCount(80):    "80B",
+		0.001 * Kibibyte: "1B",
+		ByteCount(999):   "999B",
+		10 * Gibibyte:    "10.0G",
+		100.5 * Mebibyte: "100.5M",
+		80 * Tebibyte:    "80.0T",
+	}
+
+	for value, expected := range tests {
+		Assert(t).AreEqual(expected, value.String(), fmt.Sprintf("Strings didn't match %f", value))
+	}
+}


### PR DESCRIPTION
This will be used for parsing cgroup memory sizes as well as configuring the p2-preparer with a max `installs` directory size per pod.