### PR TITLE
Make manifest.GetConfig() return a deep copy of the config map

### DIFF
--- a/bin/p2-bin2pod/main.go
+++ b/bin/p2-bin2pod/main.go
@@ -160,8 +160,7 @@ func addManifestConfig(manifestBuilder pods.ManifestBuilder) error {
 		}
 		podConfig[res[0]] = res[1]
 	}
-	manifestBuilder.SetConfig(podConfig)
-	return nil
+	return manifestBuilder.SetConfig(podConfig)
 }
 
 func writeManifest(workingDir string, manifest pods.Manifest) (string, error) {

--- a/integration/single-node-slug-deploy/check.go
+++ b/integration/single-node-slug-deploy/check.go
@@ -128,7 +128,7 @@ func generatePreparerPod(workdir string) (string, error) {
 	}
 	builder := manifest.GetBuilder()
 	builder.SetID("p2-preparer")
-	builder.SetConfig(map[interface{}]interface{}{
+	err = builder.SetConfig(map[interface{}]interface{}{
 		"preparer": map[interface{}]interface{}{
 			"auth": map[string]string{
 				"type":    "keyring",
@@ -140,6 +140,10 @@ func generatePreparerPod(workdir string) (string, error) {
 			"status_port": preparerStatusPort,
 		},
 	})
+	if err != nil {
+		return "", err
+	}
+
 	builder.SetRunAsUser("root")
 	builder.SetStatusPort(preparerStatusPort)
 	builder.SetStatusHTTP(true)


### PR DESCRIPTION
This avoids modification of config maps returned by GetConfig() from
mutating the underlying manifest or eachother.

Copying is done by marshaling to yaml and then unmarshaling into a new
map. This introduces a chance for an error, but by doing error checking
when configs are set we can guarantee that in practice these errors
should not occur, and if they do then something is very wrong and thus
we panic.