### PR TITLE
Instantiate empty config map in GetConfig() if necessary

### DIFF
--- a/pkg/pods/manifest.go
+++ b/pkg/pods/manifest.go
@@ -125,6 +125,9 @@ func (manifest *manifest) SetLaunchables(launchableStanzas map[string]Launchable
 }
 
 func (manifest *manifest) GetConfig() map[interface{}]interface{} {
+	if manifest.Config == nil {
+		return make(map[interface{}]interface{})
+	}
 	return manifest.Config
 }
 

--- a/pkg/pods/manifest_test.go
+++ b/pkg/pods/manifest_test.go
@@ -223,3 +223,10 @@ config:
 	builtManifest := builder.GetManifest()
 	Assert(t).AreEqual(builtManifest.ID(), "thepod", "Expected manifest ID to be preserved when converted to ManifestBuilder and back")
 }
+
+func TestGetConfigInitializesIfEmpty(t *testing.T) {
+	builder := NewManifestBuilder()
+	manifest := builder.GetManifest()
+	config := manifest.GetConfig()
+	Assert(t).IsNotNil(config, "Expected returned config to be instantiated by GetConfig() if not set")
+}


### PR DESCRIPTION
This is for convenience so that callers modifying a manifest's config do
not need to check if it is nil before doing so