### PR TITLE
Add watches for label selectors

### DIFF
--- a/pkg/labels/applicator.go
+++ b/pkg/labels/applicator.go
@@ -61,4 +61,14 @@ type Applicator interface {
 
 	// Return all objects of the given type that match the given selector
 	GetMatches(selector labels.Selector, labelType Type) ([]Labeled, error)
+
+	// Watch a label selector of a give type and see updates to that set
+	// of Labeled over time. If an error occurs, the Applicator implementation
+	// is responsible for handling it and recovering gracefully.
+	//
+	// The watch may be terminated by the underlying implementation without signaling on
+	// the quit channel - this will be indicated by the closing of the result channel. For
+	// this reason, the safest way to process the result of this channel is to use
+	// it in a for loop.
+	WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan []Labeled
 }

--- a/pkg/labels/applicator.go
+++ b/pkg/labels/applicator.go
@@ -62,13 +62,13 @@ type Applicator interface {
 	// Return all objects of the given type that match the given selector
 	GetMatches(selector labels.Selector, labelType Type) ([]Labeled, error)
 
-	// Watch a label selector of a give type and see updates to that set
+	// Watch a label selector of a given type and see updates to that set
 	// of Labeled over time. If an error occurs, the Applicator implementation
 	// is responsible for handling it and recovering gracefully.
 	//
 	// The watch may be terminated by the underlying implementation without signaling on
 	// the quit channel - this will be indicated by the closing of the result channel. For
 	// this reason, the safest way to process the result of this channel is to use
-	// it in a for loop.
-	WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan []Labeled
+	// it in a for loop. Alternatively, you may check for nullity of the result []Labeled
+	WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan *[]Labeled
 }

