### PR TITLE
Prevent replicator from overwriting managed pods

### DIFF
--- a/pkg/replication/common_setup_test.go
+++ b/pkg/replication/common_setup_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/square/p2/pkg/health"
 	"github.com/square/p2/pkg/health/checker"
 	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
 
@@ -34,6 +35,7 @@ func testReplicatorAndServer(t *testing.T) (Replicator, kp.Store, consultest.Fix
 		testNodes,
 		active,
 		store,
+		labels.NewConsulApplicator(f.Client, 1),
 		healthChecker,
 		threshold,
 		testLockMessage,

--- a/pkg/replication/replication.go
+++ b/pkg/replication/replication.go
@@ -77,12 +77,14 @@ func (r replication) lockHosts(overrideLock bool, lockMessage string) error {
 	for _, host := range r.nodes {
 		lockPath, err := kp.PodLockPath(kp.INTENT_TREE, host, r.manifest.ID())
 		if err != nil {
+			lock.Destroy()
 			return err
 		}
 
 		err = r.lock(lock, lockPath, overrideLock)
 
 		if err != nil {
+			lock.Destroy()
 			return err
 		}
 	}

--- a/pkg/replication/replication_test.go
+++ b/pkg/replication/replication_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/square/p2/pkg/consultest"
 	"github.com/square/p2/pkg/health"
 	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/labels"
 )
 
 func TestEnact(t *testing.T) {
@@ -20,7 +21,7 @@ func TestEnact(t *testing.T) {
 	// Make the kv store look like preparer is installed on test nodes
 	setupPreparers(f)
 
-	replication, errCh, err := replicator.InitializeReplication(false)
+	replication, errCh, err := replicator.InitializeReplication(false, false)
 	if err != nil {
 		t.Fatalf("Unable to initialize replication: %s", err)
 	}
@@ -56,6 +57,7 @@ func TestWaitsForHealthy(t *testing.T) {
 		testNodes,
 		active,
 		store,
+		labels.NewFakeApplicator(),
 		healthChecker,
 		threshold,
 		testLockMessage,
@@ -67,7 +69,7 @@ func TestWaitsForHealthy(t *testing.T) {
 	// Make the kv store look like preparer is installed on test nodes
 	setupPreparers(f)
 
-	replication, errCh, err := replicator.InitializeReplication(false)
+	replication, errCh, err := replicator.InitializeReplication(false, false)
 	if err != nil {
 		t.Fatalf("Unable to initialize replication: %s", err)
 	}
@@ -150,6 +152,7 @@ func TestReplicationStopsIfCanceled(t *testing.T) {
 		testNodes,
 		active,
 		store,
+		labels.NewFakeApplicator(),
 		healthChecker,
 		threshold,
 		testLockMessage,
@@ -161,7 +164,7 @@ func TestReplicationStopsIfCanceled(t *testing.T) {
 	// Make the kv store look like preparer is installed on test nodes
 	setupPreparers(f)
 
-	replication, errCh, err := replicator.InitializeReplication(false)
+	replication, errCh, err := replicator.InitializeReplication(false, false)
 	if err != nil {
 		t.Fatalf("Unable to initialize replication: %s", err)
 	}


### PR DESCRIPTION
Now that replication controllers are actively managing their pods' intent
manifests, the only effective way to change a pod's manifest is by going
through its controller. Simply changing the intent store, like what a
replicator does, will succeed, but the controller will reset the node later.
That probably isn't what was intended.

This commit changes the replicator to check whether its targeted pods are
already managed. If so, the replication is aborted.