### PR TITLE
handle kills correctly

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -168,7 +168,7 @@ func (hl *Launchable) stop(serviceBuilder *runit.ServiceBuilder, sv runit.SV) er
 
 	for _, executable := range executables {
 		_, err := sv.Stop(&executable.Service, hl.RestartTimeout)
-		if err != nil {
+		if err != nil && err != runit.Killed {
 			// TODO: FAILURE SCENARIO (what should we do here?)
 			// 1) does `sv stop` ever exit nonzero?
 			// 2) should we keep stopping them all anyway?
@@ -193,7 +193,7 @@ func (hl *Launchable) start(serviceBuilder *runit.ServiceBuilder, sv runit.SV) e
 		} else {
 			_, err = sv.Once(&executable.Service)
 		}
-		if err != nil && err != runit.SuperviseOkMissing {
+		if err != nil && err != runit.SuperviseOkMissing && err != runit.Killed {
 			return err
 		}
 	}

--- a/pkg/runit/runit_service.go
+++ b/pkg/runit/runit_service.go
@@ -55,6 +55,7 @@ type StatError error
 var (
 	NotRunning         StatError = errors.New("RunSV is not running and must be started")
 	SuperviseOkMissing           = errors.New("The supervise/ok file is missing")
+	Killed                       = errors.New("The process was forcibly killed")
 )
 
 func (sv *sv) waitForSupervision(service *Service) error {
@@ -166,6 +167,8 @@ func convertToErr(msg string, original error) (string, error) {
 		return msg, NotRunning
 	} else if strings.Contains(msg, "supervise/ok") {
 		return msg, SuperviseOkMissing
+	} else if len(msg) > 6 && msg[0:6] == "kill: " {
+		return msg, Killed
 	} else {
 		return msg, original
 	}


### PR DESCRIPTION
Fixes two bugs involving forcible termination of runit services. In both cases, a reliance on SIGKILL to terminate a process would incorrectly prevent other services from being killed or started.