--- a/pkg/labels/consul_aggregator.go
+++ b/pkg/labels/consul_aggregator.go
@@ -1,0 +1,174 @@
+package labels
+
+import (
+	"sync"
+	"time"
+
+	"github.com/square/p2/pkg/kp/consulutil"
+	"github.com/square/p2/pkg/logging"
+
+	"github.com/square/p2/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/api"
+	"github.com/square/p2/Godeps/_workspace/src/k8s.io/kubernetes/pkg/labels"
+)
+
+// minimum required time between retrievals of label subtrees.
+var AggregationRateCap = 10 * time.Second
+
+// linked list of watches with control channels
+type selectorWatch struct {
+	selector labels.Selector
+	resultCh chan []Labeled
+	canceled chan struct{}
+	next     *selectorWatch
+}
+
+func (s *selectorWatch) append(w *selectorWatch) {
+	if w == nil {
+		return
+	}
+	if s.next != nil {
+		s.next.append(w)
+	} else {
+		s.next = w
+	}
+}
+
+func (s *selectorWatch) delete(w *selectorWatch) {
+	if w == nil {
+		return
+	}
+	if s.next == w {
+		s.next = w.next
+	} else if s.next != nil {
+		s.next.delete(w)
+	}
+}
+
+type consulAggregator struct {
+	logger         logging.Logger
+	labelType      Type
+	watcherLock    sync.Mutex
+	path           string
+	kv             consulutil.ConsulLister
+	watchers       *selectorWatch
+	labeledCache   []Labeled // cached contents of the label subtree
+	aggregatorQuit chan struct{}
+}
+
+func NewConsulAggregator(labelType Type, kv consulutil.ConsulLister, logger logging.Logger) *consulAggregator {
+	return &consulAggregator{
+		kv:             kv,
+		logger:         logger,
+		labelType:      labelType,
+		path:           typePath(labelType),
+		aggregatorQuit: make(chan struct{}),
+	}
+}
+
+// Add a new selector to the aggregator. New values on the output channel may not appear
+// right away.
+func (c *consulAggregator) Watch(selector labels.Selector, quitCh chan struct{}) chan []Labeled {
+	resCh := make(chan []Labeled)
+	select {
+	case <-c.aggregatorQuit:
+		c.logger.WithField("selector", selector.String()).Warnln("New selector added after aggregator was closed")
+		close(resCh)
+		return resCh
+	default:
+	}
+	c.watcherLock.Lock()
+	defer c.watcherLock.Unlock()
+	watch := &selectorWatch{
+		selector: selector,
+		resultCh: resCh,
+		canceled: make(chan struct{}),
+	}
+	if c.watchers == nil {
+		c.watchers = watch
+	} else {
+		c.watchers.append(watch)
+	}
+	go func() {
+		select {
+		case <-quitCh:
+		case <-c.aggregatorQuit:
+		}
+		c.removeWatch(watch)
+	}()
+	return watch.resultCh
+}
+
+func (c *consulAggregator) removeWatch(watch *selectorWatch) {
+	close(watch.canceled)
+	close(watch.resultCh)
+	c.watcherLock.Lock()
+	defer c.watcherLock.Unlock()
+	if c.watchers == watch {
+		c.watchers = c.watchers.next
+	} else {
+		c.watchers.delete(watch)
+	}
+}
+
+func (c *consulAggregator) Quit() {
+	close(c.aggregatorQuit)
+}
+
+// Aggregate does the labor of querying Consul for all labels under a given type,
+// applying each watcher's label selector to the results and sending those results on each
+// watcher's output channel respectively.
+// Aggregate will loop forever, constantly sending matches to each watcher
+// until Quit() has been invoked.
+func (c *consulAggregator) Aggregate() {
+	outPairs := make(chan api.KVPairs)
+	done := make(chan struct{})
+	outErrors := make(chan error)
+	go consulutil.WatchPrefix(c.path, c.kv, outPairs, done, outErrors)
+	for {
+		loopTime := time.After(AggregationRateCap)
+		select {
+		case <-c.aggregatorQuit:
+			return
+		case pairs := <-outPairs:
+			// Convert watch result to []Labeled
+			c.labeledCache = make([]Labeled, len(pairs))
+			for i, kvp := range pairs {
+				val, err := convertKVPToLabeled(kvp)
+				if err != nil {
+					c.logger.WithErrorAndFields(err, logrus.Fields{
+						"key":   kvp.Key,
+						"value": string(kvp.Value),
+					}).Errorln("Invalid key encountered, skipping this value")
+					continue
+				}
+				c.labeledCache[i] = val
+			}
+
+			// Iterate over each watcher and send the []Labeled
+			// that match the watcher's selector to the watcher's out channel.
+			c.watcherLock.Lock()
+			watcher := c.watchers
+			for watcher != nil {
+				matches := []Labeled{}
+				for _, labeled := range c.labeledCache {
+					if watcher.selector.Matches(labeled.Labels) {
+						matches = append(matches, labeled)
+					}
+				}
+				select {
+				case watcher.resultCh <- matches:
+				case <-watcher.canceled:
+				}
+				watcher = watcher.next
+			}
+			c.watcherLock.Unlock()
+		}
+		select {
+		case <-c.aggregatorQuit:
+			return
+		case <-loopTime:
+		}
+
+	}
+}

--- a/pkg/labels/consul_aggregator_test.go
+++ b/pkg/labels/consul_aggregator_test.go
@@ -86,7 +86,7 @@ func TestQuitAggregateAfterResults(t *testing.T) {
 	select {
 	case <-success:
 	case <-time.After(time.Second):
-		t.Fatal("Should still be waiting or processing results after a second")
+		t.Fatal("Should not be waiting or processing results after a second")
 	}
 }
 

