### PR TITLE
Use cache on first adding a watcher

### DIFF
--- a/pkg/labels/applicator.go
+++ b/pkg/labels/applicator.go
@@ -44,6 +44,11 @@ func (l Labeled) SameAs(o Labeled) bool {
 	return l.ID == o.ID && l.LabelType == o.LabelType
 }
 
+type WatchResult struct {
+	Labeled []Labeled
+	Valid   bool // Will be false if the underlying watcher has terminated
+}
+
 // General purpose backing store for labels and assignment
 // to P2 objects
 type Applicator interface {
@@ -68,7 +73,7 @@ type Applicator interface {
 	//
 	// The watch may be terminated by the underlying implementation without signaling on
 	// the quit channel - this will be indicated by the closing of the result channel. For
-	// this reason, the safest way to process the result of this channel is to use
-	// it in a for loop. Alternatively, you may check for nullity of the result []Labeled
-	WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan *[]Labeled
+	// this reason, the resulting WatchResult have a Valid flag to help determine if
+	// the channel has been closed.
+	WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan WatchResult
 }

--- a/pkg/labels/consul_aggregator_test.go
+++ b/pkg/labels/consul_aggregator_test.go
@@ -40,16 +40,16 @@ func TestTwoClients(t *testing.T) {
 		select {
 		case <-time.After(time.Second):
 			t.Fatal("Should not have taken a second to get results")
-		case labeledPtr := <-labeledChannel1:
-			Assert(t).IsNotNil(labeledPtr, "ptr should not have been nil")
-			labeled := *labeledPtr
+		case labeledWatch := <-labeledChannel1:
+			Assert(t).IsTrue(labeledWatch.Valid, "valid should not have been true")
+			labeled := labeledWatch.Labeled
 			Assert(t).AreNotEqual("green", checked, "Should not have already checked the green selector result")
 			checked = "green" // ensure that both sides get checked
 			Assert(t).AreEqual(1, len(labeled), "Should have received one result from the color watch")
 			Assert(t).AreEqual("emeralda", labeled[0].ID, "should have received the emerald app")
-		case labeledPtr := <-labeledChannel2:
-			Assert(t).IsNotNil(labeledPtr, "ptr should not have been nil")
-			labeled := *labeledPtr
+		case labeledWatch := <-labeledChannel2:
+			Assert(t).IsTrue(labeledWatch.Valid, "valid should not have been true")
+			labeled := labeledWatch.Labeled
 			Assert(t).AreNotEqual("canary", checked, "Should not have already checked the canary selector result")
 			checked = "canary" // ensure that both sides get checked
 			Assert(t).AreEqual(2, len(labeled), "Should have received two results from the canary watch")
@@ -134,9 +134,9 @@ func TestQuitIndividualWatch(t *testing.T) {
 		select {
 		case <-time.After(time.Second):
 			t.Fatalf("Should not have taken a second to get results on iteration %v", i)
-		case labeledPtr := <-labeledChannel2:
-			Assert(t).IsNotNil(labeledPtr, "ptr should not have been nil")
-			labeled := *labeledPtr
+		case labeledWatch := <-labeledChannel2:
+			Assert(t).IsTrue(labeledWatch.Valid, "valid should not have been true")
+			labeled := labeledWatch.Labeled
 			Assert(t).AreEqual(1, len(labeled), "Should have one result with a production deployment")
 			Assert(t).AreEqual("maroono", labeled[0].ID, "Should have received maroono as the one production deployment")
 		}

--- a/pkg/labels/fake_applicator.go
+++ b/pkg/labels/fake_applicator.go
@@ -92,15 +92,15 @@ func (app *fakeApplicator) GetMatches(selector labels.Selector, labelType Type) 
 	return results, nil
 }
 
-func (app *fakeApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan *[]Labeled {
-	ch := make(chan *[]Labeled)
+func (app *fakeApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan WatchResult {
+	ch := make(chan WatchResult)
 	go func() {
 		for {
 			res, _ := app.GetMatches(selector, labelType)
 			select {
 			case <-quitCh:
 				return
-			case ch <- &res:
+			case ch <- WatchResult{res, true}:
 			}
 		}
 	}()

--- a/pkg/labels/http_applicator.go
+++ b/pkg/labels/http_applicator.go
@@ -91,7 +91,7 @@ func (h *httpApplicator) GetMatches(selector labels.Selector, labelType Type) ([
 	return labeled, nil
 }
 
-func (h *httpApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan *[]Labeled {
+func (h *httpApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan WatchResult {
 	panic("Not implemented")
 	return nil
 }


### PR DESCRIPTION
This change allows new watchers to immediately use the cached label
result. This is important in cases where the label tree is relatively
unchanging and the ongoing Consul watch will take a long time to
return new results. A new watcher added immediately after such a
Consul watch completed might have to wait for minutes before a new
result was returned.