### PR TITLE
logbridge: Preserve newlines and copy data

### DIFF
--- a/pkg/logbridge/logbridge_test.go
+++ b/pkg/logbridge/logbridge_test.go
@@ -152,8 +152,12 @@ func TestErrorCases(t *testing.T) {
 	reader = bytes.NewReader(input)
 	LossyCopy(retriableErrorWriter, reader, bridgeCapacity, logging.DefaultLogger)
 
-	if len(retriableErrorWriter.bytes) != bridgeCapacity {
-		t.Errorf("Expected bridge to successfully retry writes that result in error. Expected %d Got %d", bridgeCapacity, len(retriableErrorWriter.bytes))
+	if len(retriableErrorWriter.bytes) != len(input) {
+		t.Errorf(
+			"Expected bridge to successfully retry writes that result in error. Expected %d Got %d",
+			len(input),
+			len(retriableErrorWriter.bytes),
+		)
 	}
 }
 


### PR DESCRIPTION
The output delivered to the lossy logger is stripped of its newlines by the
default scanner. This change adds a new splitter that preserves newlines so
that the output stream of the lossy logger is the same as stdin.

---

After digging into the implementation of bufio.Scanner, it turns out that it
maintains one internal array as a large input buffer, and all the tokens it
returns are slices from that shared array. This works fine if the application
fully-handles each token as it's encountered, but logbridge asynchronously
sends them to the lossy writer. If the lossy writer is slow, there is the
potential for the array's data to have been overwritten by the Scanner by the
time a slow lossy writer gets to the slice. The data handled would not be the
same as the data sent.

This commit copies the contents of each line into a large append-only buffer.
When full, a new large buffer is allocated. If this code turns out to be a
throughput bottleneck, we could instead pursue writing a new Scanner that
doesn't need a copy.