--- a/pkg/labels/consul_aggregator_test.go
+++ b/pkg/labels/consul_aggregator_test.go
@@ -1,0 +1,133 @@
+package labels
+
+import (
+	"testing"
+	"time"
+
+	"github.com/square/p2/pkg/logging"
+
+	. "github.com/square/p2/Godeps/_workspace/src/github.com/anthonybishopric/gotcha"
+	"github.com/square/p2/Godeps/_workspace/src/k8s.io/kubernetes/pkg/labels"
+)
+
+// defer the _result_ of this function to change the time for the duration
+// of the calling function
+func alterAggregationTime(dur time.Duration) {
+	AggregationRateCap = dur
+}
+
+func fakeLabeledPods() map[string][]byte {
+	return map[string][]byte{
+		objectPath(POD, "maroono"):  []byte(`{"color": "red", "deployment": "production"}`),
+		objectPath(POD, "emeralda"): []byte(`{"color": "green", "deployment": "canary"}`),
+		objectPath(POD, "slashi"):   []byte(`{"color": "red", "deployment": "canary"}`),
+	}
+}
+
+func TestTwoClients(t *testing.T) {
+	alterAggregationTime(time.Millisecond)
+	// fake KV lister
+	// fake label data generator
+	// create aggregator
+	// watch with timeout, selector for 1/2 of results
+	// fail if timeout elapses
+	// fail if selected wrong results
+	// cache results?
+	fakeKV := &fakeLabelStore{fakeLabeledPods()}
+	aggreg := NewConsulAggregator(POD, fakeKV, logging.DefaultLogger)
+	go aggreg.Aggregate()
+	defer aggreg.Quit()
+
+	quitCh := make(chan struct{})
+	labeledChannel1 := aggreg.Watch(labels.Everything().Add("color", labels.EqualsOperator, []string{"green"}), quitCh)
+	labeledChannel2 := aggreg.Watch(labels.Everything().Add("deployment", labels.EqualsOperator, []string{"canary"}), quitCh)
+
+	var checked string
+	for i := 0; i < 2; i++ {
+		select {
+		case <-time.After(time.Second):
+			t.Fatal("Should not have taken a second to get results")
+		case labeled := <-labeledChannel1:
+			Assert(t).AreNotEqual("green", checked, "Should not have already checked the green selector result")
+			checked = "green" // ensure that both sides get checked
+			Assert(t).AreEqual(1, len(labeled), "Should have received one result from the color watch")
+			Assert(t).AreEqual("emeralda", labeled[0].ID, "should have received the emerald app")
+		case labeled := <-labeledChannel2:
+			Assert(t).AreNotEqual("canary", checked, "Should not have already checked the canary selector result")
+			checked = "canary" // ensure that both sides get checked
+			Assert(t).AreEqual(2, len(labeled), "Should have received two results from the canary watch")
+			emeraldaIndex := 0
+			slashiIndex := 1
+			if labeled[0].ID == "slashi" { // order doesn't matter
+				emeraldaIndex, slashiIndex = slashiIndex, emeraldaIndex
+			}
+			Assert(t).AreEqual("emeralda", labeled[emeraldaIndex].ID, "should have received the emerald app")
+			Assert(t).AreEqual("slashi", labeled[slashiIndex].ID, "should have received the slashi app")
+		}
+	}
+}
+
+func TestQuitAggregate(t *testing.T) {
+	alterAggregationTime(time.Millisecond)
+
+	fakeKV := &fakeLabelStore{fakeLabeledPods()}
+	aggreg := NewConsulAggregator(POD, fakeKV, logging.DefaultLogger)
+	go aggreg.Aggregate()
+
+	quitCh := make(chan struct{})
+	res := aggreg.Watch(labels.Everything().Add("color", labels.EqualsOperator, []string{"green"}), quitCh)
+
+	// Quit now. We expect that the aggregator will close the res channels
+	aggreg.Quit()
+	success := make(chan struct{})
+	go func() {
+		for _ = range res {
+		}
+		success <- struct{}{}
+	}()
+
+	select {
+	case <-success:
+	case <-time.After(time.Second):
+		t.Fatal("Should still be waiting or processing results after a second")
+	}
+}
+
+func TestQuitIndividualWatch(t *testing.T) {
+	alterAggregationTime(time.Millisecond)
+
+	fakeKV := &fakeLabelStore{fakeLabeledPods()}
+	aggreg := NewConsulAggregator(POD, fakeKV, logging.DefaultLogger)
+	go aggreg.Aggregate()
+
+	quitCh1 := make(chan struct{})
+	labeledChannel1 := aggreg.Watch(labels.Everything().Add("color", labels.EqualsOperator, []string{"green"}), quitCh1)
+
+	quitCh2 := make(chan struct{})
+	labeledChannel2 := aggreg.Watch(labels.Everything().Add("deployment", labels.EqualsOperator, []string{"production"}), quitCh2)
+
+	close(quitCh1) // this should not interrupt the flow of messages to the second channel
+
+	// iterate twice to show that we are not waiting on other now-closed channels
+	for i := 0; i < 2; i++ {
+		select {
+		case <-time.After(time.Second):
+			t.Fatalf("Should not have taken a second to get results on iteration %v", i)
+		case labeled := <-labeledChannel2:
+			Assert(t).AreEqual(1, len(labeled), "Should have one result with a production deployment")
+			Assert(t).AreEqual("maroono", labeled[0].ID, "Should have received maroono as the one production deployment")
+		}
+	}
+
+	success := make(chan struct{})
+	go func() {
+		for _ = range labeledChannel1 {
+		}
+		success <- struct{}{}
+	}()
+	select {
+	case <-time.After(time.Second):
+		t.Fatal("Should not have taken a second to see the closed label channel")
+	case <-success:
+	}
+}

