### PR TITLE
Give p2-rctl time to clean up

### DIFF
--- a/bin/p2-rctl/main.go
+++ b/bin/p2-rctl/main.go
@@ -281,7 +281,7 @@ func (r RCtl) RollingUpdate(oldID, newID string, want, need int, deletes bool) {
 	quit := make(chan struct{})
 
 	go kp.ConsulSessionManager(api.SessionEntry{
-		LockDelay: 1 * time.Nanosecond,
+		LockDelay: 5 * time.Second,
 		Behavior:  api.SessionBehaviorDelete,
 		TTL:       "15s",
 	}, r.baseClient, sessions, quit, r.logger)
@@ -333,7 +333,7 @@ LOOP:
 func (r RCtl) Farm() {
 	sessions := make(chan string)
 	go kp.ConsulSessionManager(api.SessionEntry{
-		LockDelay: 1 * time.Nanosecond,
+		LockDelay: 5 * time.Second,
 		Behavior:  api.SessionBehaviorDelete,
 		TTL:       "15s",
 	}, r.baseClient, sessions, nil, r.logger)


### PR DESCRIPTION
Increases the "LockDelay" timeout in the Consul session used in p2-rctl rolling
update operations. This change gives p2-rctl a little time to detect that its
lease on the RCs has expired and cease its modifications before another p2-rctl
(in Farm mode) thinks it has exclusive access. It doesn't technically improve
the correctness of the rolling update, but hopefully it makes it harder for a
bad execution to occur.