### PR TITLE
Prune launchable directories over specified size limit.

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -363,7 +363,11 @@ func (hl *Launchable) EnvDir() string {
 	return filepath.Join(hl.RootDir, "env")
 }
 
+func (hl *Launchable) AllInstallsDir() string {
+	return filepath.Join(hl.RootDir, "installs")
+}
+
 func (hl *Launchable) InstallDir() string {
 	launchableName := hl.Version()
-	return filepath.Join(hl.RootDir, "installs", launchableName)
+	return filepath.Join(hl.AllInstallsDir(), launchableName)
 }

--- a/pkg/hoist/prune.go
+++ b/pkg/hoist/prune.go
@@ -1,0 +1,100 @@
+package hoist
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/square/p2/pkg/util/size"
+)
+
+// Prune will attempt to get the total size of the launchable's installs
+// directory to be equal to or less than the maximum specified number of
+// bytes. This method will preserve any directories that are pointed to
+// by the `current` or `last` symlinks. Installations will be removed from
+// oldest to newest.
+func (hl *Launchable) Prune(maxSize size.ByteCount) error {
+	curTarget, err := os.Readlink(hl.CurrentDir())
+	if os.IsNotExist(err) {
+		curTarget = ""
+	} else if err != nil {
+		return err
+	}
+	curTarget = filepath.Base(curTarget)
+
+	lastTarget, err := os.Readlink(hl.LastDir())
+	if os.IsNotExist(err) {
+		lastTarget = ""
+	} else if err != nil {
+		return err
+	}
+	lastTarget = filepath.Base(lastTarget)
+
+	installs, err := ioutil.ReadDir(hl.AllInstallsDir())
+	if os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	var totalSize size.ByteCount = 0
+
+	installSizes := map[string]size.ByteCount{}
+
+	for _, i := range installs {
+		installSize, err := hl.sizeOfInstall(i.Name())
+		if err != nil {
+			return err
+		}
+		totalSize += size.ByteCount(installSize)
+		installSizes[i.Name()] = installSize
+	}
+
+	oldestFirst := installsByAge(installs)
+	sort.Sort(oldestFirst)
+
+	for _, i := range oldestFirst {
+		if totalSize <= maxSize {
+			return nil
+		}
+
+		if i.Name() == curTarget || i.Name() == lastTarget {
+			continue
+		}
+
+		installSize := installSizes[i.Name()]
+		err = os.RemoveAll(filepath.Join(hl.AllInstallsDir(), i.Name()))
+		if err != nil {
+			return err
+		}
+		totalSize = totalSize - size.ByteCount(installSize)
+	}
+
+	return nil
+}
+
+func (hl *Launchable) sizeOfInstall(name string) (size.ByteCount, error) {
+	var total int64
+	err := filepath.Walk(filepath.Join(hl.AllInstallsDir(), name), func(_ string, info os.FileInfo, err error) error {
+		if !info.IsDir() {
+			total += info.Size()
+		}
+		return err
+	})
+	return size.ByteCount(total), err
+}
+
+type installsByAge []os.FileInfo
+
+func (in installsByAge) Less(i, j int) bool {
+	return in[i].ModTime().Unix() < in[j].ModTime().Unix()
+}
+
+func (in installsByAge) Swap(i, j int) {
+	in[i], in[j] = in[j], in[i]
+}
+
+func (in installsByAge) Len() int {
+	return len(in)
+}

