### PR TITLE
create an ID type in pods package for pod IDs

### DIFF
--- a/bin/p2-bin2pod/main.go
+++ b/bin/p2-bin2pod/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/square/p2/Godeps/_workspace/src/gopkg.in/alecthomas/kingpin.v2"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/uri"
 	"github.com/square/p2/pkg/version"
 )
@@ -51,11 +52,11 @@ type Result struct {
 	FinalLocation string `json:"final_location"`
 }
 
-func podId() string {
+func podId() types.PodID {
 	if *id != "" {
-		return *id
+		return types.PodID(*id)
 	}
-	return path.Base(*executable)
+	return types.PodID(path.Base(*executable))
 }
 
 func activeDir() string {
@@ -78,7 +79,7 @@ func main() {
 	manifestBuilder.SetID(podId())
 
 	stanza := pods.LaunchableStanza{}
-	stanza.LaunchableId = podId()
+	stanza.LaunchableId = string(podId())
 	stanza.LaunchableType = "hoist"
 
 	workingDir := activeDir()
@@ -99,7 +100,7 @@ func main() {
 	}
 
 	manifestBuilder.SetLaunchables(map[string]pods.LaunchableStanza{
-		podId(): stanza,
+		string(podId()): stanza,
 	})
 
 	if err != nil {

--- a/bin/p2-bootstrap/bootstrap.go
+++ b/bin/p2-bootstrap/bootstrap.go
@@ -8,6 +8,7 @@ import (
 	"github.com/square/p2/Godeps/_workspace/src/gopkg.in/alecthomas/kingpin.v2"
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
 	"github.com/square/p2/pkg/version"
 )
@@ -128,7 +129,7 @@ func VerifyConsulUp(timeout string) error {
 	}
 }
 
-func VerifyReality(waitTime time.Duration, consulID, agentID string) error {
+func VerifyReality(waitTime time.Duration, consulID types.PodID, agentID types.PodID) error {
 	quit := make(chan struct{})
 	defer close(quit)
 	store := kp.NewConsulStore(kp.NewConsulClient(kp.Options{
@@ -172,13 +173,13 @@ func ScheduleForThisHost(manifest pods.Manifest, alsoReality bool) error {
 	if err != nil {
 		return err
 	}
-	_, err = store.SetPod(kp.IntentPath(hostname, manifest.ID()), manifest)
+	_, err = store.SetPod(kp.IntentPath(hostname, string(manifest.ID())), manifest)
 	if err != nil {
 		return err
 	}
 
 	if alsoReality {
-		_, err = store.SetPod(kp.RealityPath(hostname, manifest.ID()), manifest)
+		_, err = store.SetPod(kp.RealityPath(hostname, string(manifest.ID())), manifest)
 		return err
 	}
 	return nil

--- a/bin/p2-launch/main.go
+++ b/bin/p2-launch/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/preparer"
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
 	"github.com/square/p2/pkg/version"
 
@@ -81,7 +82,7 @@ func authorize(manifest pods.Manifest) error {
 
 		policy, err = auth.NewFileKeyringPolicy(
 			*keyring,
-			map[string][]string{
+			map[types.PodID][]string{
 				preparer.POD_ID: *allowedUsers,
 			},
 		)
@@ -100,7 +101,7 @@ func authorize(manifest pods.Manifest) error {
 			*keyring,
 			*deployPolicy,
 			preparer.POD_ID,
-			preparer.POD_ID,
+			string(preparer.POD_ID),
 		)
 		if err != nil {
 			return err

--- a/bin/p2-run-hooks/main.go
+++ b/bin/p2-run-hooks/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/square/p2/pkg/hooks"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/version"
 )
 
@@ -29,7 +30,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	pod := pods.NewPod(path.Base(*PodDir), *PodDir)
+	pod := pods.NewPod(types.PodID(path.Base(*PodDir)), *PodDir)
 
 	var manifest pods.Manifest
 	if *Manifest != "" {

--- a/bin/p2-schedule/main.go
+++ b/bin/p2-schedule/main.go
@@ -41,9 +41,9 @@ func main() {
 		if err != nil {
 			log.Fatalf("Could not read manifest at %s: %s\n", manifestPath, err)
 		}
-		path := kp.IntentPath(*nodeName, manifest.ID())
+		path := kp.IntentPath(*nodeName, string(manifest.ID()))
 		if *hookGlobal {
-			path = kp.HookPath(manifest.ID())
+			path = kp.HookPath(string(manifest.ID()))
 		}
 		duration, err := store.SetPod(path, manifest)
 		if err != nil {

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -1,8 +1,12 @@
 package health
 
+import (
+	"github.com/square/p2/pkg/types"
+)
+
 // Result stores the health state of a service.
 type Result struct {
-	ID      string
+	ID      types.PodID
 	Node    string
 	Service string
 	Status  HealthState

--- a/pkg/hooks/hook_env.go
+++ b/pkg/hooks/hook_env.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/square/p2/pkg/config"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
 )
 
@@ -35,7 +36,7 @@ func (h *HookEnv) Pod() (*pods.Pod, error) {
 		return nil, util.Errorf("No pod home given for pod ID %s", id)
 	}
 
-	return pods.NewPod(id, path), nil
+	return pods.NewPod(types.PodID(id), path), nil
 }
 
 func (h *HookEnv) Config() (*config.Config, error) {

--- a/pkg/kp/healthmanager.go
+++ b/pkg/kp/healthmanager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/square/p2/pkg/health"
 	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util/limit"
 	"github.com/square/p2/pkg/util/param"
 	"github.com/square/p2/pkg/util/stream"
@@ -98,14 +99,14 @@ func (m *consulHealthManager) Close() {
 // service health and which health it has published.
 type consulHealthUpdater struct {
 	node    string           // The node this updater is bound to
-	pod     string           // The pod ID this updater is bound to
+	pod     types.PodID      // The pod ID this updater is bound to
 	service string           // The service this updater is bound to
 	checker chan WatchResult // Stream of health updates from a checker
 }
 
 // NewUpdater creates a new HealthUpdater that can be used to update an app's health status
 // on this node.
-func (m *consulHealthManager) NewUpdater(pod, service string) HealthUpdater {
+func (m *consulHealthManager) NewUpdater(pod types.PodID, service string) HealthUpdater {
 	checksStream := make(chan WatchResult)
 	u := &consulHealthUpdater{
 		node:    m.node,

--- a/pkg/kp/kv.go
+++ b/pkg/kp/kv.go
@@ -13,6 +13,7 @@ import (
 	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
 )
 
@@ -47,7 +48,7 @@ type Store interface {
 type HealthManager interface {
 	// NewUpdater creates a new object for publishing a single service's health. Each
 	// service should have its own updater.
-	NewUpdater(pod, service string) HealthUpdater
+	NewUpdater(pod types.PodID, service string) HealthUpdater
 
 	// Close removes all published health statuses and releases all manager resources.
 	Close()
@@ -65,7 +66,7 @@ type HealthUpdater interface {
 }
 
 type WatchResult struct {
-	Id      string
+	Id      types.PodID
 	Node    string
 	Service string
 	Status  string

--- a/pkg/kp/rcstore/consul_store.go
+++ b/pkg/kp/rcstore/consul_store.go
@@ -340,5 +340,5 @@ func (s *consulStore) forEachLabel(rc fields.RC, f func(id, k, v string) error) 
 	id := rc.ID.String()
 	// As of this writing the only label we want is the pod ID.
 	// There may be more in the future.
-	return f(id, PodIDLabel, rc.Manifest.ID())
+	return f(id, PodIDLabel, string(rc.Manifest.ID()))
 }

--- a/pkg/pods/manifest_test.go
+++ b/pkg/pods/manifest_test.go
@@ -20,7 +20,7 @@ func TestPodManifestCanBeRead(t *testing.T) {
 
 	manifest, err := ManifestFromPath(testPath)
 	Assert(t).IsNil(err, "Should not have failed to get pod manifest.")
-	Assert(t).AreEqual("hello", manifest.ID(), "Id read from manifest didn't have expected value")
+	Assert(t).AreEqual("hello", string(manifest.ID()), "Id read from manifest didn't have expected value")
 	Assert(t).AreEqual(manifest.GetLaunchableStanzas()["app"].Location, "hoisted-hello_def456.tar.gz", "Location read from manifest didn't have expected value")
 	Assert(t).AreEqual("hoist", manifest.GetLaunchableStanzas()["app"].LaunchableType, "LaunchableType read from manifest didn't have expected value")
 	Assert(t).AreEqual("app", manifest.GetLaunchableStanzas()["app"].LaunchableId, "LaunchableId read from manifest didn't have expected value")
@@ -155,7 +155,7 @@ func TestRunAs(t *testing.T) {
 	manifest, err := ManifestFromBytes([]byte(config))
 	Assert(t).IsNil(err, "should not have erred when building manifest")
 
-	Assert(t).AreEqual(manifest.RunAsUser(), manifest.ID(), "RunAsUser() didn't match expectations")
+	Assert(t).AreEqual(manifest.RunAsUser(), string(manifest.ID()), "RunAsUser() didn't match expectations")
 
 	config += `run_as: specialuser`
 	manifest, err = ManifestFromBytes([]byte(config))
@@ -189,7 +189,7 @@ func TestManifestBuilder(t *testing.T) {
 	builder.SetID("testpod")
 	manifest := builder.GetManifest()
 
-	Assert(t).AreEqual(manifest.ID(), "testpod", "id of built manifest did not match expected")
+	Assert(t).AreEqual(string(manifest.ID()), "testpod", "id of built manifest did not match expected")
 }
 
 func TestManifestBuilderStripsFields(t *testing.T) {
@@ -224,7 +224,7 @@ config:
 
 	builder := manifest.GetBuilder()
 	builtManifest := builder.GetManifest()
-	Assert(t).AreEqual(builtManifest.ID(), "thepod", "Expected manifest ID to be preserved when converted to ManifestBuilder and back")
+	Assert(t).AreEqual(string(builtManifest.ID()), "thepod", "Expected manifest ID to be preserved when converted to ManifestBuilder and back")
 }
 
 func TestGetConfigInitializesIfEmpty(t *testing.T) {

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -16,13 +16,14 @@ import (
 	"github.com/square/p2/pkg/hoist"
 	"github.com/square/p2/pkg/launch"
 	"github.com/square/p2/pkg/runit"
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
 
 	. "github.com/square/p2/Godeps/_workspace/src/github.com/anthonybishopric/gotcha"
 )
 
 func getTestPod() *Pod {
-	return NewPod("hello", "/data/pods/test")
+	return NewPod(types.PodID("hello"), "/data/pods/test")
 }
 
 func getTestPodManifest(t *testing.T) Manifest {
@@ -212,7 +213,7 @@ func TestWriteManifestWillReturnOldManifestTempPath(t *testing.T) {
 
 	poddir, err := ioutil.TempDir("", "poddir")
 	Assert(t).IsNil(err, "couldn't create tempdir")
-	pod := NewPod("testPod", poddir)
+	pod := NewPod(types.PodID("testPod"), poddir)
 
 	// set the RunAs user to the user running the test, because when we
 	// write files we need an owner. Unset them after the write so that the

--- a/pkg/preparer/listener.go
+++ b/pkg/preparer/listener.go
@@ -101,7 +101,10 @@ func (l *HookListener) installHook(result kp.ManifestResult) error {
 		return err
 	}
 
-	hookPod := pods.NewPod(result.Manifest.ID(), filepath.Join(l.DestinationDir, result.Manifest.ID()))
+	hookPod := pods.NewPod(
+		result.Manifest.ID(),
+		filepath.Join(l.DestinationDir, string(result.Manifest.ID())),
+	)
 
 	// Figure out if we even need to install anything.
 	// Hooks aren't running services and so there isn't a need

--- a/pkg/preparer/orchestrate_test.go
+++ b/pkg/preparer/orchestrate_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
 	"github.com/square/p2/pkg/util/size"
 )
@@ -402,7 +403,7 @@ func TestPreparerWillRejectUnauthorizedSignatureForPreparer(t *testing.T) {
 	defer os.RemoveAll(fakePodRoot)
 	p.authPolicy = auth.FixedKeyringPolicy{
 		Keyring:             openpgp.EntityList{fakeSigner},
-		AuthorizedDeployers: map[string][]string{POD_ID: {"nobodylol"}},
+		AuthorizedDeployers: map[types.PodID][]string{POD_ID: {"nobodylol"}},
 	}
 
 	Assert(t).IsFalse(
@@ -423,7 +424,7 @@ func TestPreparerWillAcceptAuthorizedSignatureForPreparer(t *testing.T) {
 	defer os.RemoveAll(fakePodRoot)
 	p.authPolicy = auth.FixedKeyringPolicy{
 		Keyring:             openpgp.EntityList{fakeSigner},
-		AuthorizedDeployers: map[string][]string{POD_ID: {sig}},
+		AuthorizedDeployers: map[types.PodID][]string{POD_ID: {sig}},
 	}
 
 	Assert(t).IsTrue(

--- a/pkg/preparer/result_set.go
+++ b/pkg/preparer/result_set.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/types"
 )
 
 type ManifestPair struct {
 	// save the ID in a separate field, so that the user of this object doesn't
 	// have to check both manifests
-	ID      string
+	ID      types.PodID
 	Intent  pods.Manifest
 	Reality pods.Manifest
 }
@@ -26,7 +27,7 @@ func ZipResultSets(intent, reality []kp.ManifestResult) (ret []ManifestPair) {
 
 	// this is like a union algorithm, we want to exhaust both lists
 	for intentIndex < len(intent) || realityIndex < len(reality) {
-		var iID, rID string
+		var iID, rID types.PodID
 		// since one of the lists may go off-the-end before the other, we have
 		// to guard any indexing into the lists to avoid out-of-range panics
 		if intentIndex < len(intent) {
@@ -70,7 +71,7 @@ func (s sortByID) Len() int           { return len(s) }
 func (s sortByID) Less(i, j int) bool { return s[i].Manifest.ID() < s[j].Manifest.ID() }
 func (s sortByID) Swap(i, j int)      { tmp := s[i]; s[i] = s[j]; s[j] = tmp }
 
-func checkResultsForID(intent []kp.ManifestResult, id string) bool {
+func checkResultsForID(intent []kp.ManifestResult, id types.PodID) bool {
 	for _, result := range intent {
 		if result.Manifest.ID() == id {
 			return true

--- a/pkg/preparer/result_set_test.go
+++ b/pkg/preparer/result_set_test.go
@@ -8,11 +8,12 @@ import (
 	. "github.com/square/p2/Godeps/_workspace/src/github.com/anthonybishopric/gotcha"
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/types"
 )
 
 func podWithID(id string) pods.Manifest {
 	builder := pods.NewManifestBuilder()
-	builder.SetID(id)
+	builder.SetID(types.PodID(id))
 	return builder.GetManifest()
 }
 

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -19,6 +19,7 @@ import (
 	"github.com/square/p2/pkg/launch"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
 	"github.com/square/p2/pkg/util/param"
 	"github.com/square/p2/pkg/util/size"
@@ -47,7 +48,7 @@ type Preparer struct {
 	caFile                 string
 	authPolicy             auth.Policy
 	maxLaunchableDiskUsage size.ByteCount
-	logExecTestGroup       []string
+	logExecTestGroup       []types.PodID
 }
 
 type PreparerConfig struct {
@@ -67,7 +68,7 @@ type PreparerConfig struct {
 	ExtraLogDestinations   []LogDestination       `yaml:"extra_log_destinations,omitempty"`
 	LogLevel               string                 `yaml:"log_level,omitempty"`
 	MaxLaunchableDiskUsage string                 `yaml:"max_launchable_disk_usage"`
-	LogExecTestGroup       []string               `yaml:"log_exec_test_group",omitempty`
+	LogExecTestGroup       []types.PodID          `yaml:"log_exec_test_group",omitempty`
 
 	// Params defines a collection of miscellaneous runtime parameters defined throughout the
 	// source files.
@@ -277,7 +278,7 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 		}
 		authPolicy, err = auth.NewFileKeyringPolicy(
 			authConfig.KeyringPath,
-			map[string][]string{POD_ID: authConfig.AuthorizedDeployers},
+			map[types.PodID][]string{POD_ID: authConfig.AuthorizedDeployers},
 		)
 		if err != nil {
 			return nil, util.Errorf("error configuring keyring auth: %s", err)
@@ -298,7 +299,7 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 			userConfig.KeyringPath,
 			userConfig.DeployPolicyPath,
 			POD_ID,
-			POD_ID,
+			string(POD_ID),
 		)
 		if err != nil {
 			return nil, util.Errorf("error configuring user auth: %s", err)

--- a/pkg/rc/replication_controller.go
+++ b/pkg/rc/replication_controller.go
@@ -212,7 +212,7 @@ func (rc *replicationController) CurrentNodes() ([]string, error) {
 // If forEachLabel encounters any error applying the function, it returns that error immediately.
 // The function is not further applied to subsequent labels on an error.
 func (rc *replicationController) forEachLabel(node string, f func(id, k, v string) error) error {
-	id := node + "/" + rc.Manifest.ID()
+	id := node + "/" + string(rc.Manifest.ID())
 
 	// user-requested labels.
 	for k, v := range rc.PodLabels {
@@ -226,7 +226,7 @@ func (rc *replicationController) forEachLabel(node string, f func(id, k, v strin
 
 func (rc *replicationController) schedule(node string) error {
 	// First, schedule the new pod.
-	intentPath := kp.IntentPath(node, rc.Manifest.ID())
+	intentPath := kp.IntentPath(node, string(rc.Manifest.ID()))
 	rc.logger.NoFields().Infof("Scheduling on %s", intentPath)
 	_, err := rc.kpStore.SetPod(intentPath, rc.Manifest)
 	if err != nil {
@@ -243,7 +243,7 @@ func (rc *replicationController) schedule(node string) error {
 }
 
 func (rc *replicationController) unschedule(node string) error {
-	intentPath := kp.IntentPath(node, rc.Manifest.ID())
+	intentPath := kp.IntentPath(node, string(rc.Manifest.ID()))
 	rc.logger.NoFields().Infof("Uncheduling from %s", intentPath)
 
 	// TODO: As above in schedule, it could be the case that RemoveLabel fails.

--- a/pkg/rc/replication_controller_test.go
+++ b/pkg/rc/replication_controller_test.go
@@ -138,7 +138,7 @@ func TestSchedule(t *testing.T) {
 
 	for k, v := range kp.manifests {
 		Assert(t).AreEqual(k, "intent/node2/testPod", "expected manifest scheduled on the right node")
-		Assert(t).AreEqual(v.ID(), "testPod", "expected manifest with correct ID")
+		Assert(t).AreEqual(string(v.ID()), "testPod", "expected manifest with correct ID")
 	}
 }
 
@@ -163,7 +163,7 @@ func TestSchedulePartial(t *testing.T) {
 
 	for k, v := range kp.manifests {
 		Assert(t).AreEqual(k, "intent/node2/testPod", "expected manifest scheduled on the right node")
-		Assert(t).AreEqual(v.ID(), "testPod", "expected manifest with correct ID")
+		Assert(t).AreEqual(string(v.ID()), "testPod", "expected manifest with correct ID")
 	}
 
 	select {
@@ -206,7 +206,7 @@ func TestScheduleTwice(t *testing.T) {
 		if k != "intent/node1/testPod" && k != "intent/node2/testPod" {
 			Assert(t).Fail("expected manifest scheduled on the right node")
 		}
-		Assert(t).AreEqual(v.ID(), "testPod", "expected manifest with correct ID")
+		Assert(t).AreEqual(string(v.ID()), "testPod", "expected manifest with correct ID")
 	}
 }
 

--- a/pkg/replication/replication_test.go
+++ b/pkg/replication/replication_test.go
@@ -264,7 +264,7 @@ func TestStopsIfLockDestroyed(t *testing.T) {
 	}
 
 	for _, host := range testNodes {
-		lockPath := kp.LockPath(kp.IntentPath(host, manifest.ID()))
+		lockPath := kp.LockPath(kp.IntentPath(host, string(manifest.ID())))
 		err := replication.lock(lock, lockPath, false)
 
 		if err != nil {
@@ -344,7 +344,7 @@ func TestStopsIfLockDestroyed(t *testing.T) {
 	}
 
 	// Destroy lock holder so the next renewal will fail
-	lockPath := kp.LockPath(kp.IntentPath(testNodes[0], manifest.ID()))
+	lockPath := kp.LockPath(kp.IntentPath(testNodes[0], string(manifest.ID())))
 	_, id, err := store.LockHolder(lockPath)
 	if err != nil {
 		t.Fatalf("Unable to determine lock holder in order to destroy the lock: %s", err)

--- a/pkg/replication/replicator.go
+++ b/pkg/replication/replicator.go
@@ -86,7 +86,7 @@ func (r replicator) InitializeReplication(overrideLock bool) (Replication, chan 
 // Checks that the preparer is running on every host being deployed to.
 func (r replicator) checkPreparers() error {
 	for _, host := range r.nodes {
-		_, _, err := r.store.Pod(kp.RealityPath(host, preparer.POD_ID))
+		_, _, err := r.store.Pod(kp.RealityPath(host, string(preparer.POD_ID)))
 		if err != nil {
 			return util.Errorf("Could not verify %v state on %q: %v", preparer.POD_ID, host, err)
 		}

--- a/pkg/roll/run_update.go
+++ b/pkg/roll/run_update.go
@@ -117,7 +117,7 @@ func (u update) Run(quit <-chan struct{}) (ret bool) {
 	hErrs := make(chan error)
 	hQuit := make(chan struct{})
 	defer close(hQuit)
-	go u.hcheck.WatchService(newFields.Manifest.ID(), hChecks, hErrs, hQuit)
+	go u.hcheck.WatchService(string(newFields.Manifest.ID()), hChecks, hErrs, hQuit)
 
 ROLL_LOOP:
 	for {
@@ -306,7 +306,7 @@ func (u update) countHealthy(id rcf.ID, checks map[string]health.Result) (rcNode
 
 	for _, node := range nodes {
 		// TODO: is reality checking an rc-layer concern?
-		realManifest, _, err := u.kps.Pod(kp.RealityPath(node, rcFields.Manifest.ID()))
+		realManifest, _, err := u.kps.Pod(kp.RealityPath(node, string(rcFields.Manifest.ID())))
 		if err != nil {
 			return ret, err
 		}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,0 +1,6 @@
+// Package for declaring types that will be used by various other packages. This is useful
+// for preventing import cycles. For example, pkg/pods depends on pkg/auth. If both
+// wish to use pods.ID, an import cycle is created.
+package types
+
+type PodID string

--- a/pkg/watch/health.go
+++ b/pkg/watch/health.go
@@ -11,6 +11,7 @@ import (
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/preparer"
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util/param"
 )
 
@@ -46,10 +47,9 @@ type PodWatch struct {
 }
 
 // StatusChecker holds all the data required to perform
-// a status check on a particular service (ID corresponds
-// to service name to be consistent with pods.Manifest).
+// a status check on a particular service
 type StatusChecker struct {
-	ID     string
+	ID     types.PodID
 	Node   string
 	URI    string
 	Client *http.Client
@@ -162,7 +162,7 @@ func updatePods(
 			}
 			newPod := PodWatch{
 				manifest:      man.Manifest,
-				updater:       healthManager.NewUpdater(man.Manifest.ID(), man.Manifest.ID()),
+				updater:       healthManager.NewUpdater(man.Manifest.ID(), string(man.Manifest.ID())),
 				statusChecker: sc,
 				shutdownCh:    make(chan bool, 1),
 				logger:        logger,
@@ -219,7 +219,7 @@ func (sc *StatusChecker) Check() (health.Result, error) {
 		return health.Result{
 			ID:      sc.ID,
 			Node:    sc.Node,
-			Service: sc.ID,
+			Service: string(sc.ID),
 			Status:  health.Passing,
 			Output:  "(no health check defined)",
 		}, nil
@@ -230,7 +230,7 @@ func (sc *StatusChecker) resultFromCheck(resp *http.Response, err error) (health
 	res := health.Result{
 		ID:      sc.ID,
 		Node:    sc.Node,
-		Service: sc.ID,
+		Service: string(sc.ID),
 	}
 	if err != nil || resp == nil {
 		res.Status = health.Critical

--- a/pkg/watch/health_test.go
+++ b/pkg/watch/health_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/types"
 )
 
 type MockHealthManager struct {
@@ -24,7 +25,7 @@ func (m *MockHealthManager) Reset() {
 	*m = MockHealthManager{}
 }
 
-func (m *MockHealthManager) NewUpdater(pod, service string) kp.HealthUpdater {
+func (m *MockHealthManager) NewUpdater(pod types.PodID, service string) kp.HealthUpdater {
 	m.UpdaterCreated += 1
 	return m
 }
@@ -44,7 +45,7 @@ func TestUpdatePods(t *testing.T) {
 	var reality []kp.ManifestResult
 	// ids for current: 0, 1, 2, 3
 	for i := 0; i < 4; i++ {
-		current = append(current, *newWatch(strconv.Itoa(i)))
+		current = append(current, *newWatch(types.PodID(strconv.Itoa(i))))
 	}
 	// ids for reality: 1, 2, test
 	for i := 1; i < 3; i++ {
@@ -61,7 +62,7 @@ func TestUpdatePods(t *testing.T) {
 
 	Assert(t).AreEqual(current[1].manifest.ID(), pods[0].manifest.ID(), "pod with id:1 should have been returned")
 	Assert(t).AreEqual(current[2].manifest.ID(), pods[1].manifest.ID(), "pod with id:1 should have been returned")
-	Assert(t).AreEqual("test", pods[2].manifest.ID(), "should have added pod with id:test to list")
+	Assert(t).AreEqual("test", string(pods[2].manifest.ID()), "should have added pod with id:test to list")
 }
 
 func TestUpdateStatus(t *testing.T) {
@@ -112,7 +113,7 @@ output`))), nil)
 	Assert(t).AreEqual(health.Critical, val.Status, "err != nil should correspond to health.Critical")
 }
 
-func newWatch(id string) *PodWatch {
+func newWatch(id types.PodID) *PodWatch {
 	ch := make(chan bool, 1)
 	return &PodWatch{
 		manifest:   newManifestResult(id).Manifest,
@@ -120,7 +121,7 @@ func newWatch(id string) *PodWatch {
 	}
 }
 
-func newManifestResult(id string) kp.ManifestResult {
+func newManifestResult(id types.PodID) kp.ManifestResult {
 	builder := pods.NewManifestBuilder()
 	builder.SetID(id)
 	builder.SetStatusPort(1) // StatusPort must != 0 for updatePods to use it


### PR DESCRIPTION
This will increase type safety when passing around pod IDs from package
to package. For instance, the kp package can provide some safety around
constructing keys by differentiating the pod id type from the hostname
type.