### PR TITLE
Adds RollDelay to rolling updates

### DIFF
--- a/pkg/roll/fields/update.go
+++ b/pkg/roll/fields/update.go
@@ -1,6 +1,8 @@
 package fields
 
 import (
+	"time"
+
 	"github.com/square/p2/pkg/rc/fields"
 )
 
@@ -40,4 +42,12 @@ type Update struct {
 	// a partial rollout using one update, and leave the old RC so that another
 	// update can be created to finish the rollout.
 	LeaveOld bool
+
+	// RollDelay adds a period of mandatory sleep between rolling updates to the
+	// next set of nodes. This can be useful for creating a buffer period between
+	// a pod instance becoming healthy and clients to that instance resuming
+	// normal operation. In some pathological cases, applications may become
+	// unhealthy after being healthy for a short duration. Naive implementations like
+	// p2-replicate do not handle such after-the-fact unhealthiness. Default is 0.
+	RollDelay time.Duration
 }

--- a/pkg/roll/run_update.go
+++ b/pkg/roll/run_update.go
@@ -157,7 +157,7 @@ ROLL_LOOP:
 				// become healthy - this ensures that, when the old RC is
 				// cleaned up, we do not accidentally remove the nodes we just
 				// assigned to the new RC
-				// normal execution of this algorithm will never cause
+				// normal execution of this rollAlgorithm will never cause
 				// newDesired > u.Desired, but if Run is resuming from an unusual
 				// situation, we don't want to get stuck
 				u.logger.WithFields(logrus.Fields{
@@ -167,13 +167,44 @@ ROLL_LOOP:
 				break ROLL_LOOP
 			}
 
-			next := algorithm(oldNodes.Healthy, newNodes.Healthy, u.DesiredReplicas, u.MinimumReplicas)
+			next := rollAlgorithm(oldNodes.Healthy, newNodes.Healthy, u.DesiredReplicas, u.MinimumReplicas)
 			if next > 0 {
+				// apply the delay only if we've already added to the new RC, since there's
+				// no value in sitting around doing nothing before anything has happened.
+				if newNodes.Desired > 0 && u.RollDelay > time.Duration(0) {
+					u.logger.WithField("delay", u.RollDelay).Infof("Waiting %v before continuing deploy", u.RollDelay)
+
+					select {
+					case <-time.After(u.RollDelay):
+					case <-quit:
+						return
+					}
+
+					// Check health again following the roll delay. If things have gotten
+					// worse since we last looked, or there is an error, we break this iteration.
+					checks, err = u.hcheck.Service(newFields.Manifest.ID().String())
+					afterDelayNew, err := u.countHealthy(u.NewRC, checks)
+
+					if err != nil {
+						u.logger.WithError(err).Errorln("Could not count nodes after delay, skipping this iteration")
+						break
+					}
+
+					if afterDelayNew.Healthy < newNodes.Healthy {
+						u.logger.WithFields(logrus.Fields{
+							"beforeDelay": newNodes.Healthy,
+							"afterDelay":  afterDelayNew.Healthy,
+							"delay":       u.RollDelay,
+						}).Errorf("Healthy node count on the new RC dropped after %v roll delay, skipping this iteration", u.RollDelay)
+						break
+					}
+				}
+
 				u.logger.WithFields(logrus.Fields{
 					"old":  oldNodes,
 					"new":  newNodes,
 					"next": next,
-				}).Infoln("Undergoing next update")
+				}).Infof("Adding %v new nodes", next)
 				err = u.rcs.AddDesiredReplicas(u.OldRC, -next)
 				if err != nil {
 					u.logger.WithError(err).Errorln("Could not decrement old replica count")
@@ -335,49 +366,49 @@ func (u update) countHealthy(id rcf.ID, checks map[string]health.Result) (rcNode
 }
 
 // the roll algorithm defines how to mutate RCs over time. it takes four args:
-// - old: the number of nodes on the old RC
-// - new: the number of nodes on the new RC
-// - want: the number of nodes desired on the new RC (ie the target)
-// - need: the number of nodes that must always be up (ie the minimum)
+// - old: the number of healthy nodes on the old RC
+// - new: the number of healthy nodes on the new RC
+// - desired: the number of nodes desired on the new RC (ie the target)
+// - minHealthy: the number of nodes that must always be up (ie the minimum)
 // given these four arguments, rollAlgorithm returns the number of nodes to add
 // to the new RC and to delete from the old
 //
 // returns zero under the following circumstances:
-// - new >= want (the update is done)
-// - old+new <= need (at or below the minimum, update has to block)
-func algorithm(old, new, want, need int) int {
+// - new >= desired (the update is done)
+// - old+new <= minHealthy (at or below the minimum, update has to block)
+func rollAlgorithm(old, new, desired, minHealthy int) int {
 	// how much "headroom" do we have between the number of nodes that are
 	// currently healthy, and the number that must be healthy?
 	// if we schedule more than this, we'll go below the minimum
-	difference := old + new - need
+	headroom := old + new - minHealthy
 
 	// how many nodes do we have left to go? we can't schedule more than this
 	// or we'll go over the target
-	// note that remaining < difference is possible depending on how many
+	// note that remaining < headroom is possible depending on how many
 	// old nodes are still alive
-	remaining := want - new
+	remaining := desired - new
 
 	// heuristic time:
 	if remaining <= 0 {
 		// no nodes remaining, noop out
 		return 0
 	}
-	if new >= need {
+	if new >= minHealthy {
 		// minimum is satisfied by new nodes, doesn't matter how many old ones
-		// we kill. this includes the edge case where need==0
+		// we kill. this includes the edge case where minHealthy==0
 		return remaining
 	}
-	if difference <= 0 {
-		// the case of need==0 was caught above. in this case, need>0 and
-		// difference is non-positive. this means that we are at, or below, the
+	if headroom <= 0 {
+		// the case of minHealthy==0 was caught above. in this case, minHealthy>0 and
+		// headroom is non-positive. this means that we are at, or below, the
 		// minimum, and we cannot schedule new nodes because we might take
 		// down an old one (which would go below the minimum)
 		return 0
 	}
-	// remaining>0 and difference>0. each one imposes an upper bound on how
+	// remaining>0 and headroom>0. each one imposes an upper bound on how
 	// many we can schedule at once, so return the minimum of the two
-	if remaining < difference {
+	if remaining < headroom {
 		return remaining
 	}
-	return difference
+	return headroom
 }

--- a/pkg/roll/update_test.go
+++ b/pkg/roll/update_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 func TestWouldBlock(t *testing.T) {
-	// in the following cases, algorithm should return 0
-	Assert(t).AreEqual(algorithm(1, 1, 3, 4), 0, "should do nothing if below minimum")
-	Assert(t).AreEqual(algorithm(1, 1, 2, 4), 0, "should do nothing if at minimum")
-	Assert(t).AreEqual(algorithm(1, 4, 3, 4), 0, "should do nothing if done")
+	// in the following cases, rollAlgorithm should return 0
+	Assert(t).AreEqual(rollAlgorithm(1, 1, 3, 4), 0, "should do nothing if below minimum")
+	Assert(t).AreEqual(rollAlgorithm(1, 1, 2, 4), 0, "should do nothing if at minimum")
+	Assert(t).AreEqual(rollAlgorithm(1, 4, 3, 4), 0, "should do nothing if done")
 
-	Assert(t).AreEqual(algorithm(2, 2, 6, 3), 1, "should schedule difference if minimum must be maintained")
-	Assert(t).AreEqual(algorithm(1, 3, 6, 3), 3, "should schedule remaining if minimum is satisfied by new")
-	Assert(t).AreEqual(algorithm(3, 0, 6, 0), 6, "should schedule remaining if no minimum")
+	Assert(t).AreEqual(rollAlgorithm(2, 2, 6, 3), 1, "should schedule difference if minimum must be maintained")
+	Assert(t).AreEqual(rollAlgorithm(1, 3, 6, 3), 3, "should schedule remaining if minimum is satisfied by new")
+	Assert(t).AreEqual(rollAlgorithm(3, 0, 6, 0), 6, "should schedule remaining if no minimum")
 }
 
 func TestSimulateRollingUpgradeDisable(t *testing.T) {
@@ -27,7 +27,7 @@ func TestSimulateRollingUpgradeDisable(t *testing.T) {
 	}
 }
 
-// this fuzzer tests the rolling upgrade algorithm in an environment where new
+// this fuzzer tests the rolling upgrade rollAlgorithm in an environment where new
 // pods replace old pods (eg hoist artifacts). it creates an imaginary list of
 // nodes, some of which may have old pods on them, and attempts to run a rolling
 // upgrade across this list.
@@ -104,13 +104,13 @@ func SimulateRollingUpgradeDisable(t *testing.T, full, nonew bool) {
 		Assert(t).IsTrue(len(old)+len(new) >= minimum, fmt.Sprintf("went below %d minimum nodes (nodes %v)\n", minimum, nodes))
 		Assert(t).IsTrue(len(new) <= target, fmt.Sprintf("went above %d target nodes (nodes %v)\n", target, nodes))
 		if len(new) == target {
-			Assert(t).AreEqual(algorithm(len(old), len(new), target, minimum), 0, "update should be done")
+			Assert(t).AreEqual(rollAlgorithm(len(old), len(new), target, minimum), 0, "update should be done")
 			t.Logf("Simulation complete\n\n")
 			break
 		}
 
 		// calculate the next update
-		nextUpdate := algorithm(len(old), len(new), target, minimum)
+		nextUpdate := rollAlgorithm(len(old), len(new), target, minimum)
 		t.Logf("Scheduling %d new out of %v eligible\n", nextUpdate, eligible)
 		Assert(t).AreNotEqual(nextUpdate, 0, "got noop update, would never terminate")
 		// choose nodes from the eligible list, randomly, and put the new pod


### PR DESCRIPTION
RollDelay establishes a required period of inactivity prior to
altering any underlying RCs. See the documentation for more
information.