### PR TITLE
logging: Defer most operations to Logrus

### DIFF
--- a/pkg/logging/process_counter_test.go
+++ b/pkg/logging/process_counter_test.go
@@ -1,14 +1,46 @@
 package logging
 
 import (
+	"io/ioutil"
 	"testing"
 
+	"github.com/square/p2/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	. "github.com/square/p2/Godeps/_workspace/src/github.com/anthonybishopric/gotcha"
 )
 
+// RecordingLogger keeps a record of all the entries it's asked to write.
+type RecordingLogger struct {
+	Logger
+	Entries []*logrus.Entry
+}
+
+func NewRecordingLogger(fields logrus.Fields) *RecordingLogger {
+	l := NewLogger(fields)
+	l.SetLogOut(ioutil.Discard)
+	rl := &RecordingLogger{l, make([]*logrus.Entry, 0, 5)}
+	l.Logger.Formatter = rl
+	return rl
+}
+
+func (rl *RecordingLogger) Format(entry *logrus.Entry) ([]byte, error) {
+	rl.Entries = append(rl.Entries, entry)
+	return []byte{}, nil
+}
+
 func TestProcessCounterIncrementsEveryTime(t *testing.T) {
-	counter := processCounter.counter
-	Assert(t).AreEqual(counter, processCounter.Fields()["Counter"], "The counter was wrong")
-	Assert(t).AreEqual(counter+1, processCounter.Fields()["Counter"], "The counter was wrong")
-	Assert(t).AreEqual(counter+2, processCounter.Fields()["Counter"], "The counter was wrong")
+	logger := NewRecordingLogger(nil)
+	c := processCounter.counter
+	Assert(t).AreEqual(c+0, processCounter.counter, "unexpected counter value")
+
+	logger.Info("First message")
+	Assert(t).AreEqual(c+0, logger.Entries[0].Data["Counter"], "wrong counter value")
+	Assert(t).AreEqual(c+1, processCounter.counter, "unexpected counter value")
+
+	logger.Info("Second message")
+	Assert(t).AreEqual(c+1, logger.Entries[1].Data["Counter"], "wrong counter value")
+	Assert(t).AreEqual(c+2, processCounter.counter, "unexpected counter value")
+
+	logger.Info("Third message")
+	Assert(t).AreEqual(c+2, logger.Entries[2].Data["Counter"], "wrong counter value")
+	Assert(t).AreEqual(c+3, processCounter.counter, "unexpected counter value")
 }

--- a/pkg/preparer/setup_test.go
+++ b/pkg/preparer/setup_test.go
@@ -21,6 +21,6 @@ func TestLoadConfigWillMarshalYaml(t *testing.T) {
 	Assert(t).AreEqual("/etc/p2.keyring", preparerConfig.Auth["keyring"], "did not read the keyring path correctly")
 	Assert(t).AreEqual(1, len(preparerConfig.ExtraLogDestinations), "should have picked up 1 log destination")
 	destination := preparerConfig.ExtraLogDestinations[0]
-	Assert(t).AreEqual(logging.OUT_SOCKET, destination.Type, "should have been the socket type")
+	Assert(t).AreEqual(logging.OutSocket, destination.Type, "should have been the socket type")
 	Assert(t).AreEqual("/var/log/p2-socket.out", destination.Path, "should have parsed path correctly")
 }


### PR DESCRIPTION
This change refactors the logging package to be little more than a thin wrapper
around Logrus's native data structures. The wrapper allows P2 to add some extra
functionality to Logrus, like recording more information about errors and
attaching a sequential counter.

With this refactor, a couple bugs are also fixed:
* Use atomic increments in the ProcessCounter type to avoid data races
* Allow WithError() calls to work correctly when given as a second field, e.g.:
  `logger.WithField(...).WithError(e)`