### PR TITLE
Preserve cgroup serialization

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -169,11 +169,7 @@ func (subsys Subsystems) Write(config Config) error {
 	if err != nil {
 		return err
 	}
-	memory, err := config.MemoryByteCount()
-	if err != nil {
-		return err
-	}
-	return subsys.SetMemory(config.Name, int(memory))
+	return subsys.SetMemory(config.Name, int(config.Memory))
 }
 
 func (subsys Subsystems) AddPID(name string, pid int) error {

--- a/pkg/cgroups/config.go
+++ b/pkg/cgroups/config.go
@@ -7,23 +7,9 @@ import (
 )
 
 type Config struct {
-	Name   string `yaml:"-"`                // The name of the cgroup in cgroupfs
-	CPUs   int    `yaml:"cpus,omitempty"`   // The number of logical CPUs
-	Memory string `yaml:"memory,omitempty"` // The number of bytes of memory
-}
-
-func NewCGroup(cpus int, memory size.ByteCount) Config {
-	return Config{
-		CPUs:   cpus,
-		Memory: memory.String(),
-	}
-}
-
-func (config Config) MemoryByteCount() (size.ByteCount, error) {
-	if config.Memory == "" {
-		return size.Byte * 0, nil
-	}
-	return size.Parse(config.Memory)
+	Name   string         `yaml:"-"`                // The name of the cgroup in cgroupfs
+	CPUs   int            `yaml:"cpus,omitempty"`   // The number of logical CPUs
+	Memory size.ByteCount `yaml:"memory,omitempty"` // The number of bytes of memory
 }
 
 func (config Config) CgexecArgs() []string {

--- a/pkg/cgroups/config_test.go
+++ b/pkg/cgroups/config_test.go
@@ -12,17 +12,15 @@ import (
 func TestMarshalIntegerByteCount(t *testing.T) {
 	integeredMemory := []byte(`memory: 500`)
 	config := Config{}
-	yaml.Unmarshal(integeredMemory, &config)
-	memory, err := config.MemoryByteCount()
-	Assert(t).IsNil(err, "Should not have erred getting the byte count")
-	Assert(t).AreEqual(memory, size.ByteCount(500), "Should have unmarshaled the integer representation of bytes")
+	err := yaml.Unmarshal(integeredMemory, &config)
+	Assert(t).IsNil(err, "Should not have erred unmarshaling")
+	Assert(t).AreEqual(config.Memory, size.ByteCount(500), "Should have unmarshaled the integer representation of bytes")
 }
 
 func TestMarshalStringByteCount(t *testing.T) {
 	integeredMemory := []byte(`memory: 500G`)
 	config := Config{}
-	yaml.Unmarshal(integeredMemory, &config)
-	memory, err := config.MemoryByteCount()
-	Assert(t).IsNil(err, "Should not have erred getting the byte count")
-	Assert(t).AreEqual(memory, 500*size.Gibibyte, "Should have unmarshaled the integer representation of bytes")
+	err := yaml.Unmarshal(integeredMemory, &config)
+	Assert(t).IsNil(err, "Should not have erred unmarshaling")
+	Assert(t).AreEqual(config.Memory, 500*size.Gibibyte, "Should have unmarshaled the integer representation of bytes")
 }

--- a/pkg/pods/manifest_test.go
+++ b/pkg/pods/manifest_test.go
@@ -40,7 +40,7 @@ launchables:
     location: https://localhost:4444/foo/bar/baz.tar.gz
     cgroup:
       cpus: 4
-      memory: 1.0G
+      memory: 1073741824
 config:
   ENVIRONMENT: staging
 status_port: 8000
@@ -82,7 +82,10 @@ func TestPodManifestCanBeWritten(t *testing.T) {
 			LaunchableType: "hoist",
 			LaunchableId:   "web",
 			Location:       "https://localhost:4444/foo/bar/baz.tar.gz",
-			CgroupConfig:   cgroups.NewCGroup(4, 1*size.Gibibyte),
+			CgroupConfig: cgroups.Config{
+				CPUs:   4,
+				Memory: 1 * size.Gibibyte,
+			},
 		},
 	}
 	builder.SetLaunchables(launchables)
@@ -118,7 +121,11 @@ func TestPodManifestCanReportItsSHA(t *testing.T) {
 	Assert(t).IsNil(err, "should not have erred when building manifest")
 	val, err := manifest.SHA()
 	Assert(t).IsNil(err, "should not have erred when getting SHA")
-	Assert(t).AreEqual("b3b8aa6c2e7b52ace2fd4b524d84aaa71bc39eb0ef7a254ffe1752011a84e97a", val, "SHA mismatched expectations - if this was expected, change the assertion value")
+	Assert(t).AreEqual(
+		"fda3c8130dd7e2850b80bbbc0e56dcd3add02d4d67bed5cd3f8679db04854c58",
+		val,
+		"SHA mismatched expectations - if this was expected, change the assertion value",
+	)
 }
 
 func TestPodManifestLaunchablesCGroups(t *testing.T) {
@@ -129,9 +136,7 @@ func TestPodManifestLaunchablesCGroups(t *testing.T) {
 	for _, launchable := range launchables {
 		cgroup := launchable.CgroupConfig
 		Assert(t).AreEqual(cgroup.CPUs, 4, "Expected cgroup to have 4 CPUs")
-		memory, err := cgroup.MemoryByteCount()
-		Assert(t).IsNil(err, "Should not have erred parsing cgroup memory size")
-		Assert(t).AreEqual(memory, 1*size.Gibibyte, "Should have matched on memory bytecount")
+		Assert(t).AreEqual(cgroup.Memory, 1*size.Gibibyte, "Should have matched on memory bytecount")
 	}
 }
 

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -134,7 +134,7 @@ config:
 	expectedPlatConfig := `web:
   cgroup:
     cpus: 4
-    memory: 4G
+    memory: 4294967296
 `
 	Assert(t).AreEqual(expectedPlatConfig, string(platConfig), "the platform config didn't match")
 

--- a/pkg/util/size/bytes.go
+++ b/pkg/util/size/bytes.go
@@ -68,3 +68,25 @@ func Parse(sizeStr string) (ByteCount, error) {
 
 	return ByteCount(size), nil
 }
+
+// MarshalYAML() serializes a ByteCount into YAML. To maintain a canonical representation
+// of the value and to preserve compatibility with older parsers, the byte count will
+// always be serialized as a plain integer without a suffix.
+func (b ByteCount) MarshalYAML() (interface{}, error) {
+	return uint64(b), nil
+}
+
+// UnmarshalYAML unserializes a YAML representation of the ByteCount.
+func (b *ByteCount) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var strVal string
+	err := unmarshal(&strVal)
+	if err != nil {
+		return err
+	}
+	parsed, err := Parse(strVal)
+	if err != nil {
+		return err
+	}
+	*b = parsed
+	return nil
+}


### PR DESCRIPTION
Changes the cgroup.Config struct so that it preserves its old serialization.
For example, an input of "4K" is valid and parses to 4096, but regardless of
the input format, it will always serialize as 4096. This will allow older tools
to continue to work with the update input format, and it will ensure that there
is a single canonical representation of any manifest.