### PR TITLE
Add flags to p2-launch to support user auth policy

### DIFF
--- a/bin/p2-launch/main.go
+++ b/bin/p2-launch/main.go
@@ -3,14 +3,27 @@ package main
 import (
 	"log"
 
-	"github.com/square/p2/Godeps/_workspace/src/gopkg.in/alecthomas/kingpin.v2"
+	"github.com/square/p2/pkg/auth"
+	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/preparer"
+	"github.com/square/p2/pkg/util"
 	"github.com/square/p2/pkg/version"
+
+	"github.com/square/p2/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	"github.com/square/p2/Godeps/_workspace/src/gopkg.in/alecthomas/kingpin.v2"
 )
 
 var (
-	manifestURI = kingpin.Arg("manifest", "a path or url to a pod manifest that will be installed and launched immediately.").String()
-	podRoot     = kingpin.Flag("pod-root", "the root of the pods directory").Default(pods.DEFAULT_PATH).String()
+	manifestURI  = kingpin.Arg("manifest", "a path or url to a pod manifest that will be installed and launched immediately.").Required().ExistingFile()
+	podRoot      = kingpin.Flag("pod-root", "the root of the pods directory").Default(pods.DEFAULT_PATH).Short('p').String()
+	authType     = kingpin.Flag("auth-type", "the auth policy to use e.g. (none, keyring, user)").Short('a').Default("none").String()
+	keyring      = kingpin.Flag("keyring", "the pgp keyring to use for auth policies if --auth-type other than none is given").Short('k').ExistingFile()
+	allowedUsers = kingpin.Flag("allowed-user", "a user allowed to deploy. may be specified more than once. only necessary when '--auth-type keyring' is used").Short('u').Strings()
+	deployPolicy = kingpin.Flag(
+		"deploy-policy",
+		"the deploy policy specifying who may deploy each pod. Only used when --auth-type is 'user'",
+	).Short('d').ExistingFile()
 )
 
 func main() {
@@ -18,6 +31,11 @@ func main() {
 	kingpin.Parse()
 
 	manifest, err := pods.ManifestFromURI(*manifestURI)
+	if err != nil {
+		log.Fatalf("%s", err)
+	}
+
+	err = authorize(manifest)
 	if err != nil {
 		log.Fatalf("%s", err)
 	}
@@ -35,4 +53,74 @@ func main() {
 	if !success {
 		log.Fatalln("Unsuccessful launch of one or more things in the manifest")
 	}
+}
+
+func authorize(manifest pods.Manifest) error {
+	var policy auth.Policy
+	var err error
+	switch *authType {
+	case auth.Null:
+		if *keyring != "" {
+			return util.Errorf("--keyring may not be specified if --auth-type is '%s'", *authType)
+		}
+		if *deployPolicy != "" {
+			return util.Errorf("--deploy-policy may not be specified if --auth-type is '%s'", *authType)
+		}
+		if len(*allowedUsers) != 0 {
+			return util.Errorf("--allowed-users may not be specified if --auth-type is '%s'", *authType)
+		}
+
+		return nil
+	case auth.Keyring:
+		if *keyring == "" {
+			return util.Errorf("Must specify --keyring if --auth-type is '%s'", *authType)
+		}
+		if len(*allowedUsers) == 0 {
+			return util.Errorf("Must specify at least one allowed user if using a keyring auth type")
+		}
+
+		policy, err = auth.NewFileKeyringPolicy(
+			*keyring,
+			map[string][]string{
+				preparer.POD_ID: *allowedUsers,
+			},
+		)
+		if err != nil {
+			return err
+		}
+	case auth.User:
+		if *keyring == "" {
+			return util.Errorf("Must specify --keyring if --auth-type is '%s'", *authType)
+		}
+		if *deployPolicy == "" {
+			return util.Errorf("Must specify --deploy-policy if --auth-type is '%s'", *authType)
+		}
+
+		policy, err = auth.NewUserPolicy(
+			*keyring,
+			*deployPolicy,
+			preparer.POD_ID,
+			preparer.POD_ID,
+		)
+		if err != nil {
+			return err
+		}
+	default:
+		return util.Errorf("Unknown --auth-type: %s", *authType)
+	}
+
+	logger := logging.NewLogger(logrus.Fields{})
+	logger.Logger.Formatter = new(logrus.TextFormatter)
+
+	err = policy.AuthorizeApp(manifest, logger)
+	if err != nil {
+		if err, ok := err.(auth.Error); ok {
+			logger.WithFields(err.Fields).Errorln(err)
+		} else {
+			logger.NoFields().Errorln(err)
+		}
+		return err
+	}
+
+	return nil
 }

--- a/pkg/auth/policy.go
+++ b/pkg/auth/policy.go
@@ -15,6 +15,14 @@ import (
 	"github.com/square/p2/pkg/util"
 )
 
+// These string constants are used to determine the requested auth policy type
+// both in the "auth" section of preparer config and in p2-launch flags
+const (
+	Null    = "none"
+	Keyring = "keyring"
+	User    = "user"
+)
+
 // A Policy encapsulates the behavior a p2 node needs to authorize
 // its actions. It is possible for implementations to rely on other
 // services for these behaviors, so these calls may be slow or

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -258,9 +258,9 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 	switch t, _ := preparerConfig.Auth["type"].(string); t {
 	case "":
 		return nil, util.Errorf("must specify authorization policy type")
-	case "none":
+	case auth.Null:
 		authPolicy = auth.NullPolicy{}
-	case "keyring":
+	case auth.Keyring:
 		var authConfig KeyringAuth
 		err := castYaml(preparerConfig.Auth, &authConfig)
 		if err != nil {
@@ -276,7 +276,7 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 		if err != nil {
 			return nil, util.Errorf("error configuring keyring auth: %s", err)
 		}
-	case "user":
+	case auth.User:
 		var userConfig UserAuth
 		err := castYaml(preparerConfig.Auth, &userConfig)
 		if err != nil {


### PR DESCRIPTION
Adds --auth-type, --keyring, and --deploy-policy flags.

If launching a signed manifest from an untrusted source, a user of
p2-launch may wish to verify the signature of the manifest against a
deploy policy just as the preparer does.