### PR TITLE
Check for 0 byte manifest in pkg/rc/fields.UnmarshalJSON

### DIFF
--- a/pkg/kp/rcstore/consul_store.go
+++ b/pkg/kp/rcstore/consul_store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/rc/fields"
+	"github.com/square/p2/pkg/util"
 )
 
 const (
@@ -340,5 +341,9 @@ func (s *consulStore) forEachLabel(rc fields.RC, f func(id, k, v string) error) 
 	id := rc.ID.String()
 	// As of this writing the only label we want is the pod ID.
 	// There may be more in the future.
+
+	if rc.Manifest == nil {
+		return util.Errorf("RC manifest is nil, cannot compute its ID")
+	}
 	return f(id, PodIDLabel, string(rc.Manifest.ID()))
 }

--- a/pkg/rc/fields/fields.go
+++ b/pkg/rc/fields/fields.go
@@ -89,13 +89,17 @@ var _ json.Marshaler = RC{}
 // representation of an RC.
 func (rc *RC) UnmarshalJSON(b []byte) error {
 	var rawRC RawRC
-	if err := json.Unmarshal(b, &rawRC); err != nil {
+	err := json.Unmarshal(b, &rawRC)
+	if err != nil {
 		return err
 	}
 
-	m, err := pods.ManifestFromBytes([]byte(rawRC.Manifest))
-	if err != nil {
-		return err
+	var m pods.Manifest
+	if len(rawRC.Manifest) != 0 {
+		m, err = pods.ManifestFromBytes([]byte(rawRC.Manifest))
+		if err != nil {
+			return err
+		}
 	}
 
 	nodeSel, err := labels.Parse(rawRC.NodeSelector)

--- a/pkg/rc/fields/fields_test.go
+++ b/pkg/rc/fields/fields_test.go
@@ -29,3 +29,12 @@ func TestJSONMarshal(t *testing.T) {
 	Assert(t).AreEqual(rc1.ID, rc2.ID, "RC ID changed when serialized")
 	Assert(t).AreEqual(rc1.Manifest.ID(), rc2.Manifest.ID(), "Manifest ID changed when serialized")
 }
+
+func TestJSONUnmarshalEmpty(t *testing.T) {
+	rc := fields.RC{}
+	b, err := json.Marshal(&rc)
+	Assert(t).IsNil(err, "should have marshaled")
+
+	err = json.Unmarshal(b, &rc)
+	Assert(t).IsNil(err, "Unexpected error unmarshaling an empty RC")
+}


### PR DESCRIPTION
This allows unmarshaling of structs that contain an empty fields.RC.
Previously an error would be hit due to manifest validation in
pods.Manifest.ManifestFromBytes()