### PR TITLE
make kp.Lock into an interface so that tests may mock it

### DIFF
--- a/pkg/rc/farm.go
+++ b/pkg/rc/farm.go
@@ -26,7 +26,7 @@ type Farm struct {
 	sessions <-chan string
 
 	children map[fields.ID]childRC
-	lock     *kp.Lock
+	lock     kp.Lock
 
 	logger logging.Logger
 }
@@ -88,7 +88,7 @@ START_LOOP:
 				// expiration message, so len(children)==0
 				rcf.logger.WithField("session", session).Infoln("Acquired new session")
 				lock := rcf.kpStore.NewUnmanagedLock(session, "")
-				rcf.lock = &lock
+				rcf.lock = lock
 				// TODO: restart the watch so that you get updates right away?
 			}
 		case err := <-rcErr:

--- a/pkg/roll/farm.go
+++ b/pkg/roll/farm.go
@@ -48,7 +48,7 @@ type Farm struct {
 	sessions <-chan string
 
 	children map[fields.ID]childRU
-	lock     *kp.Lock
+	lock     kp.Lock
 
 	logger logging.Logger
 }
@@ -109,7 +109,7 @@ START_LOOP:
 				// expiration message, so len(children)==0
 				rlf.logger.WithField("session", session).Infoln("Acquired new session")
 				lock := rlf.kps.NewUnmanagedLock(session, "")
-				rlf.lock = &lock
+				rlf.lock = lock
 				// TODO: restart the watch so that you get updates right away?
 			}
 		case err := <-rlErr:
@@ -166,7 +166,7 @@ START_LOOP:
 				// at this point the ru is ours, time to spin it up
 				rlLogger.NoFields().Infoln("Acquired lock on new update, spawning")
 
-				newChild := rlf.factory.New(rlField, rlLogger, *rlf.lock)
+				newChild := rlf.factory.New(rlField, rlLogger, rlf.lock)
 				childQuit := make(chan struct{})
 				rlf.children[rlField.NewRC] = childRU{ru: newChild, quit: childQuit}
 				foundChildren[rlField.NewRC] = struct{}{}


### PR DESCRIPTION
code using pkg/kp as a library will have a much easier time testing
functionality that relies on locking if the implementation can be
mocked. Furthermore, the underlying (consul) api.Client that the kp.Lock
struct contains is also a struct type and cannot be mocked.