--- a/pkg/hoist/prune_test.go
+++ b/pkg/hoist/prune_test.go
@@ -1,0 +1,146 @@
+package hoist
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/square/p2/pkg/util/size"
+
+	. "github.com/square/p2/Godeps/_workspace/src/github.com/anthonybishopric/gotcha"
+)
+
+type testInstall struct {
+	name      string
+	modTime   time.Time
+	byteCount size.ByteCount
+}
+
+func (i testInstall) create(parent string) error {
+	path := filepath.Join(parent, "installs", i.name)
+	err := os.MkdirAll(path, 0755)
+	if err != nil {
+		return err
+	}
+	payloadPath := filepath.Join(parent, "installs", i.name, "payload")
+	file, err := os.OpenFile(payloadPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	var soFar int64
+	bytesToWrite := []byte{'a'}
+	for size.ByteCount(soFar) < i.byteCount {
+		written, err := file.Write(bytesToWrite)
+		if err != nil {
+			return err
+		}
+		soFar += int64(written)
+	}
+
+	err = file.Close()
+	if err != nil {
+		return err
+	}
+
+	if i.name == "current" {
+		err := os.Symlink(path, filepath.Join(parent, "current"))
+		if err != nil {
+			return err
+		}
+	}
+
+	if i.name == "last" {
+		err := os.Symlink(path, filepath.Join(parent, "last"))
+		if err != nil {
+			return err
+		}
+	}
+
+	return os.Chtimes(path, i.modTime, i.modTime)
+}
+
+func launchableWithInstallations(t *testing.T, installs []testInstall, testFn func(*Launchable)) {
+	parent, err := ioutil.TempDir("", "prune")
+	defer os.RemoveAll(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, i := range installs {
+		err := i.create(parent)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	launchable := &Launchable{
+		RootDir: parent,
+	}
+	testFn(launchable)
+}
+
+func assertShouldBePruned(t *testing.T, hl *Launchable, name string) {
+	_, err := os.Stat(filepath.Join(hl.AllInstallsDir(), name))
+	Assert(t).IsTrue(os.IsNotExist(err), fmt.Sprintf("Should have removed %v", name))
+}
+
+func assertShouldExist(t *testing.T, hl *Launchable, name string) {
+	info, err := os.Stat(filepath.Join(hl.AllInstallsDir(), name))
+	Assert(t).IsNil(err, fmt.Sprintf("should not have erred stat'ing %v", name))
+	Assert(t).IsTrue(info.IsDir(), fmt.Sprintf("Should not have removed the %v directory", name))
+}
+
+func TestPruneRemovesOldInstallations(t *testing.T) {
+	launchableWithInstallations(t, []testInstall{
+		{"first", time.Now().Add(-1000 * time.Hour), 10 * size.Kibibyte},
+		{"second", time.Now().Add(-800 * time.Hour), 10 * size.Kibibyte},
+		{"third", time.Now().Add(-600 * time.Hour), 10 * size.Kibibyte},
+	}, func(hl *Launchable) {
+
+		Assert(t).IsNil(hl.Prune(20*size.Kibibyte), "Should not have erred when pruning")
+
+		assertShouldBePruned(t, hl, "first")
+		assertShouldExist(t, hl, "second")
+		assertShouldExist(t, hl, "third")
+	})
+}
+
+func TestPruneIgnoresInstallsWhenUnderLimit(t *testing.T) {
+	launchableWithInstallations(t, []testInstall{
+		{"first", time.Now().Add(-1000 * time.Hour), 10 * size.Kibibyte},
+		{"second", time.Now().Add(-800 * time.Hour), 10 * size.Kibibyte},
+		{"third", time.Now().Add(-600 * time.Hour), 10 * size.Kibibyte},
+	}, func(hl *Launchable) {
+		Assert(t).IsNil(hl.Prune(2*size.Mebibyte), "Should not have erred when pruning")
+
+		assertShouldExist(t, hl, "first")
+		assertShouldExist(t, hl, "second")
+		assertShouldExist(t, hl, "third")
+	})
+}
+
+func TestPruneIgnoresCurrent(t *testing.T) {
+	launchableWithInstallations(t, []testInstall{
+		{"current", time.Now().Add(-1000 * time.Hour), 10 * size.Kibibyte},
+		{"second", time.Now().Add(-800 * time.Hour), 10 * size.Kibibyte},
+		{"third", time.Now().Add(-600 * time.Hour), 10 * size.Kibibyte},
+	}, func(hl *Launchable) {
+		Assert(t).IsNil(hl.Prune(20*size.Kibibyte), "Should not have erred when pruning")
+
+		assertShouldExist(t, hl, "current")
+		assertShouldBePruned(t, hl, "second")
+		assertShouldExist(t, hl, "third")
+	})
+}
+
+func TestPruneIgnoresCurrentAndLast(t *testing.T) {
+	launchableWithInstallations(t, []testInstall{
+		{"current", time.Now().Add(-1000 * time.Hour), 10 * size.Kibibyte},
+		{"last", time.Now().Add(-800 * time.Hour), 10 * size.Kibibyte},
+		{"third", time.Now().Add(-600 * time.Hour), 10 * size.Kibibyte},
+	}, func(hl *Launchable) {
+		Assert(t).IsNil(hl.Prune(20*size.Kibibyte), "Should not have erred when pruning")
+
+		assertShouldExist(t, hl, "current")
+		assertShouldExist(t, hl, "last")
+		assertShouldBePruned(t, hl, "third")
+	})
+}

--- a/pkg/launch/launchable.go
+++ b/pkg/launch/launchable.go
@@ -7,7 +7,10 @@ import (
 
 	"github.com/square/p2/pkg/runit"
 	"github.com/square/p2/pkg/uri"
+	"github.com/square/p2/pkg/util/size"
 )
+
+const DefaultAllowableDiskUsage = 10 * size.Gibibyte
 
 type DisableError struct{ Inner error }
 
@@ -54,6 +57,10 @@ type Launchable interface {
 	// MakeCurrent adjusts a "current" symlink for this launchable name to point to this
 	// launchable's version.
 	MakeCurrent() error
+	// Prune performs necessary cleanup for a particular launchable's resources, should it
+	// be necessary. The provided argument is guidance for how many bytes on disk a particular
+	// launchable should consume
+	Prune(size.ByteCount) error
 }
 
 // Executable describes a command and its arguments that should be executed to start a

--- a/pkg/opencontainer/containers.go
+++ b/pkg/opencontainer/containers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/square/p2/pkg/user"
 	"github.com/square/p2/pkg/util"
 	"github.com/square/p2/pkg/util/param"
+	"github.com/square/p2/pkg/util/size"
 )
 
 // The name of the OpenContainer spec file in the container's root.
@@ -300,5 +301,10 @@ func (l *Launchable) Halt(serviceBuilder *runit.ServiceBuilder, sv runit.SV) err
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+func (l *Launchable) Prune(max size.ByteCount) error {
+	// No-op for now
 	return nil
 }

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -20,6 +20,7 @@ import (
 	"github.com/square/p2/pkg/user"
 	"github.com/square/p2/pkg/util"
 	"github.com/square/p2/pkg/util/param"
+	"github.com/square/p2/pkg/util/size"
 
 	"github.com/square/p2/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 )
@@ -191,6 +192,20 @@ func (pod *Pod) Launch(manifest Manifest) (bool, error) {
 	}
 
 	return success, nil
+}
+
+func (pod *Pod) Prune(max size.ByteCount, manifest Manifest) {
+	launchables, err := pod.Launchables(manifest)
+	if err != nil {
+		return
+	}
+	for _, l := range launchables {
+		err := l.Prune(max)
+		if err != nil {
+			pod.logLaunchableError(l.ID(), err, "Could not prune directory")
+			// Don't return here. We want to prune other launchables if possible.
+		}
+	}
 }
 
 func (pod *Pod) Services(manifest Manifest) ([]runit.Service, error) {

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/util/size"
 )
 
 // The Pod ID of the preparer.
@@ -22,6 +23,7 @@ type Pod interface {
 	Uninstall() error
 	Verify(pods.Manifest, auth.Policy) error
 	Halt(pods.Manifest) (bool, error)
+	Prune(size.ByteCount, pods.Manifest)
 }
 
 type Hooks interface {
@@ -292,6 +294,8 @@ func (p *Preparer) installAndLaunchPod(pair ManifestPair, pod Pod, logger loggin
 		}
 
 		p.tryRunHooks(hooks.AFTER_LAUNCH, pod, pair.Intent, logger)
+
+		pod.Prune(p.maxLaunchableDiskUsage, pair.Intent) // errors are logged internally
 	}
 	return err == nil && ok
 }

--- a/pkg/preparer/orchestrate_test.go
+++ b/pkg/preparer/orchestrate_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/util"
+	"github.com/square/p2/pkg/util/size"
 )
 
 type TestPod struct {
@@ -26,6 +27,10 @@ type TestPod struct {
 	installed, uninstalled, launched, launchSuccess, halted, haltSuccess bool
 	installErr, uninstallErr, launchErr, haltError, currentManifestError error
 	configDir, envDir                                                    string
+}
+
+func (t *TestPod) Prune(_ size.ByteCount, _ pods.Manifest) {
+	return
 }
 
 func (t *TestPod) ManifestSHA() (string, error) {


### PR DESCRIPTION
This change prevents launchable directories from exceeding a
configurable size limit by removing cached installations from oldest
to newest until the limits have been overcome. This pruning facility
ignores directories pointed at by the `current` and `last` symlinks.