### PR TITLE
Always list keys with an extra "/"

### DIFF
--- a/pkg/kp/rcstore/consul_store.go
+++ b/pkg/kp/rcstore/consul_store.go
@@ -128,7 +128,7 @@ func (s *consulStore) Get(id fields.ID) (fields.RC, error) {
 }
 
 func (s *consulStore) List() ([]fields.RC, error) {
-	listed, _, err := s.kv.List(kp.RC_TREE, nil)
+	listed, _, err := s.kv.List(kp.RC_TREE+"/", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func (s *consulStore) WatchNew(quit <-chan struct{}) (<-chan []fields.RC, <-chan
 	errCh := make(chan error)
 	inCh := make(chan api.KVPairs)
 
-	go consulutil.WatchPrefix(kp.RC_TREE, s.kv, inCh, quit, errCh)
+	go consulutil.WatchPrefix(kp.RC_TREE+"/", s.kv, inCh, quit, errCh)
 
 	go func() {
 		defer close(outCh)

--- a/pkg/kp/rollstore/store.go
+++ b/pkg/kp/rollstore/store.go
@@ -108,7 +108,7 @@ func (s consulStore) Watch(quit <-chan struct{}) (<-chan []rollf.Update, <-chan 
 	errCh := make(chan error)
 	inCh := make(chan api.KVPairs)
 
-	go consulutil.WatchPrefix(kp.ROLL_TREE, s.kv, inCh, quit, errCh)
+	go consulutil.WatchPrefix(kp.ROLL_TREE+"/", s.kv, inCh, quit, errCh)
 
 	go func() {
 		defer close(outCh)

--- a/pkg/labels/consul_aggregator.go
+++ b/pkg/labels/consul_aggregator.go
@@ -124,7 +124,7 @@ func (c *consulAggregator) Aggregate() {
 	outPairs := make(chan api.KVPairs)
 	done := make(chan struct{})
 	outErrors := make(chan error)
-	go consulutil.WatchPrefix(c.path, c.kv, outPairs, done, outErrors)
+	go consulutil.WatchPrefix(c.path+"/", c.kv, outPairs, done, outErrors)
 	for {
 		loopTime := time.After(AggregationRateCap)
 		select {

--- a/pkg/labels/consul_applicator.go
+++ b/pkg/labels/consul_applicator.go
@@ -75,7 +75,7 @@ func (c *consulApplicator) GetLabels(labelType Type, id string) (Labeled, error)
 
 func (c *consulApplicator) GetMatches(selector labels.Selector, labelType Type) ([]Labeled, error) {
 	// TODO: use aggregator to enable caching
-	allMatches, _, err := c.kv.List(typePath(labelType), nil)
+	allMatches, _, err := c.kv.List(typePath(labelType)+"/", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/preparer/listener.go
+++ b/pkg/preparer/listener.go
@@ -14,7 +14,7 @@ import (
 
 type IntentStore interface {
 	WatchPods(watchPath string, quit <-chan struct{}, errCh chan<- error, manifests chan<- []kp.ManifestResult)
-	ListPods(keyPrefix string) ([]kp.ManifestResult, time.Duration, error)
+	ListPods(path string) ([]kp.ManifestResult, time.Duration, error)
 }
 
 type HookListener struct {

--- a/pkg/preparer/listener_test.go
+++ b/pkg/preparer/listener_test.go
@@ -48,7 +48,7 @@ func (f *fakeIntentStore) WatchPods(watchedPath string, quitCh <-chan struct{}, 
 	<-quitCh
 }
 
-func (f *fakeIntentStore) ListPods(keyPrefix string) ([]kp.ManifestResult, time.Duration, error) {
+func (f *fakeIntentStore) ListPods(path string) ([]kp.ManifestResult, time.Duration, error) {
 	return f.manifests, 0, nil
 }
 

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -35,7 +35,7 @@ type Hooks interface {
 }
 
 type Store interface {
-	ListPods(keyPrefix string) ([]kp.ManifestResult, time.Duration, error)
+	ListPods(path string) ([]kp.ManifestResult, time.Duration, error)
 	SetPod(string, pods.Manifest) (time.Duration, error)
 	Pod(key string) (pods.Manifest, time.Duration, error)
 	DeletePod(key string) (time.Duration, error)


### PR DESCRIPTION
Changes all callers of api.KV.List(), consulutil.SafeList(), or
consulutil.WatchPrefix() to append an extra "/" to the end of the watched
string.  Also changes kp.Store.ListPods() and kp.Store.WatchPods() to accept a
"path" to a Consul subtree, not an arbitrary "prefix." All existing callers of
of these two methods already pass subtree paths, e.g., `kp.*_TREE` or
`kp.*Path(hostname)`, so this shouldn't change any existing behavior.

These changes are an extra safeguard to make sure that a List operation returns
the right results in the presence of path components that are subsets of each
other. For instance, if two nodes were named "node1" and "node10", listing all
of node1's pods (e.g., List("intent/node1")) would previously have returned
node10's pods too (e.g., "intent/node10/p2-preparer").