### PR TITLE
Restart a log agent whenever we restart a service

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -201,6 +201,11 @@ func (hl *Launchable) start(serviceBuilder *runit.ServiceBuilder, sv runit.SV) e
 		if err != nil && err != runit.SuperviseOkMissing && err != runit.Killed {
 			return err
 		}
+
+		if _, err = sv.Restart(&executable.LogAgent, hl.RestartTimeout); err != nil {
+			return err
+		}
+
 	}
 
 	return nil
@@ -250,6 +255,10 @@ func (hl *Launchable) Executables(
 			Service: runit.Service{
 				Path: filepath.Join(serviceBuilder.RunitRoot, serviceName),
 				Name: serviceName,
+			},
+			LogAgent: runit.Service{
+				Path: filepath.Join(serviceBuilder.RunitRoot, serviceName, "log"),
+				Name: serviceName + " logAgent",
 			},
 			Exec: execCmd,
 		})

--- a/pkg/launch/launchable.go
+++ b/pkg/launch/launchable.go
@@ -74,6 +74,7 @@ type Launchable interface {
 // service running.
 type Executable struct {
 	Service       runit.Service
+	LogAgent      runit.Service
 	Exec          []string
 	RestartPolicy runit.RestartPolicy
 }

--- a/pkg/runit/test_helper.go
+++ b/pkg/runit/test_helper.go
@@ -19,38 +19,37 @@ func ErringSV() SV {
 }
 
 func NewRecordingSV() SV {
-	return &RecordingSV{}
+	return &RecordingSV{Commands: make([]string, 0)}
 }
 
 type RecordingSV struct {
-	LastCommand string
+	Commands []string
 }
 
-func (r *RecordingSV) setLastCommand(command string) (string, error) {
-	if r.LastCommand != "" {
-		return "", util.Errorf("This recording SV has already been issued a command, it must be cleared first")
-	}
-	r.LastCommand = command
+func (r *RecordingSV) LastCommand() string {
+	return r.Commands[len(r.Commands)-1]
+}
+
+func (r *RecordingSV) recordCommand(command string) (string, error) {
+	r.Commands = append(r.Commands, command)
 	return "success", nil
 }
 
 func (r *RecordingSV) Start(service *Service) (string, error) {
-	return r.setLastCommand("start")
+	return r.recordCommand("start")
 }
 func (r *RecordingSV) Stop(service *Service, timeout time.Duration) (string, error) {
-	return r.setLastCommand("stop")
+	return r.recordCommand("stop")
 }
 func (r *RecordingSV) Stat(service *Service) (*StatResult, error) {
-	_, err := r.setLastCommand("stat")
+	_, err := r.recordCommand("stat")
 	return nil, err
 }
-
 func (r *RecordingSV) Restart(service *Service, timeout time.Duration) (string, error) {
-	return r.setLastCommand("restart")
+	return r.recordCommand("restart")
 }
-
 func (r *RecordingSV) Once(service *Service) (string, error) {
-	return r.setLastCommand("once")
+	return r.recordCommand("once")
 }
 
 func FakeChpst() string {


### PR DESCRIPTION
The log process is not bound by the RestartPolicy because we need to be
restarted in case of a crash regardless of what the service does.