### PR TITLE
Reduce restart timeout period for log agent

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -202,7 +202,7 @@ func (hl *Launchable) start(serviceBuilder *runit.ServiceBuilder, sv runit.SV) e
 			return err
 		}
 
-		if _, err = sv.Restart(&executable.LogAgent, hl.RestartTimeout); err != nil {
+		if _, err = sv.Restart(&executable.LogAgent, runit.DefaultTimeout); err != nil {
 			return err
 		}
 

--- a/pkg/runit/runit_service.go
+++ b/pkg/runit/runit_service.go
@@ -58,6 +58,8 @@ var (
 	Killed                       = errors.New("The process was forcibly killed")
 )
 
+const DefaultTimeout = 7 * time.Second // This is runit's default wait period for commands that stop a process
+
 func (sv *sv) waitForSupervision(service *Service) error {
 	maxWait := time.After(10 * time.Second)
 	for {


### PR DESCRIPTION
7 seconds is runit's default wait period for stopping processes: http://smarden.org/runit/sv.8.html

We are less friendly to the log agent than the service it is paired with
primarily because we need the log agent to boot before the service does. Not
having a log agent on the reading end of STDOUT, STDERR may result in
indigestion for the service.