### PR TITLE
Allow shorthand for memory limits.

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -169,7 +169,11 @@ func (subsys Subsystems) Write(config Config) error {
 	if err != nil {
 		return err
 	}
-	return subsys.SetMemory(config.Name, config.Memory)
+	memory, err := config.MemoryByteCount()
+	if err != nil {
+		return err
+	}
+	return subsys.SetMemory(config.Name, int(memory))
 }
 
 func (subsys Subsystems) AddPID(name string, pid int) error {

--- a/pkg/cgroups/config.go
+++ b/pkg/cgroups/config.go
@@ -2,12 +2,28 @@ package cgroups
 
 import (
 	"fmt"
+
+	"github.com/square/p2/pkg/util/size"
 )
 
 type Config struct {
 	Name   string `yaml:"-"`                // The name of the cgroup in cgroupfs
 	CPUs   int    `yaml:"cpus,omitempty"`   // The number of logical CPUs
-	Memory int    `yaml:"memory,omitempty"` // The number of bytes of memory
+	Memory string `yaml:"memory,omitempty"` // The number of bytes of memory
+}
+
+func NewCGroup(cpus int, memory size.ByteCount) Config {
+	return Config{
+		CPUs:   cpus,
+		Memory: memory.String(),
+	}
+}
+
+func (config Config) MemoryByteCount() (size.ByteCount, error) {
+	if config.Memory == "" {
+		return size.Byte * 0, nil
+	}
+	return size.Parse(config.Memory)
 }
 
 func (config Config) CgexecArgs() []string {

--- a/pkg/cgroups/config_test.go
+++ b/pkg/cgroups/config_test.go
@@ -1,0 +1,28 @@
+package cgroups
+
+import (
+	"testing"
+
+	"github.com/square/p2/pkg/util/size"
+
+	. "github.com/square/p2/Godeps/_workspace/src/github.com/anthonybishopric/gotcha"
+	"github.com/square/p2/Godeps/_workspace/src/gopkg.in/yaml.v2"
+)
+
+func TestMarshalIntegerByteCount(t *testing.T) {
+	integeredMemory := []byte(`memory: 500`)
+	config := Config{}
+	yaml.Unmarshal(integeredMemory, &config)
+	memory, err := config.MemoryByteCount()
+	Assert(t).IsNil(err, "Should not have erred getting the byte count")
+	Assert(t).AreEqual(memory, size.ByteCount(500), "Should have unmarshaled the integer representation of bytes")
+}
+
+func TestMarshalStringByteCount(t *testing.T) {
+	integeredMemory := []byte(`memory: 500G`)
+	config := Config{}
+	yaml.Unmarshal(integeredMemory, &config)
+	memory, err := config.MemoryByteCount()
+	Assert(t).IsNil(err, "Should not have erred getting the byte count")
+	Assert(t).AreEqual(memory, 500*size.Gibibyte, "Should have unmarshaled the integer representation of bytes")
+}

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -91,7 +91,7 @@ launchables:
     location: https://localhost:4444/foo/bar/baz.tar.gz
     cgroup:
       cpus: 4
-      memory: 4294967296
+      memory: 4G
 config:
   ENVIRONMENT: staging
 `
@@ -134,7 +134,7 @@ config:
 	expectedPlatConfig := `web:
   cgroup:
     cpus: 4
-    memory: 4294967296
+    memory: 4G
 `
 	Assert(t).AreEqual(expectedPlatConfig, string(platConfig), "the platform config didn't match")
 


### PR DESCRIPTION
This change allows manifest authors to specify a shorthand for
the byte limits of their cgroups. Previously, all `memory` entries
for the `cgroup` stanza had to be in the form of an integer
number of bytes. Authors may now use a shorthand as defined by
the package `github.com/square/p2/pkg/util/size`.

An author wishing to limit their launchable to a maximum resident
memory limit of 4 Gibibytes may use the shorthand `4G` instead of
`4294967296`.

The old form of specifying an integer limit of bytes is also supported.