--- a/pkg/labels/consul_applicator.go
+++ b/pkg/labels/consul_applicator.go
@@ -32,21 +32,27 @@ type consulKV interface {
 }
 
 type consulApplicator struct {
-	kv      consulKV
-	logger  logging.Logger
-	retries int
+	kv          consulKV
+	logger      logging.Logger
+	retries     int
+	aggregators map[Type]*consulAggregator
 }
 
 func NewConsulApplicator(client *api.Client, retries int) *consulApplicator {
 	return &consulApplicator{
-		logger:  logging.DefaultLogger,
-		kv:      client.KV(),
-		retries: retries,
+		logger:      logging.DefaultLogger,
+		kv:          client.KV(),
+		retries:     retries,
+		aggregators: map[Type]*consulAggregator{},
 	}
 }
 
+func typePath(labelType Type) string {
+	return path.Join(labelRoot, labelType.String())
+}
+
 func objectPath(labelType Type, id string) string {
-	return path.Join(labelRoot, labelType.String(), id)
+	return path.Join(typePath(labelType), id)
 }
 
 func (c *consulApplicator) getLabels(labelType Type, id string) (Labeled, uint64, error) {
@@ -68,8 +74,8 @@ func (c *consulApplicator) GetLabels(labelType Type, id string) (Labeled, error)
 }
 
 func (c *consulApplicator) GetMatches(selector labels.Selector, labelType Type) ([]Labeled, error) {
-	// TODO: Label selector result caching
-	allMatches, _, err := c.kv.List(path.Join(labelRoot, labelType.String()), nil)
+	// TODO: use aggregator to enable caching
+	allMatches, _, err := c.kv.List(typePath(labelType), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -186,6 +192,29 @@ func convertLabeledToKVP(l Labeled) (*api.KVPair, error) {
 		Key:   objectPath(l.LabelType, l.ID),
 		Value: value,
 	}, nil
+}
+
+// The current schema of labels in Consul is optimized for label retrieval on a single
+// object of a given ID. This layout is less effective when attempting to perform a
+// watch on the results of an arbitrary label selector, which is necessarily un-indexable.
+// This implementation will perform the simplest possible optimization, which is to cache
+// the entire contents of the tree under the given label type and share it with other watches.
+//
+// Due to the possibility that this tree might change quite frequently in environments
+// with lots of concurrent deployments, the aggregated result from Consul will only be queried
+// by a maximum frequency of once per LabelAggregationCap.
+//
+// Preparers should not use the consulApplicator's implementation of WatchMatches directly due
+// to the cost of querying for this subtree on any sizeable fleet of machines. Instead, preparers should
+// use the httpApplicator from a server that exposes the results of this (or another)
+// implementation's watch.
+func (c *consulApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan []Labeled {
+	aggregator, ok := c.aggregators[labelType]
+	if !ok {
+		aggregator = NewConsulAggregator(labelType, c.kv, c.logger)
+		c.aggregators[labelType] = aggregator
+	}
+	return aggregator.Watch(selector, quitCh)
 }
 
 // confirm at compile time that consulApplicator is an implementation of the Applicator interface

--- a/pkg/labels/consul_applicator.go
+++ b/pkg/labels/consul_applicator.go
@@ -208,7 +208,7 @@ func convertLabeledToKVP(l Labeled) (*api.KVPair, error) {
 // to the cost of querying for this subtree on any sizeable fleet of machines. Instead, preparers should
 // use the httpApplicator from a server that exposes the results of this (or another)
 // implementation's watch.
-func (c *consulApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan []Labeled {
+func (c *consulApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan *[]Labeled {
 	aggregator, ok := c.aggregators[labelType]
 	if !ok {
 		aggregator = NewConsulAggregator(labelType, c.kv, c.logger)

--- a/pkg/labels/consul_applicator_test.go
+++ b/pkg/labels/consul_applicator_test.go
@@ -14,10 +14,17 @@ import (
 
 type fakeLabelStore struct {
 	data map[string][]byte
+	// If this channel is set, fakeApplicator will wait to return content until
+	// this channel receives a value
+	watchTrigger chan struct{}
 }
 
 func (f *fakeLabelStore) List(prefix string, opts *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error) {
 	var ret api.KVPairs
+
+	if f.watchTrigger != nil {
+		<-f.watchTrigger
+	}
 
 	for k, v := range f.data {
 		if strings.HasPrefix(k, prefix) {

--- a/pkg/labels/fake_applicator.go
+++ b/pkg/labels/fake_applicator.go
@@ -91,6 +91,21 @@ func (app *fakeApplicator) GetMatches(selector labels.Selector, labelType Type) 
 	return results, nil
 }
 
+func (app *fakeApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan []Labeled {
+	ch := make(chan []Labeled)
+	go func() {
+		for {
+			res, _ := app.GetMatches(selector, labelType)
+			select {
+			case <-quitCh:
+				return
+			case ch <- res:
+			}
+		}
+	}()
+	return ch
+}
+
 // avoid returning elements of the inner data map, otherwise concurrent callers
 // may cause races when mutating them
 func copySet(in labels.Set) labels.Set {

--- a/pkg/labels/fake_applicator.go
+++ b/pkg/labels/fake_applicator.go
@@ -11,6 +11,7 @@ import (
 type fakeApplicatorData map[Type]map[string]labels.Set
 
 type fakeApplicator struct {
+	// KV data that will be returned by queries
 	data fakeApplicatorData
 	// since entry() may mutate the map, every read can potentially trigger a
 	// write. no point using rwmutex here
@@ -91,15 +92,15 @@ func (app *fakeApplicator) GetMatches(selector labels.Selector, labelType Type) 
 	return results, nil
 }
 
-func (app *fakeApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan []Labeled {
-	ch := make(chan []Labeled)
+func (app *fakeApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan *[]Labeled {
+	ch := make(chan *[]Labeled)
 	go func() {
 		for {
 			res, _ := app.GetMatches(selector, labelType)
 			select {
 			case <-quitCh:
 				return
-			case ch <- res:
+			case ch <- &res:
 			}
 		}
 	}()

--- a/pkg/labels/http_applicator.go
+++ b/pkg/labels/http_applicator.go
@@ -91,7 +91,7 @@ func (h *httpApplicator) GetMatches(selector labels.Selector, labelType Type) ([
 	return labeled, nil
 }
 
-func (h *httpApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan []Labeled {
+func (h *httpApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan *[]Labeled {
 	panic("Not implemented")
 	return nil
 }

--- a/pkg/labels/http_applicator.go
+++ b/pkg/labels/http_applicator.go
@@ -15,6 +15,7 @@ type httpApplicator struct {
 	client *http.Client
 	// The endpoint that will be queried for matches.
 	// GetMatches will add to this endpoint a query parameter with key "selector" and value selector.String()
+	// WatchMatches will add the above "selector" as well as "watch=true"
 	matchesEndpoint *url.URL
 	logger          logging.Logger
 }
@@ -88,4 +89,9 @@ func (h *httpApplicator) GetMatches(selector labels.Selector, labelType Type) ([
 	}
 
 	return labeled, nil
+}
+
+func (h *httpApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan []Labeled {
+	panic("Not implemented")
+	return nil
 }


### PR DESCRIPTION
This change introduces watches for label selectors. This is especially useful for forming abstractions around label selectors, such as Kubernetes-style Services.

This implementation attempts to cache the result of the label tree, with a watch in place to get updates over time. Watches share the same cache result. See function documentation for details.