### PR TITLE
Sync hooks once before starting normal pod management

### DIFF
--- a/bin/p2-preparer/main.go
+++ b/bin/p2-preparer/main.go
@@ -64,6 +64,11 @@ func main() {
 	quitHookUpdate := make(chan struct{})
 	quitChans := []chan struct{}{quitHookUpdate}
 
+	// Guarantee that hooks are synced before any other pods are processed
+	err = prep.SyncHooksOnce()
+	if err != nil {
+		logger.WithError(err).Fatalln("Could not do initial sync of hooks")
+	}
 	go prep.WatchForPodManifestsForNode(quitMainUpdate)
 	go prep.WatchForHooks(quitHookUpdate)
 

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -56,6 +56,12 @@ func (p *Preparer) WatchForHooks(quit chan struct{}) {
 	}
 }
 
+// Sync the hooks just once. This is useful at preparer startup so that hooks
+// will be synced before normal pod management begins
+func (p *Preparer) SyncHooksOnce() error {
+	return p.hookListener.SyncOnce()
+}
+
 func (p *Preparer) WatchForPodManifestsForNode(quitAndAck chan struct{}) {
 	pods.Log = p.Logger
 	path := kp.IntentPath(p.node)


### PR DESCRIPTION
This avoids a race condition where simultaneous pod updates and hook
updates are scheduled while the preparer is stopped. We want to
guarantee that when it is started, hooks are processed before any other
pods so that th epod will benefit from any hooks being installed