### PR TITLE
add pod to the healthchecker logger

### DIFF
--- a/pkg/kp/healthmanager.go
+++ b/pkg/kp/healthmanager.go
@@ -122,6 +122,7 @@ func (m *consulHealthManager) NewUpdater(pod, service string) HealthUpdater {
 			sub.Chan(),
 			m.logger.SubLogger(logrus.Fields{
 				"service": service,
+				"pod":     pod,
 				"node":    m.node,
 			}),
 		)


### PR DESCRIPTION
Small change, makes it easier to identify healthchecking in logs.