### PR TITLE
Launchables may specify environment variables

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -37,6 +37,7 @@ type Launchable struct {
 	CgroupConfigName string              // The string in PLATFORM_CONFIG to pass to p2-exec
 	RestartTimeout   time.Duration       // How long to wait when restarting the services in this launchable.
 	RestartPolicy    runit.RestartPolicy // Dictates whether the launchable should be automatically restarted upon exit.
+	SuppliedEnvVars  map[string]string   // A map of user-supplied environment variables to be exported for this launchable
 }
 
 // LaunchAdapter adapts a hoist.Launchable to the launch.Launchable interface.
@@ -384,4 +385,8 @@ func (hl *Launchable) AllInstallsDir() string {
 func (hl *Launchable) InstallDir() string {
 	launchableName := hl.Version()
 	return filepath.Join(hl.AllInstallsDir(), launchableName)
+}
+
+func (hl *Launchable) EnvVars() map[string]string {
+	return hl.SuppliedEnvVars
 }

--- a/pkg/launch/launchable.go
+++ b/pkg/launch/launchable.go
@@ -68,6 +68,9 @@ type Launchable interface {
 	// be necessary. The provided argument is guidance for how many bytes on disk a particular
 	// launchable should consume
 	Prune(size.ByteCount) error
+
+	// Env vars that will be exported to the launchable for its launch script and other hooks.
+	EnvVars() map[string]string
 }
 
 // Executable describes a command and its arguments that should be executed to start a

--- a/pkg/opencontainer/containers.go
+++ b/pkg/opencontainer/containers.go
@@ -37,15 +37,16 @@ var RuncPath = param.String("runc_path", "/usr/local/bin/runc")
 
 // Launchable represents an installation of a container.
 type Launchable struct {
-	Location       string              // A URL where we can download the artifact from.
-	ID_            string              // A (pod-wise) unique identifier for this launchable, used to distinguish it from other launchables in the pod
-	ServiceID_     string              // A (host-wise) unique identifier for this launchable, used when creating runit services
-	RunAs          string              // The user to assume when launching the executable
-	RootDir        string              // The root directory of the launchable, containing N:N>=1 installs.
-	P2Exec         string              // The path to p2-exec
-	RestartTimeout time.Duration       // How long to wait when restarting the services in this launchable.
-	RestartPolicy  runit.RestartPolicy // Dictates whether the container should be automatically restarted upon exit.
-	CgroupConfig   cgroups.Config      // Cgroup parameters to use with p2-exec
+	Location        string              // A URL where we can download the artifact from.
+	ID_             string              // A (pod-wise) unique identifier for this launchable, used to distinguish it from other launchables in the pod
+	ServiceID_      string              // A (host-wise) unique identifier for this launchable, used when creating runit services
+	RunAs           string              // The user to assume when launching the executable
+	RootDir         string              // The root directory of the launchable, containing N:N>=1 installs.
+	P2Exec          string              // The path to p2-exec
+	RestartTimeout  time.Duration       // How long to wait when restarting the services in this launchable.
+	RestartPolicy   runit.RestartPolicy // Dictates whether the container should be automatically restarted upon exit.
+	CgroupConfig    cgroups.Config      // Cgroup parameters to use with p2-exec
+	SuppliedEnvVars map[string]string   // User-supplied env variables
 
 	spec *LinuxSpec // The container's "config.json"
 }
@@ -76,6 +77,10 @@ func (l *Launchable) ID() string {
 
 func (l *Launchable) ServiceID() string {
 	return l.ServiceID_
+}
+
+func (l *Launchable) EnvVars() map[string]string {
+	return l.SuppliedEnvVars
 }
 
 // The version of the artifact is currently derived from the location, using
@@ -147,7 +152,7 @@ func (l *Launchable) Executables(serviceBuilder *runit.ServiceBuilder) ([]launch
 		},
 		Exec: append(
 			[]string{l.P2Exec},
-			p2exec.P2ExecArgs{
+			p2exec.P2ExecArgs{ // TODO: support environment variables
 				NoLimits: true,
 				WorkDir:  l.InstallDir(),
 				Command:  []string{*RuncPath, "start"},

--- a/pkg/pods/manifest.go
+++ b/pkg/pods/manifest.go
@@ -23,13 +23,14 @@ import (
 )
 
 type LaunchableStanza struct {
-	LaunchableType          string         `yaml:"launchable_type"`
-	LaunchableId            string         `yaml:"launchable_id"`
-	Location                string         `yaml:"location"`
-	DigestLocation          string         `yaml:"digest_location,omitempty"`
-	DigestSignatureLocation string         `yaml:"digest_signature_location,omitempty"`
-	RestartTimeout          string         `yaml:"restart_timeout,omitempty"`
-	CgroupConfig            cgroups.Config `yaml:"cgroup,omitempty"`
+	LaunchableType          string            `yaml:"launchable_type"`
+	LaunchableId            string            `yaml:"launchable_id"`
+	Location                string            `yaml:"location"`
+	DigestLocation          string            `yaml:"digest_location,omitempty"`
+	DigestSignatureLocation string            `yaml:"digest_signature_location,omitempty"`
+	RestartTimeout          string            `yaml:"restart_timeout,omitempty"`
+	CgroupConfig            cgroups.Config    `yaml:"cgroup,omitempty"`
+	Env                     map[string]string `yaml:"env,omitempty"`
 }
 
 type StatusStanza struct {

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -94,6 +94,8 @@ launchables:
     cgroup:
       cpus: 4
       memory: 4G
+    env:
+      ENABLED_BLAMS: 5
 config:
   ENVIRONMENT: staging
 `
@@ -113,6 +115,8 @@ config:
 		Assert(t).IsNil(err, "There shouldn't have been an error getting launchable")
 		launchables = append(launchables, launchable)
 	}
+	Assert(t).IsTrue(len(launchables) > 0, "Test setup error: no launchables from launchable stanzas")
+
 	err = pod.setupConfig(manifest, launchables)
 	Assert(t).IsNil(err, "There shouldn't have been an error setting up config")
 
@@ -152,6 +156,10 @@ config:
 		launchableRootEnv, err := ioutil.ReadFile(filepath.Join(launchable.EnvDir(), "LAUNCHABLE_ROOT"))
 		Assert(t).IsNil(err, "should not have erred reading the launchable root env file")
 		Assert(t).AreEqual(launchable.InstallDir(), string(launchableRootEnv), "The launchable root path did not match expected")
+
+		enableBlamSetting, err := ioutil.ReadFile(filepath.Join(launchable.EnvDir(), "ENABLED_BLAMS"))
+		Assert(t).IsNil(err, "should not have erred reading custom env var")
+		Assert(t).AreEqual("5", string(enableBlamSetting), "The user-supplied custom env var was wrong")
 	}
 }
 


### PR DESCRIPTION
This is a useful feature that is mostly, but not entirely,
solved by CONFIG_PATH. There are occasions where code
cannot conveniently use the exported YAML file for config,
despite being a more flexible configuration system. This
is especially true for legacy or 3rd party software that
is conventionally configured with environment variables.

A bug I discovered while implementing this: the current
implementation of the opencontainer launchable does not
support pod-supplied variables.