### PR TITLE
Update p2 log bridge path

### DIFF
--- a/bin/p2-log-bridge/main.go
+++ b/bin/p2-log-bridge/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
-	"os/signal"
+	"sync"
 
+	"github.com/square/p2/Godeps/_workspace/src/golang.org/x/sys/unix"
 	"github.com/square/p2/Godeps/_workspace/src/gopkg.in/alecthomas/kingpin.v2"
 	"github.com/square/p2/pkg/logbridge"
 	"github.com/square/p2/pkg/logging"
@@ -20,31 +22,61 @@ func main() {
 	kingpin.Version(version.VERSION)
 	kingpin.Parse()
 
+	if err := setSTDINToBlock(); err != nil {
+		logging.DefaultLogger.WithError(err).Error("fatal error setting STDIN to block")
+		os.Exit(1)
+	}
+
+	var wg sync.WaitGroup
 	loggerCmd := exec.Command(*durableLogger)
 	durablePipe, err := loggerCmd.StdinPipe()
 	if err != nil {
-		logging.DefaultLogger.WithError(err).Errorln("failed during logbridge setup")
-		os.Exit(1)
+		logging.DefaultLogger.WithError(err).Error("fatal error during configuration of subordinate log command")
 	}
 
-	go handleSignals(durablePipe)
+	wg.Add(1)
+	go func(loggerCmd exec.Cmd) {
+		defer wg.Done()
 
-	go func(r io.Reader, durableWriter io.Writer, nonDurableWriter io.Writer, logger logging.Logger) {
-		logbridge.Tee(r, durableWriter, nonDurableWriter, logger)
+		if err := loggerCmd.Start(); err != nil {
+			logging.DefaultLogger.WithError(err).Errorln("fatal error during execution of subordinate log command")
+			os.Exit(1)
+		}
+
+		err := loggerCmd.Wait()
+		if err != nil {
+			logging.DefaultLogger.WithError(err).Errorln("fatal error in subordinate log command")
+			os.Exit(1)
+		}
+	}(*loggerCmd)
+
+	wg.Add(1)
+	go func(r io.Reader, durableWriter, lossyWriter io.Writer, logger logging.Logger) {
+		defer wg.Done()
+
+		logbridge.Tee(r, durableWriter, lossyWriter, logger)
+		logging.DefaultLogger.NoFields().Infoln("logbridge Tee returned. Shutting down subordinate log command.")
+		durablePipe.Close()
 	}(os.Stdin, durablePipe, os.Stdout, logging.DefaultLogger)
 
-	loggerCmd.Start()
-	err = loggerCmd.Wait()
-	if err != nil {
-		logging.DefaultLogger.WithError(err)
-		os.Exit(1)
-	}
+	logging.DefaultLogger.NoFields().Info("logging running in background…")
+	wg.Wait()
 }
 
-// This is slightly naive, it could be more narrow in the signals it cares about
-func handleSignals(c io.Closer) {
-	signals := make(chan os.Signal, 2)
-	signal.Notify(signals)
-	<-signals
-	c.Close()
+// In environments where svlogd is used, the pipe that becomes STDIN of this
+// program can be non-blocking. Go's File implementation does not play well
+// with non-blocking pipes, in particular it does not recover from an EAGAIN
+// error from read(2).
+// This function defensively sets its 0th file descriptor to be blocking so
+// that we do not have to handle EAGAIN errors.
+func setSTDINToBlock() error {
+	oldflags, _, errno := unix.Syscall(unix.SYS_FCNTL, 0, unix.F_GETFL, 0)
+	if errno != 0 {
+		return fmt.Errorf("unix.FCNTL F_GETFL errno: %d", errno)
+	}
+	_, _, errno = unix.Syscall(unix.SYS_FCNTL, 0, unix.F_SETFL, oldflags&^unix.O_NONBLOCK)
+	if errno != 0 {
+		return fmt.Errorf("unix.FCNTL F_SETFL errno: %d", errno)
+	}
+	return nil
 }

--- a/pkg/logbridge/logbridge.go
+++ b/pkg/logbridge/logbridge.go
@@ -57,7 +57,7 @@ func lossyCopy(src io.Reader, lines chan []byte, logger logging.Logger) {
 	}
 }
 
-// Tee will copy to faithfulWriter without dropping messages, it will copy
+// Tee will copy to durableWriter without dropping messages, it will copy
 // through a buffer to better handle mismatched latencies. Lines written to
 // lossyWriter will be copied in a best effort way with respect to latency and
 // buffered through a go channel.

--- a/pkg/logbridge/logbridge.go
+++ b/pkg/logbridge/logbridge.go
@@ -47,7 +47,7 @@ func lossyCopy(src io.Reader, lines chan []byte, logger logging.Logger) {
 				select {
 				case lines <- []byte(warningMessage):
 				case <-time.After(100 * time.Millisecond):
-					// best effort warning of dropped messages. If this doesn't suceed expediently, forget it and get back to work
+					// best effort warning of dropped messages. If this doesn't succeed expediently, forget it and get back to work
 				}
 			}
 		}
