### PR TITLE
Query health through localhost

### DIFF
--- a/pkg/pods/manifest.go
+++ b/pkg/pods/manifest.go
@@ -34,9 +34,10 @@ type LaunchableStanza struct {
 }
 
 type StatusStanza struct {
-	HTTP bool   `yaml:"http,omitempty"`
-	Path string `yaml:"path,omitempty"`
-	Port int    `yaml:"port,omitempty"`
+	HTTP          bool   `yaml:"http,omitempty"`
+	Path          string `yaml:"path,omitempty"`
+	Port          int    `yaml:"port,omitempty"`
+	LocalhostOnly bool   `yaml:"localhost_only,omitempty"`
 }
 
 type ManifestBuilder interface {
@@ -80,6 +81,7 @@ type Manifest interface {
 	GetStatusHTTP() bool
 	GetStatusPath() string
 	GetStatusPort() int
+	GetStatusLocalhostOnly() bool
 	Marshal() ([]byte, error)
 	SignatureData() (plaintext, signature []byte)
 	GetRestartPolicy() runit.RestartPolicy
@@ -211,6 +213,14 @@ func (manifest *manifest) GetStatusPort() int {
 func (manifest *manifest) SetStatusPort(port int) {
 	manifest.StatusPort = 0
 	manifest.Status.Port = port
+}
+
+func (manifest *manifest) GetStatusLocalhostOnly() bool {
+	return manifest.Status.LocalhostOnly
+}
+
+func (manifest *manifest) SetStatusLocalhostOnly(localhostOnly bool) {
+	manifest.Status.LocalhostOnly = localhostOnly
 }
 
 func (manifest *manifest) RunAsUser() string {

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -222,6 +222,22 @@ func (c *PreparerConfig) GetClient(cxnTimeout time.Duration) (*http.Client, erro
 	}}, nil
 }
 
+func (c *PreparerConfig) GetInsecureClient(cxnTimeout time.Duration) (*http.Client, error) {
+	tlsConfig, err := getTLSConfig(c.CertFile, c.KeyFile, c.CAFile)
+	if err != nil {
+		return nil, err
+	}
+	tlsConfig.InsecureSkipVerify = true
+	return &http.Client{Transport: &http.Transport{
+		TLSClientConfig: tlsConfig,
+		// same dialer as http.DefaultTransport
+		Dial: (&net.Dialer{
+			Timeout:   cxnTimeout,
+			KeepAlive: cxnTimeout,
+		}).Dial,
+	}}, nil
+}
+
 func addHooks(preparerConfig *PreparerConfig, logger logging.Logger) {
 	for _, dest := range preparerConfig.ExtraLogDestinations {
 		logger.WithFields(logrus.Fields{

--- a/pkg/watch/health_test.go
+++ b/pkg/watch/health_test.go
@@ -56,7 +56,7 @@ func TestUpdatePods(t *testing.T) {
 	// ids for pods: 1, 2, test
 	// 0, 3 should have values in their shutdownCh
 	logger := logging.NewLogger(logrus.Fields{})
-	pods := updatePods(&MockHealthManager{}, nil, current, reality, "", &logger)
+	pods := updatePods(&MockHealthManager{}, nil, nil, current, reality, "", &logger)
 	Assert(t).AreEqual(true, <-current[0].shutdownCh, "this PodWatch should have been shutdown")
 	Assert(t).AreEqual(true, <-current[3].shutdownCh, "this PodWatch should have been shutdown")
 
@@ -70,7 +70,7 @@ func TestUpdateStatus(t *testing.T) {
 	healthManager := &MockHealthManager{}
 
 	reality := []kp.ManifestResult{newManifestResult("foo"), newManifestResult("bar")}
-	pods1 := updatePods(healthManager, nil, []PodWatch{}, reality, "", &logger)
+	pods1 := updatePods(healthManager, nil, nil, []PodWatch{}, reality, "", &logger)
 	Assert(t).AreEqual(2, len(pods1), "new pods were not added")
 	Assert(t).AreEqual(2, healthManager.UpdaterCreated, "new pods did not create an updaters")
 
@@ -79,7 +79,7 @@ func TestUpdateStatus(t *testing.T) {
 	builder := reality[0].Manifest.GetBuilder()
 	builder.SetStatusPort(2)
 	reality[0].Manifest = builder.GetManifest()
-	pods2 := updatePods(healthManager, nil, pods1, reality, "", &logger)
+	pods2 := updatePods(healthManager, nil, nil, pods1, reality, "", &logger)
 	Assert(t).AreEqual(2, len(pods2), "updatePods() changed the number of pods")
 	Assert(t).AreEqual(1, healthManager.UpdaterCreated, "one pod should have been refreshed")
 }
@@ -89,7 +89,7 @@ func TestUpdatePath(t *testing.T) {
 	healthManager := &MockHealthManager{}
 
 	reality := []kp.ManifestResult{newManifestResult("foo"), newManifestResult("bar")}
-	pods1 := updatePods(healthManager, nil, []PodWatch{}, reality, "bobnode", &logger)
+	pods1 := updatePods(healthManager, nil, nil, []PodWatch{}, reality, "bobnode", &logger)
 	Assert(t).AreEqual(2, len(pods1), "new pods were not added")
 	Assert(t).AreEqual(2, healthManager.UpdaterCreated, "new pods did not create an updaters")
 
@@ -98,7 +98,7 @@ func TestUpdatePath(t *testing.T) {
 	builder := reality[0].Manifest.GetBuilder()
 	builder.SetStatusPath("/_foobar")
 	reality[0].Manifest = builder.GetManifest()
-	pods2 := updatePods(healthManager, nil, pods1, reality, "bobnode", &logger)
+	pods2 := updatePods(healthManager, nil, nil, pods1, reality, "bobnode", &logger)
 	Assert(t).AreEqual(2, len(pods2), "updatePods() changed the number of pods")
 	Assert(t).AreEqual(1, healthManager.UpdaterCreated, "one pod should have been refreshed")
 	Assert(t).AreEqual("https://bobnode:1/_status", pods2[0].statusChecker.URI, "pod should be checking correct path")


### PR DESCRIPTION
Since p2-preparer runs on the same node, it can talk to the app on
localhost in order to check its health. This way apps can serve the
status port on the loopback interface only. In many cases, it's not
necessary to expose it to the outside world. Closes #392.