### PR TITLE
Add type safety when computing consul key paths

### DIFF
--- a/bin/p2-bootstrap/bootstrap.go
+++ b/bin/p2-bootstrap/bootstrap.go
@@ -146,7 +146,7 @@ func VerifyReality(waitTime time.Duration, consulID types.PodID, agentID types.P
 				"Consul and/or Preparer weren't in the reality store within %s (consul=%t, preparer=%t)",
 				waitTime, hasConsul, hasPreparer)
 		case <-time.After(100 * time.Millisecond):
-			results, _, err := store.ListPods(kp.RealityPath(hostname))
+			results, _, err := store.ListPods(kp.REALITY_TREE, hostname)
 			if err != nil {
 				log.Printf("Error looking for pods: %s\n", err)
 				continue
@@ -173,13 +173,13 @@ func ScheduleForThisHost(manifest pods.Manifest, alsoReality bool) error {
 	if err != nil {
 		return err
 	}
-	_, err = store.SetPod(kp.IntentPath(hostname, string(manifest.ID())), manifest)
+	_, err = store.SetPod(kp.INTENT_TREE, hostname, manifest)
 	if err != nil {
 		return err
 	}
 
 	if alsoReality {
-		_, err = store.SetPod(kp.RealityPath(hostname, string(manifest.ID())), manifest)
+		_, err = store.SetPod(kp.REALITY_TREE, hostname, manifest)
 		return err
 	}
 	return nil

--- a/bin/p2-inspect/main.go
+++ b/bin/p2-inspect/main.go
@@ -27,7 +27,7 @@ func main() {
 	client := kp.NewConsulClient(opts)
 	store := kp.NewConsulStore(client)
 
-	intents, _, err := store.ListPods(kp.INTENT_TREE)
+	intents, _, err := store.AllPods(kp.INTENT_TREE)
 	if err != nil {
 		message := "Could not list intent kvpairs: %s"
 		if kvErr, ok := err.(consulutil.KVError); ok {
@@ -36,7 +36,7 @@ func main() {
 			log.Fatalf(message, err)
 		}
 	}
-	realities, _, err := store.ListPods(kp.REALITY_TREE)
+	realities, _, err := store.AllPods(kp.REALITY_TREE)
 	if err != nil {
 		message := "Could not list reality kvpairs: %s"
 		if kvErr, ok := err.(consulutil.KVError); ok {

--- a/bin/p2-schedule/main.go
+++ b/bin/p2-schedule/main.go
@@ -41,11 +41,11 @@ func main() {
 		if err != nil {
 			log.Fatalf("Could not read manifest at %s: %s\n", manifestPath, err)
 		}
-		path := kp.IntentPath(*nodeName, string(manifest.ID()))
+		podPrefix := kp.INTENT_TREE
 		if *hookGlobal {
-			path = kp.HookPath(string(manifest.ID()))
+			podPrefix = kp.HOOK_TREE
 		}
-		duration, err := store.SetPod(path, manifest)
+		duration, err := store.SetPod(podPrefix, *nodeName, manifest)
 		if err != nil {
 			log.Fatalf("Could not write manifest %s to intent store: %s\n", manifest.ID(), err)
 		}

--- a/bin/p2-watch/main.go
+++ b/bin/p2-watch/main.go
@@ -32,23 +32,23 @@ func main() {
 		*nodeName = hostname
 	}
 
-	path := kp.IntentPath(*nodeName)
+	podPrefix := kp.INTENT_TREE
 	if *watchReality {
-		path = kp.RealityPath(*nodeName)
+		podPrefix = kp.REALITY_TREE
 	} else if *hooks {
-		path = kp.HookPath()
+		podPrefix = kp.HOOK_TREE
 	}
-	log.Printf("Watching manifests at %s\n", path)
+	log.Printf("Watching manifests at %s/%s/\n", podPrefix, *nodeName)
 
 	quit := make(chan struct{})
 	errChan := make(chan error)
 	podCh := make(chan []kp.ManifestResult)
-	go store.WatchPods(path, quit, errChan, podCh)
+	go store.WatchPods(podPrefix, *nodeName, quit, errChan, podCh)
 	for {
 		select {
 		case results := <-podCh:
 			if len(results) == 0 {
-				fmt.Println(fmt.Sprintf("No manifest exists at key %s (it may have been deleted)", path))
+				fmt.Println(fmt.Sprintf("No manifests exist for %s under %s (they may have been deleted)", *nodeName, podPrefix))
 			} else {
 				for _, result := range results {
 					fmt.Println("")

--- a/pkg/kp/constants.go
+++ b/pkg/kp/constants.go
@@ -1,38 +1,59 @@
 package kp
 
 import (
-	"strings"
+	"path"
+
+	"github.com/square/p2/pkg/types"
+	"github.com/square/p2/pkg/util"
 )
+
+// PodPrefix represents the top level of a subtree whose leaves are expected to
+// be pods, e.g. "hooks", "intent", "reality"
+type PodPrefix string
 
 const (
-	INTENT_TREE  string = "intent"
-	REALITY_TREE string = "reality"
-	HOOK_TREE    string = "hooks"
-	LOCK_TREE    string = "lock"
-	RC_TREE      string = "replication_controllers"
-	ROLL_TREE    string = "rolls"
+	INTENT_TREE  PodPrefix = "intent"
+	REALITY_TREE PodPrefix = "reality"
+	HOOK_TREE    PodPrefix = "hooks"
+	LOCK_TREE    string    = "lock"
 )
 
-func IntentPath(args ...string) string {
-	return strings.Join(append([]string{INTENT_TREE}, args...), "/")
+func nodePath(podPrefix PodPrefix, nodeName string) (string, error) {
+	// hook tree is an exception to the rule because they are not scheduled
+	// by host, and it is valid to want to watch for them agnostic to pod
+	// id. There are plans to deploy hooks by host at which time this
+	// exception can be removed
+	if podPrefix == HOOK_TREE {
+		nodeName = ""
+	} else {
+		if nodeName == "" {
+			return "", util.Errorf("nodeName not specified when computing host path")
+		}
+	}
+
+	return path.Join(string(podPrefix), nodeName), nil
 }
 
-func RealityPath(args ...string) string {
-	return strings.Join(append([]string{REALITY_TREE}, args...), "/")
+func podPath(podPrefix PodPrefix, nodeName string, podId types.PodID) (string, error) {
+	nodePath, err := nodePath(podPrefix, nodeName)
+	if err != nil {
+		return "", err
+	}
+
+	if podId == "" {
+		return "", util.Errorf("pod id not specified when computing pod path")
+	}
+
+	return path.Join(nodePath, string(podId)), nil
 }
 
-func HookPath(args ...string) string {
-	return strings.Join(append([]string{HOOK_TREE}, args...), "/")
-}
+// Returns the consul path to use when intending to lock a pod, e.g.
+// lock/intent/some_host/some_pod
+func PodLockPath(podPrefix PodPrefix, nodeName string, podId types.PodID) (string, error) {
+	subPodPath, err := podPath(podPrefix, nodeName, podId)
+	if err != nil {
+		return "", err
+	}
 
-func LockPath(args ...string) string {
-	return strings.Join(append([]string{LOCK_TREE}, args...), "/")
-}
-
-func RCPath(args ...string) string {
-	return strings.Join(append([]string{RC_TREE}, args...), "/")
-}
-
-func RollPath(args ...string) string {
-	return strings.Join(append([]string{ROLL_TREE}, args...), "/")
+	return path.Join(LOCK_TREE, subPodPath), nil
 }

--- a/pkg/kp/constants_test.go
+++ b/pkg/kp/constants_test.go
@@ -1,0 +1,78 @@
+package kp
+
+import (
+	"fmt"
+	"testing"
+)
+
+const (
+	testHostname = "some_host.com"
+	testPodId    = "some_pod_id"
+)
+
+func TestNodePathHappy(t *testing.T) {
+	nodePath, err := nodePath(INTENT_TREE, testHostname)
+	if err != nil {
+		t.Errorf("should not have errored retrieving node path: %s", err)
+	}
+
+	expected := fmt.Sprintf("%s/%s", INTENT_TREE, testHostname)
+	if nodePath != expected {
+		t.Errorf(
+			"Unexpected value for nodePath, wanted '%s' got '%s'",
+			expected,
+			nodePath,
+		)
+	}
+}
+
+func TestNodePathErrorsWhenNoNodeName(t *testing.T) {
+	_, err := nodePath(INTENT_TREE, "")
+	if err == nil {
+		t.Errorf("Should have gotten an error passing empty hostname")
+	}
+}
+
+func TestHookPathIsExceptionToNodeNameRule(t *testing.T) {
+	_, err := nodePath(HOOK_TREE, "")
+	if err != nil {
+		t.Errorf("Should not have errored omitting hostname when creating hook path: %s", err)
+	}
+}
+
+func TestHookPathNodeNameIsIgnored(t *testing.T) {
+	nodePath, err := nodePath(HOOK_TREE, testHostname)
+	if err != nil {
+		t.Errorf("Should not have errored retrieving node path: %s", err)
+	}
+
+	expected := fmt.Sprintf("%s", HOOK_TREE)
+	if nodePath != expected {
+		t.Errorf("Unexpected value for nodePath, wanted '%s' got '%s'",
+			expected,
+			nodePath,
+		)
+	}
+}
+
+func TestPodPath(t *testing.T) {
+	podPath, err := podPath(REALITY_TREE, testHostname, testPodId)
+	if err != nil {
+		t.Errorf("should not have errored retrieving pod path: %s", err)
+	}
+
+	expected := fmt.Sprintf("%s/%s/%s", REALITY_TREE, testHostname, testPodId)
+	if podPath != expected {
+		t.Errorf("Unexpected value for podPath, wanted '%s' got '%s'",
+			expected,
+			podPath,
+		)
+	}
+}
+
+func TestPodPathErrorNoHostname(t *testing.T) {
+	_, err := podPath(REALITY_TREE, "", testPodId)
+	if err == nil {
+		t.Errorf("should have errored retrieving pod path with empty nodeName")
+	}
+}

--- a/pkg/kp/rcstore/store_test.go
+++ b/pkg/kp/rcstore/store_test.go
@@ -1,0 +1,76 @@
+package rcstore
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/square/p2/pkg/kp"
+)
+
+const testRCId = "abcd-1234"
+
+func TestRCPathHappy(t *testing.T) {
+	rcPath, err := rcPath(testRCId)
+	if err != nil {
+		t.Fatalf("Unable to compute rc path: %s", err)
+	}
+
+	expected := fmt.Sprintf("%s/%s", rcTree, testRCId)
+	if rcPath != expected {
+		t.Errorf("Unexpected value for rcPath, wanted '%s' got '%s'",
+			expected,
+			rcPath,
+		)
+	}
+}
+
+func TestRCPathErrorNoID(t *testing.T) {
+	_, err := rcPath("")
+	if err == nil {
+		t.Errorf("Should have errored retrieving rc path with empty rcID")
+	}
+}
+
+func TestRCLockPath(t *testing.T) {
+	rcLockPath, err := RCLockPath(testRCId)
+	if err != nil {
+		t.Fatalf("Unable to compute rc lock path: %s", err)
+	}
+
+	expected := fmt.Sprintf("%s/%s/%s", kp.LOCK_TREE, rcTree, testRCId)
+	if rcLockPath != expected {
+		t.Errorf("Unexpected value for rcLockPath, wanted '%s' got '%s'",
+			expected,
+			rcLockPath,
+		)
+	}
+}
+
+func TestRCLockPathErrorNoID(t *testing.T) {
+	_, err := RCLockPath("")
+	if err == nil {
+		t.Errorf("Expected error computing rc lock path with no id")
+	}
+}
+
+func TestRCUpdateLockPath(t *testing.T) {
+	rcUpdateLockPath, err := RCUpdateLockPath(testRCId)
+	if err != nil {
+		t.Fatalf("Unable to compute rc update lock path: %s", err)
+	}
+
+	expected := fmt.Sprintf("%s/%s/%s/update", kp.LOCK_TREE, rcTree, testRCId)
+	if rcUpdateLockPath != expected {
+		t.Errorf("Unexpected value for rcUpdateLockPath, wanted '%s' got '%s'",
+			expected,
+			rcUpdateLockPath,
+		)
+	}
+}
+
+func TestRCUpdateLockPathErrorNoID(t *testing.T) {
+	_, err := RCUpdateLockPath("")
+	if err == nil {
+		t.Errorf("Expected error computing rc update lock path with no id")
+	}
+}

--- a/pkg/kp/rollstore/store_test.go
+++ b/pkg/kp/rollstore/store_test.go
@@ -1,0 +1,54 @@
+package rollstore
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/square/p2/pkg/kp"
+)
+
+const testRCId = "abcd-1234"
+
+func TestRollPath(t *testing.T) {
+	rollPath, err := RollPath(testRCId)
+	if err != nil {
+		t.Fatalf("Unable to compute roll path: %s", err)
+	}
+
+	expected := fmt.Sprintf("%s/%s", rollTree, testRCId)
+	if rollPath != expected {
+		t.Errorf("Unexpected value for rollPath, wanted '%s' got '%s'",
+			expected,
+			rollPath,
+		)
+	}
+}
+
+func TestRollPathErrorNoID(t *testing.T) {
+	_, err := RollPath("")
+	if err == nil {
+		t.Errorf("Expected error computing roll path with no id")
+	}
+}
+
+func TestRollLockPath(t *testing.T) {
+	rollLockPath, err := RollLockPath(testRCId)
+	if err != nil {
+		t.Fatalf("Unable to compute roll lock path: %s", err)
+	}
+
+	expected := fmt.Sprintf("%s/%s/%s", kp.LOCK_TREE, rollTree, testRCId)
+	if rollLockPath != expected {
+		t.Errorf("Unexpected value for rollLockPath, wanted '%s' got '%s'",
+			expected,
+			rollLockPath,
+		)
+	}
+}
+
+func TestRollLockPathErrorNoID(t *testing.T) {
+	_, err := RollLockPath("")
+	if err == nil {
+		t.Errorf("Expected error computing roll lock path with no id")
+	}
+}

--- a/pkg/preparer/orchestrate_test.go
+++ b/pkg/preparer/orchestrate_test.go
@@ -160,7 +160,7 @@ type FakeStore struct {
 	currentManifestError error
 }
 
-func (f *FakeStore) ListPods(string) ([]kp.ManifestResult, time.Duration, error) {
+func (f *FakeStore) ListPods(kp.PodPrefix, string) ([]kp.ManifestResult, time.Duration, error) {
 	if f.currentManifest == nil {
 		return nil, 0, nil
 	}
@@ -172,19 +172,20 @@ func (f *FakeStore) ListPods(string) ([]kp.ManifestResult, time.Duration, error)
 	}, 0, nil
 }
 
-func (f *FakeStore) SetPod(string, pods.Manifest) (time.Duration, error) {
+func (f *FakeStore) SetPod(kp.PodPrefix, string, pods.Manifest) (time.Duration, error) {
 	return 0, nil
 }
 
-func (f *FakeStore) Pod(key string) (pods.Manifest, time.Duration, error) {
+func (f *FakeStore) Pod(kp.PodPrefix, string, types.PodID) (pods.Manifest, time.Duration, error) {
 	return nil, 0, fmt.Errorf("not implemented")
 }
 
-func (f *FakeStore) DeletePod(string) (time.Duration, error) {
+func (f *FakeStore) DeletePod(kp.PodPrefix, string, types.PodID) (time.Duration, error) {
 	return 0, nil
 }
 
-func (f *FakeStore) WatchPods(string, <-chan struct{}, chan<- error, chan<- []kp.ManifestResult) {}
+func (f *FakeStore) WatchPods(kp.PodPrefix, string, <-chan struct{}, chan<- error, chan<- []kp.ManifestResult) {
+}
 
 func testPreparer(t *testing.T, f *FakeStore) (*Preparer, *fakeHooks, string) {
 	podRoot, _ := ioutil.TempDir("", "pod_root")

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -327,6 +327,7 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 	listener := HookListener{
 		Intent:         store,
 		HookPrefix:     kp.HOOK_TREE,
+		Node:           preparerConfig.NodeName,
 		DestinationDir: path.Join(pods.DEFAULT_PATH, "hooks"),
 		ExecDir:        preparerConfig.HooksDirectory,
 		Logger:         logger,

--- a/pkg/rc/replication_controller_test.go
+++ b/pkg/rc/replication_controller_test.go
@@ -2,13 +2,16 @@ package rc
 
 import (
 	"fmt"
+	"path"
 	"testing"
 	"time"
 
+	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/kp/rcstore"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/types"
 
 	. "github.com/square/p2/Godeps/_workspace/src/github.com/anthonybishopric/gotcha"
 	klabels "github.com/square/p2/Godeps/_workspace/src/k8s.io/kubernetes/pkg/labels"
@@ -18,12 +21,14 @@ type fakeKpStore struct {
 	manifests map[string]pods.Manifest
 }
 
-func (s *fakeKpStore) SetPod(key string, manifest pods.Manifest) (time.Duration, error) {
+func (s *fakeKpStore) SetPod(podPrefix kp.PodPrefix, nodeName string, manifest pods.Manifest) (time.Duration, error) {
+	key := path.Join(string(podPrefix), nodeName, string(manifest.ID()))
 	s.manifests[key] = manifest
 	return 0, nil
 }
 
-func (s *fakeKpStore) DeletePod(key string) (time.Duration, error) {
+func (s *fakeKpStore) DeletePod(podPrefix kp.PodPrefix, nodeName string, podID types.PodID) (time.Duration, error) {
+	key := path.Join(string(podPrefix), nodeName, string(podID))
 	delete(s.manifests, key)
 	return 0, nil
 }

--- a/pkg/replication/replication_test.go
+++ b/pkg/replication/replication_test.go
@@ -264,9 +264,12 @@ func TestStopsIfLockDestroyed(t *testing.T) {
 	}
 
 	for _, host := range testNodes {
-		lockPath := kp.LockPath(kp.IntentPath(host, string(manifest.ID())))
-		err := replication.lock(lock, lockPath, false)
+		lockPath, err := kp.PodLockPath(kp.INTENT_TREE, host, manifest.ID())
+		if err != nil {
+			t.Fatalf("Unable to compute lock path for pod: %s", err)
+		}
 
+		err = replication.lock(lock, lockPath, false)
 		if err != nil {
 			t.Fatalf("Unable to perform initial replication lock: %s", err)
 		}
@@ -344,7 +347,11 @@ func TestStopsIfLockDestroyed(t *testing.T) {
 	}
 
 	// Destroy lock holder so the next renewal will fail
-	lockPath := kp.LockPath(kp.IntentPath(testNodes[0], string(manifest.ID())))
+	lockPath, err := kp.PodLockPath(kp.INTENT_TREE, testNodes[0], manifest.ID())
+	if err != nil {
+		t.Fatalf("Unable to compute pod lock path")
+	}
+
 	_, id, err := store.LockHolder(lockPath)
 	if err != nil {
 		t.Fatalf("Unable to determine lock holder in order to destroy the lock: %s", err)

--- a/pkg/replication/replicator.go
+++ b/pkg/replication/replicator.go
@@ -86,7 +86,7 @@ func (r replicator) InitializeReplication(overrideLock bool) (Replication, chan 
 // Checks that the preparer is running on every host being deployed to.
 func (r replicator) checkPreparers() error {
 	for _, host := range r.nodes {
-		_, _, err := r.store.Pod(kp.RealityPath(host, string(preparer.POD_ID)))
+		_, _, err := r.store.Pod(kp.REALITY_TREE, host, preparer.POD_ID)
 		if err != nil {
 			return util.Errorf("Could not verify %v state on %q: %v", preparer.POD_ID, host, err)
 		}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -4,3 +4,4 @@
 package types
 
 type PodID string
+type RCID string

--- a/pkg/watch/health.go
+++ b/pkg/watch/health.go
@@ -81,7 +81,13 @@ func MonitorPodHealth(config *preparer.PreparerConfig, logger *logging.Logger, s
 	watchQuitCh := make(chan struct{})
 	watchErrCh := make(chan error)
 	watchPodCh := make(chan []kp.ManifestResult)
-	go store.WatchPods(kp.RealityPath(node), watchQuitCh, watchErrCh, watchPodCh)
+	go store.WatchPods(
+		kp.REALITY_TREE,
+		node,
+		watchQuitCh,
+		watchErrCh,
+		watchPodCh,
+	)
 
 	for {
 		select {


### PR DESCRIPTION
Previously the kp package provided functions (e.g.
kp.IntentPath(string...)) that would simply join the passed strings
with a "/" in between and return a consul path that would be used. This
means all callers need to know the structure of consul keys and do
sanity checking against bad things happening.

These functions are replaced with functions that are named more
explicitly to indicate what the caller wants.