@@ -57,12 +57,11 @@ func lossyCopy(src io.Reader, lines chan []byte, logger logging.Logger) {
 	}
 }
 
-// Tee will copy to durableWriter without dropping messages, it will copy
-// through a buffer to better handle mismatched latencies. Lines written to
-// lossyWriter will be copied in a best effort way with respect to latency and
-// buffered through a go channel.
+// Tee will copy to durableWriter without dropping messages. Lines written to
+// lossyWriter will be copied best effort with respect to latency on the
+// writer. Writes to lossyWriter are buffered through a go channel.
 func Tee(r io.Reader, durableWriter io.Writer, lossyWriter io.Writer, logger logging.Logger) {
-	tr := io.TeeReader(r, bufio.NewWriterSize(durableWriter, 1<<10))
+	tr := io.TeeReader(r, durableWriter)
 
 	LossyCopy(lossyWriter, tr, 1<<10, logger)
 }

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -66,6 +66,7 @@ func NewPod(id string, path string) *Pod {
 		ServiceBuilder: runit.DefaultBuilder,
 		P2Exec:         DefaultP2Exec,
 		DefaultTimeout: 60 * time.Second,
+		LogExec:        defaultLogExec,
 	}
 }
 
@@ -246,7 +247,7 @@ func (pod *Pod) buildRunitServices(launchables []launch.Launchable, newManifest 
 				return util.Errorf("Duplicate executable %q for launchable %q", executable.Service.Name, launchable.ServiceID())
 			}
 			sbTemplate[executable.Service.Name] = runit.ServiceTemplate{
-				Log: pod.logExec(),
+				Log: pod.LogExec,
 				Run: executable.Exec,
 			}
 		}
@@ -649,11 +650,4 @@ func (p *Pod) logLaunchableWarning(launchableId string, err error, message strin
 
 func (p *Pod) logInfo(message string) {
 	p.logger.WithFields(logrus.Fields{}).Info(message)
-}
-
-func (p *Pod) logExec() runit.LogExec {
-	if len(p.LogExec) == 0 {
-		return defaultLogExec
-	}
-	return p.LogExec
 }

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -255,6 +255,7 @@ func TestBuildRunitServices(t *testing.T) {
 		Id:             "testPod",
 		path:           "/data/pods/testPod",
 		ServiceBuilder: serviceBuilder,
+		LogExec:        defaultLogExec,
 	}
 	hl, sb := hoist.FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
 	defer hoist.CleanupFakeLaunchable(hl, sb)


### PR DESCRIPTION
When https://github.com/square/p2/pull/319 was merged, we were not sure how log-bridge would be installed on our systems. It turns out that it fits naturally as a secondary launchable for p2-preparer.