### PR TITLE
WIP: Unified storage package

### DIFF
--- a/pkg/store/consulstore/consulstore.go
+++ b/pkg/store/consulstore/consulstore.go
@@ -1,0 +1,68 @@
+package consulstore
+
+import (
+	"fmt"
+
+	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/api"
+
+	"github.com/square/p2/pkg/store"
+)
+
+// ConsulStore implements the main P2 Store interface to store all its data in a Consul
+// cluster.
+type ConsulStore struct {
+	Client *api.Client
+	// TODO: finish me
+}
+
+type podStore struct {
+	store  *ConsulStore
+	prefix string
+}
+
+func (s *ConsulStore) Reality() store.PodStore {
+	// return &podStore{cs, "reality"}
+	return nil
+}
+
+func (s *ConsulStore) Intent() store.PodStore {
+	// return &podStore{cs, "intent"}
+	return nil
+}
+
+func (s *ConsulStore) Health() store.HealthStore {
+	return nil
+
+}
+func (s *ConsulStore) ReplicationControllers() store.ReplicationControllerStore {
+	return nil
+}
+
+func (s *ConsulStore) RollingUpdates() store.RollingUpdateStore {
+	return nil
+}
+
+func (s *ConsulStore) NewLockManager(name string) (store.LockManager, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *ConsulStore) NewSessionLockManager(
+	name string,
+	session string,
+) (store.LockManager, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *ConsulStore) Ping() error {
+	return fmt.Errorf("not implemented")
+}
+
+type Options struct {
+	// TODO: finish me
+}
+
+func New(opt Options) (*ConsulStore, error) {
+	return new(ConsulStore), nil
+}
+
+var _ store.Store = (*ConsulStore)(nil)

--- a/pkg/store/health.go
+++ b/pkg/store/health.go
@@ -1,0 +1,103 @@
+package store
+
+import (
+	"time"
+)
+
+type HealthState string
+
+// String representations of the canonical health states
+var (
+	Critical = HealthState("critical")
+	Unknown  = HealthState("unknown")
+	Warning  = HealthState("warning")
+	Passing  = HealthState("passing")
+)
+
+// Integer enum representations of the canonical health states. These are not guaranteed
+// to be consistent across versions. Only externalize the strings! The enum value is used
+// to order HealthStates.
+const (
+	criticalInt = iota
+	unknownInt
+	warningInt
+	passingInt
+)
+
+// ToHealthState converts a string to its corresponding HealthState value. Unrecognized
+// values become Unknown.
+func ToHealthState(str string) HealthState {
+	switch s := HealthState(str); s {
+	case Critical, Unknown, Warning, Passing:
+		return s
+	default:
+		return Unknown
+	}
+}
+
+// Int converts a HealthState to an enum representation suitable for comparisons.
+func (s HealthState) Int() int {
+	switch s {
+	case Critical:
+		return criticalInt
+	case Unknown:
+		return unknownInt
+	case Warning:
+		return warningInt
+	case Passing:
+		return passingInt
+	default:
+		return criticalInt
+	}
+}
+
+// Returns whether the given string matches a particular health state
+func (s HealthState) Is(state string) bool {
+	return ToHealthState(state) == s
+}
+
+// Compare two HealthStates. Return 0 if equal, a value less than 0 if a < b and a value
+// greater than 0 if a > b. The ordering is Passing > Warning > Unknown > Critical.
+func Compare(a, b HealthState) int {
+	return a.Int() - b.Int()
+}
+
+// HealthCheck defines the data structure used to record health checks. The non-standard
+// JSON names are for legacy compatibility.
+type HealthCheck struct {
+	Node    string      `json:"Node"`
+	Pod     PodID       `json:"Id"`
+	Service PodID       `json:"Service"` // DEPRECATED: should always = Id
+	Status  HealthState `json:"Status"`
+	Output  string      `json:"Output"`
+	Time    time.Time   `json:"Time"`
+	Expires time.Time   `json:"Expires,omitempty"`
+}
+
+// SortOrder sorts the nodes in the list from least to most health.
+type SortOrder struct {
+	Nodes  []string
+	Health map[string]*HealthCheck
+}
+
+func (s SortOrder) Len() int {
+	return len(s.Nodes)
+}
+
+func (s SortOrder) Swap(i, j int) {
+	s.Nodes[i], s.Nodes[j] = s.Nodes[j], s.Nodes[i]
+}
+
+func (s SortOrder) Less(i, j int) bool {
+	iHealth := Unknown
+	if res, ok := s.Health[s.Nodes[i]]; ok {
+		iHealth = res.Status
+	}
+
+	jHealth := Unknown
+	if res, ok := s.Health[s.Nodes[j]]; ok {
+		jHealth = res.Status
+	}
+
+	return Compare(iHealth, jHealth) < 0
+}

--- a/pkg/store/manifest.go
+++ b/pkg/store/manifest.go
@@ -1,0 +1,421 @@
+// Package pods borrows heavily from the Kubernetes definition of pods to provide
+// p2 with a convenient way to colocate several related launchable artifacts, as well
+// as basic shared runtime configuration. Pod manifests are written as YAML files
+// that describe what to launch.
+package store
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/square/p2/Godeps/_workspace/src/golang.org/x/crypto/openpgp/clearsign"
+	"github.com/square/p2/Godeps/_workspace/src/gopkg.in/yaml.v2"
+	"github.com/square/p2/pkg/cgroups"
+	"github.com/square/p2/pkg/runit"
+	"github.com/square/p2/pkg/uri"
+	"github.com/square/p2/pkg/util"
+)
+
+type PodID string
+
+type Launchable struct {
+	Type                    string            `yaml:"launchable_type"`
+	ID                      string            `yaml:"launchable_id"`
+	Location                string            `yaml:"location"`
+	DigestLocation          string            `yaml:"digest_location,omitempty"`
+	DigestSignatureLocation string            `yaml:"digest_signature_location,omitempty"`
+	RestartTimeout          string            `yaml:"restart_timeout,omitempty"`
+	Cgroup                  cgroups.Config    `yaml:"cgroup,omitempty"`
+	Env                     map[string]string `yaml:"env,omitempty"`
+}
+
+type Status struct {
+	HTTP bool   `yaml:"http,omitempty"`
+	Path string `yaml:"path,omitempty"`
+	Port int    `yaml:"port,omitempty"`
+}
+
+type ManifestBuilder interface {
+	GetManifest() Manifest
+	SetID(PodID)
+	SetConfig(config map[interface{}]interface{}) error
+	SetRunAsUser(user string)
+	SetStatusHTTP(statusHTTP bool)
+	SetStatusPath(statusPath string)
+	SetStatusPort(port int)
+	SetLaunchables(launchables map[string]Launchable)
+}
+
+var _ ManifestBuilder = manifestBuilder{}
+
+func NewManifestBuilder() ManifestBuilder {
+	return manifestBuilder{&manifest{}}
+}
+
+func (m manifestBuilder) GetManifest() Manifest {
+	return m.manifest
+}
+
+type manifestBuilder struct {
+	*manifest
+}
+
+// Read-only immutable interface for manifests. To programatically build a
+// manifest, use ManifestBuilder
+type Manifest interface {
+	ID() PodID
+	RunAsUser() string
+	Write(out io.Writer) error
+	ConfigFileName() (string, error)
+	WriteConfig(out io.Writer) error
+	PlatformConfigFileName() (string, error)
+	WritePlatformConfig(out io.Writer) error
+	GetLaunchables() map[string]Launchable
+	GetConfig() map[interface{}]interface{}
+	SHA() (string, error)
+	GetStatusHTTP() bool
+	GetStatusPath() string
+	GetStatusPort() int
+	Marshal() ([]byte, error)
+	SignatureData() (plaintext, signature []byte)
+	GetRestartPolicy() runit.RestartPolicy
+
+	GetBuilder() ManifestBuilder
+}
+
+// assert manifest implements Manifest
+var _ Manifest = &manifest{}
+
+type manifest struct {
+	Id            PodID                       `yaml:"id"` // public for yaml marshaling access. Use ID() instead.
+	RunAs         string                      `yaml:"run_as,omitempty"`
+	Launchables   map[string]Launchable       `yaml:"launchables"`
+	Config        map[interface{}]interface{} `yaml:"config"`
+	StatusPort    int                         `yaml:"status_port,omitempty"` // DEPRECATED
+	StatusHTTP    bool                        `yaml:"status_http,omitempty"` // DEPRECATED
+	Status        Status                      `yaml:"status,omitempty"`
+	RestartPolicy runit.RestartPolicy         `yaml:"restart_policy,omitempty"`
+
+	// Used to track the original bytes so that we don't reorder them when
+	// doing a yaml.Unmarshal and a yaml.Marshal in succession
+	raw []byte
+
+	// Signature related fields, may be empty if manifest is not signed
+	plaintext []byte
+	signature []byte
+}
+
+func (m *manifest) GetBuilder() ManifestBuilder {
+	builder := manifestBuilder{
+		&manifest{},
+	}
+	*builder.manifest = *m
+	builder.manifest.plaintext = nil
+	builder.manifest.signature = nil
+	builder.manifest.raw = nil
+	return builder
+}
+
+func (manifest *manifest) ID() PodID {
+	return manifest.Id
+}
+
+func (m manifestBuilder) SetID(id PodID) {
+	m.manifest.Id = id
+}
+
+func (manifest *manifest) GetLaunchables() map[string]Launchable {
+	return manifest.Launchables
+}
+
+func (manifest *manifest) SetLaunchables(launchables map[string]Launchable) {
+	manifest.Launchables = launchables
+}
+
+func (manifest *manifest) GetConfig() map[interface{}]interface{} {
+	configCopy := make(map[interface{}]interface{})
+
+	// We want to make a deep copy of the config and return that. We will
+	// take advantage of YAML marshaling to do this by first serializing
+	// the config data, and then unmarshaling it into a new map
+	bytes, err := yaml.Marshal(manifest.Config)
+	if err != nil {
+		// We panic here because our code maintains an invariant that
+		// manifest.Config can be serialized to yaml successfully. See
+		// the test in SetConfig()
+		panic(err)
+	}
+
+	err = yaml.Unmarshal(bytes, &configCopy)
+	if err != nil {
+		// We panic here because our code maintains an invariant that
+		// manifest.Config can be unserialized from yaml successfully.
+		// See the test in SetConfig()
+		panic(err)
+	}
+
+	return configCopy
+}
+
+func (m manifestBuilder) SetConfig(config map[interface{}]interface{}) error {
+	// Confirm that the data passed in can be successfully serialized as YAML
+	bytes, err := yaml.Marshal(config)
+	if err != nil {
+		return err
+	}
+
+	configCopy := make(map[interface{}]interface{})
+	err = yaml.Unmarshal(bytes, &configCopy)
+	if err != nil {
+		return err
+	}
+
+	m.Config = configCopy
+	return nil
+}
+
+func (manifest *manifest) GetStatusHTTP() bool {
+	if manifest.StatusHTTP {
+		return true
+	}
+	return manifest.Status.HTTP
+}
+
+func (manifest *manifest) SetStatusHTTP(statusHTTP bool) {
+	manifest.StatusHTTP = false
+	manifest.Status.HTTP = statusHTTP
+}
+
+func (manifest *manifest) GetStatusPath() string {
+	if manifest.Status.Path != "" {
+		return path.Join("/", manifest.Status.Path)
+	}
+	return "/_status"
+}
+
+func (manifest *manifest) SetStatusPath(statusPath string) {
+	manifest.Status.Path = statusPath
+}
+
+func (manifest *manifest) GetStatusPort() int {
+	if manifest.StatusPort != 0 {
+		return manifest.StatusPort
+	}
+	return manifest.Status.Port
+}
+
+func (manifest *manifest) SetStatusPort(port int) {
+	manifest.StatusPort = 0
+	manifest.Status.Port = port
+}
+
+func (manifest *manifest) RunAsUser() string {
+	if manifest.RunAs != "" {
+		return manifest.RunAs
+	}
+	return string(manifest.ID())
+}
+
+func (mb manifestBuilder) SetRunAsUser(user string) {
+	mb.manifest.RunAs = user
+}
+
+// ManifestFromPath constructs a Manifest from a local file. This function is a helper for
+// ManifestFromBytes().
+func ManifestFromPath(path string) (Manifest, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return ManifestFromReader(f)
+}
+
+// ManifestFromURI constructs a Manifest from data located at a URI. This function is a
+// helper for ManifestFromBytes().
+func ManifestFromURI(manifestUri string) (Manifest, error) {
+	f, err := uri.DefaultFetcher.Open(manifestUri)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return ManifestFromReader(f)
+}
+
+// ManifestFromReader constructs a Manifest from an open Reader. All bytes will be read
+// from the Reader. The caller is responsible for closing the Reader, if necessary. This
+// function is a helper for ManifestFromBytes().
+func ManifestFromReader(reader io.Reader) (Manifest, error) {
+	bytes, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	return ManifestFromBytes(bytes)
+}
+
+// ManifestFromBytes constructs a Manifest by parsing its serialized representation. The
+// manifest can be a raw YAML document or a PGP clearsigned YAML document. If signed, the
+// signature components will be stored inside the Manifest instance.
+func ManifestFromBytes(bytes []byte) (Manifest, error) {
+	manifest := &manifest{}
+
+	// Preserve the raw manifest so that manifest.Bytes() returns bytes in
+	// the same order that they were passed to this function
+	manifest.raw = make([]byte, len(bytes))
+	copy(manifest.raw, bytes)
+
+	signed, _ := clearsign.Decode(bytes)
+	if signed != nil {
+		signature, err := ioutil.ReadAll(signed.ArmoredSignature.Body)
+		if err != nil {
+			return nil, util.Errorf("Could not read signature from pod manifest: %s", err)
+		}
+		manifest.signature = signature
+
+		// the original plaintext is in signed.Plaintext, but the signature
+		// corresponds to signed.Bytes, so that's what we need to save
+		manifest.plaintext = signed.Bytes
+
+		// parse YAML from the message's plaintext instead
+		bytes = signed.Plaintext
+	}
+
+	if err := yaml.Unmarshal(bytes, manifest); err != nil {
+		return nil, util.Errorf("Could not read pod manifest: %s", err)
+	}
+	if err := ValidManifest(manifest); err != nil {
+		return nil, util.Errorf("invalid manifest: %s", err)
+	}
+	return manifest, nil
+}
+
+func (manifest *manifest) Write(out io.Writer) error {
+	bytes, err := manifest.Marshal()
+	if err != nil {
+		return util.Errorf("Could not write manifest for %s: %s", manifest.ID(), err)
+	}
+	_, err = out.Write(bytes)
+	if err != nil {
+		return util.Errorf("Could not write manifest for %s: %s", manifest.ID(), err)
+	}
+	return nil
+}
+
+func (manifest *manifest) Marshal() ([]byte, error) {
+	// if it's signed, we must recycle the original content to preserve the
+	// signature's validity. remarshaling it might change the exact text of
+	// the YAML, which would invalidate the signature.
+	if manifest.raw != nil {
+		// if it's signed, we must recycle the original content to preserve the
+		// signature's validity. remarshaling it might change the exact text of
+		// the YAML, which would invalidate the signature.
+		ret := make([]byte, len(manifest.raw))
+		copy(ret, manifest.raw)
+		return ret, nil
+	}
+	return yaml.Marshal(manifest)
+}
+
+func (manifest *manifest) WriteConfig(out io.Writer) error {
+	bytes, err := yaml.Marshal(manifest.Config)
+	if err != nil {
+		return util.Errorf("Could not write config for %s: %s", manifest.ID(), err)
+	}
+	_, err = out.Write(bytes)
+	if err != nil {
+		return util.Errorf("Could not write config for %s: %s", manifest.ID(), err)
+	}
+	return nil
+}
+
+func (manifest *manifest) WritePlatformConfig(out io.Writer) error {
+	platConf := make(map[string]interface{})
+	for _, launchable := range manifest.Launchables {
+		platConf[launchable.ID] = map[string]interface{}{
+			"cgroup": launchable.Cgroup,
+		}
+	}
+
+	bytes, err := yaml.Marshal(platConf)
+	if err != nil {
+		return util.Errorf("Could not write config for %s: %s", manifest.ID(), err)
+	}
+	_, err = out.Write(bytes)
+	if err != nil {
+		return util.Errorf("Could not write config for %s: %s", manifest.ID(), err)
+	}
+	return nil
+}
+
+// SHA() returns a string containing a hex encoded SHA256 checksum of the
+// manifest's contents. The contents are normalized, such that all equivalent
+// YAML structures have the same SHA (despite differences in comments,
+// indentation, etc).
+func (manifest *manifest) SHA() (string, error) {
+	if manifest == nil {
+		return "", util.Errorf("the manifest is nil")
+	}
+	buf, err := yaml.Marshal(manifest) // always remarshal
+	if err != nil {
+		return "", err
+	}
+	hasher := sha256.New()
+	hasher.Write(buf)
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func (manifest *manifest) ConfigFileName() (string, error) {
+	sha, err := manifest.SHA()
+	if err != nil {
+		return "", err
+	}
+	return string(manifest.Id) + "_" + sha + ".yaml", nil
+}
+
+func (manifest *manifest) PlatformConfigFileName() (string, error) {
+	sha, err := manifest.SHA()
+	if err != nil {
+		return "", err
+	}
+	return string(manifest.Id) + "_" + sha + ".platform.yaml", nil
+}
+
+// Returns readers needed to verify the signature on the
+// manifest. These readers do not need closing.
+func (m manifest) SignatureData() (plaintext, signature []byte) {
+	if m.signature == nil {
+		return nil, nil
+	}
+	return m.plaintext, m.signature
+}
+
+func (m manifest) GetRestartPolicy() runit.RestartPolicy {
+	if m.RestartPolicy == "" {
+		return runit.DefaultRestartPolicy
+	}
+	return m.RestartPolicy
+}
+
+// ValidManifest checks the internal consistency of a manifest. Returns an error if the
+// data is inconsistent or "nil" otherwise.
+func ValidManifest(m Manifest) error {
+	if m.ID() == "" {
+		return fmt.Errorf("manifest must contain an 'id'")
+	}
+	for key, launchable := range m.GetLaunchables() {
+		switch {
+		case launchable.Type == "":
+			return fmt.Errorf("'%s': launchable must contain a 'launchable_type'", key)
+		case launchable.ID == "":
+			return fmt.Errorf("'%s': launchable must contain a 'launchable_id'", key)
+		case launchable.Location == "":
+			return fmt.Errorf("'%s': launchable must contain a 'location'", key)
+		}
+	}
+	return nil
+}

--- a/pkg/store/memorystore/memorystore.go
+++ b/pkg/store/memorystore/memorystore.go
@@ -1,0 +1,42 @@
+package memorystore
+
+import (
+	"fmt"
+
+	"github.com/square/p2/pkg/store"
+)
+
+// MemoryStore implements the main P2 Store interface that stores all data in local
+// memory. This is primarily targeted to unit tests to test higher-level components
+// without having to spin up a Consul instance required for ConsulStore.
+type MemoryStore struct {
+	// TODO: finish me
+}
+
+func (s *MemoryStore) Reality() store.PodStore                                  { return nil }
+func (s *MemoryStore) Intent() store.PodStore                                   { return nil }
+func (s *MemoryStore) Health() store.HealthStore                                { return nil }
+func (s *MemoryStore) ReplicationControllers() store.ReplicationControllerStore { return nil }
+func (s *MemoryStore) RollingUpdates() store.RollingUpdateStore                 { return nil }
+
+func (s *MemoryStore) NewLockManager(name string) (store.LockManager, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *MemoryStore) NewSessionLockManager(
+	name string,
+	session string,
+) (store.LockManager, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *MemoryStore) Ping() error {
+	return fmt.Errorf("not implemented")
+}
+
+// New creates a new MemoryStore.
+func New() (*MemoryStore, error) {
+	return new(MemoryStore), nil
+}
+
+var _ store.Store = (*MemoryStore)(nil)

--- a/pkg/store/rc.go
+++ b/pkg/store/rc.go
@@ -1,0 +1,104 @@
+package store
+
+import (
+	"encoding/json"
+
+	"github.com/square/p2/Godeps/_workspace/src/k8s.io/kubernetes/pkg/labels"
+)
+
+type ReplicationControllerID string
+
+// RC holds the runtime state of a Replication Controller as saved in Consul.
+type ReplicationController struct {
+	// GUID for this controller
+	ID ReplicationControllerID
+
+	// The pod manifest that should be scheduled on nodes
+	Manifest Manifest
+
+	// Defines the set of nodes on which the manifest can be scheduled
+	NodeSelector labels.Selector
+
+	// A set of labels that will be added to every pod scheduled by this controller
+	PodLabels labels.Set
+
+	// The desired number of instances of the manifest that should be scheduled
+	ReplicasDesired int
+
+	// When disabled, this controller will not make any scheduling changes
+	Disabled bool
+}
+
+// RawRC defines the JSON format used to store data into Consul. It should only be used
+// while (de-)serializing the RC state. Prefer using the "ReplicationController" when
+// possible.
+type RawRC struct {
+	ID              ReplicationControllerID `json:"id"`
+	Manifest        string                  `json:"manifest"`
+	NodeSelector    string                  `json:"node_selector"`
+	PodLabels       labels.Set              `json:"pod_labels"`
+	ReplicasDesired int                     `json:"replicas_desired"`
+	Disabled        bool                    `json:"disabled"`
+}
+
+// MarshalJSON implements the json.Marshaler interface for serializing the RC to JSON
+// format.
+//
+// The RC struct contains interfaces (pods.Manifest, labels.Selector), and unmarshaling
+// into a nil, non-empty interface is impossible (unless the value is a JSON null),
+// because the unmarshaler doesn't know what structure to allocate there.  We own
+// Manifest, but we don't own labels.Selector, so we have to implement the JSON marshaling
+// here to wrap around the interface values.
+func (rc *ReplicationController) MarshalJSON() ([]byte, error) {
+	var manifest []byte
+	var err error
+	if rc.Manifest != nil {
+		manifest, err = rc.Manifest.Marshal()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var nodeSel string
+	if rc.NodeSelector != nil {
+		nodeSel = rc.NodeSelector.String()
+	}
+
+	return json.Marshal(RawRC{
+		ID:              rc.ID,
+		Manifest:        string(manifest),
+		NodeSelector:    nodeSel,
+		PodLabels:       rc.PodLabels,
+		ReplicasDesired: rc.ReplicasDesired,
+		Disabled:        rc.Disabled,
+	})
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for deserializing the JSON
+// representation of an RC.
+func (rc *ReplicationController) UnmarshalJSON(b []byte) error {
+	var rawRC RawRC
+	if err := json.Unmarshal(b, &rawRC); err != nil {
+		return err
+	}
+
+	m, err := ManifestFromBytes([]byte(rawRC.Manifest))
+	if err != nil {
+		return err
+	}
+
+	nodeSel, err := labels.Parse(rawRC.NodeSelector)
+	if err != nil {
+		return err
+	}
+
+	*rc = ReplicationController{
+		ID:              rawRC.ID,
+		Manifest:        m,
+		NodeSelector:    nodeSel,
+		PodLabels:       rawRC.PodLabels,
+		ReplicasDesired: rawRC.ReplicasDesired,
+		Disabled:        rawRC.Disabled,
+	}
+	return nil
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1,0 +1,199 @@
+package store
+
+import (
+	"github.com/square/p2/pkg/logging"
+)
+
+// ManifestLocation stores a manifest and the node it came from.
+type ManifestLocation struct {
+	Node     string
+	Manifest Manifest
+}
+
+// PodStore stores pod manifests attached to a node.
+type PodStore interface {
+	// Get retrieves one pod from a node.
+	Get(node string, pod PodID) (Manifest, error)
+
+	// Put saves one manifest to a node.
+	Put(node string, manifest Manifest) error
+
+	// Delete removes a pod from a node.
+	Delete(node string, pod PodID) error
+
+	// GetNode retrieves all pods from a node.
+	GetNode(node string) ([]Manifest, error)
+
+	// All retrieves all pods from all nodes.
+	All() ([]ManifestLocation, error)
+
+	// Watch watches one pod for changes. Whenever the pod is changed (added, modified, or
+	// deleted), the pod's new value will be sent to the given channel. This method runs
+	// until explicitly canceled by closing the done channel.
+	Watch(
+		done <-chan struct{},
+		logger logging.Logger,
+		podValues chan<- Manifest,
+		node string,
+		pod PodID,
+	)
+
+	// WatchNode watches a node for changes to any of its pods. Whenever anything changes,
+	// all of the node's manifests will be sent to the given channel. This method runs
+	// until explicitly canceled by closing the done channel.
+	WatchNode(
+		done <-chan struct{},
+		logger logging.Logger,
+		podValues chan<- []Manifest,
+		node string,
+	)
+
+	// Lock acquires a lock on the given pod.
+	Lock(manager LockManager, node string, pod PodID) (Unlocker, error)
+}
+
+// HealthUpdater allows a single pod's health to be updated.
+type HealthUpdater interface {
+	// PutHealth updates the health status of the pod. Checkers are free to call it after
+	// every health check or other status change.
+	Put(check *HealthCheck) error
+
+	// Close removes a pod's health check and releases all updater resources. Call this
+	// when no more health statuses will be published.
+	Close()
+}
+
+// HealthManager manages a collection of health checks that share configuration and
+// resources.
+type HealthManager interface {
+	// NewUpdater creates a new object for publishing a single pod's health. Each
+	// pod should have its own updater.
+	NewUpdater(pod PodID) HealthUpdater
+
+	// Close removes all published health statuses and releases all manager resources.
+	Close()
+}
+
+// HealthStore stores health checks.
+type HealthStore interface {
+	Get(node string, pod PodID) (*HealthCheck, error)
+	Put(check *HealthCheck) error
+	GetPod(pod PodID) (map[string]*HealthCheck, error)
+
+	NewManager(node string, logger logging.Logger) HealthManager
+}
+
+type ReplicationControllerStore interface {
+	Get(id ReplicationControllerID) (*ReplicationController, error)
+	Put(controller *ReplicationController) error
+	All() ([]*ReplicationController, error)
+
+	// AtomicModify allows an existing replication controller to be atomically modified.
+	// The caller should provide a function that accepts a controller and changes it to
+	// the desired state. The new controller state will be atomically written back to the
+	// store. The caller's function may be called multiple times if there is contention.
+	//
+	// NOTE: Should this be removed, since modifications should only happen while a lock
+	// is held? Do we really want to support unlocked atomic operations on an RC while
+	// something else holds its modify lock?
+	AtomicModify(id ReplicationControllerID, f func(*ReplicationController) error) error
+
+	// Watch a single replication controller for any changes. This method runs until
+	// explicitly canceled by closing the done channel. New values of the controller will
+	// be sent to the given channel.
+	Watch(
+		done <-chan struct{},
+		logger logging.Logger,
+		controllers chan<- *ReplicationController,
+		id ReplicationControllerID,
+	)
+
+	// WatchAll watches all replication controllers for any changes. This method runs
+	// until explicitly canceled by closing the done channel. When any controller changes,
+	// all controllers will be sent to the given channel. WARNING: leaky abstraction.
+	WatchAll(
+		done <-chan struct{},
+		logger logging.Logger,
+		controllers chan<- []*ReplicationController,
+	)
+
+	// LockOwner acquires the ownership lock on a replication controller. This is used for
+	// determining which instance of a farm is responsible for monitoring the controller
+	// for changes.
+	LockOwner(id ReplicationControllerID) (Unlocker, error)
+
+	// LockModify acquires the modify lock on a replication controller. This lock should
+	// be acquired whenever a process needs to change the controller.
+	LockModify(id ReplicationControllerID) (Unlocker, error)
+}
+
+type RollingUpdateStore interface {
+	Get(id ReplicationControllerID) (*RollingUpdate, error)
+	Put(update *RollingUpdate) error
+	Delete(id ReplicationControllerID) error
+
+	All() ([]*RollingUpdate, error)
+
+	WatchAll(
+		done <-chan struct{},
+		logger logging.Logger,
+		updates chan<- []*RollingUpdate,
+	)
+
+	// LockOwner acquires the ownership lock on the rolling update. This is used for
+	// determining which instance of a farm is responsible for monitoring the update for
+	// deletion.
+	LockOwner(id ReplicationControllerID) (Unlocker, error)
+
+	// LockRCs acquires locks on the two replication controllers involved in creating a
+	// new update.
+	LockRCs(from, to ReplicationControllerID) (Unlocker, error)
+}
+
+// Unlocker instances are returned when a lock is successfully acquired. Their Unlock()
+// method should be called to release the lock.
+type Unlocker interface {
+	Unlock() error
+}
+
+// Returned by Lock() methods when the lock is already held by another LockManager.
+type AlreadyLockedError interface {
+	AlreadyLocked() // Has no effect. It exists to create a distinct interface type.
+	error
+}
+
+// A LockManager controls how locks are acquired and released. Methods to acquire and
+// release locks are found in the stores that contain objects that can be locked.
+type LockManager interface {
+	// When a lock cannot be acquired because the object is already locked, this method
+	// returns the name of the LockManager that holds the lock.
+	LockHolder(err AlreadyLockedError) (string, error)
+
+	// DestroyLockHolder destroys the LockManager that holds the lock. WARNING: leaky
+	// abstraction.
+	DestroyLockHolder(err AlreadyLockedError) error
+
+	// Close destroys this LockManager and releases all the locks it holds. WARNING: leaky
+	// abstraction.
+	Close() error
+}
+
+// Store defines the main interface that P2 uses to store data.
+type Store interface {
+	Reality() PodStore
+	Intent() PodStore
+	Health() HealthStore
+	ReplicationControllers() ReplicationControllerStore
+	RollingUpdates() RollingUpdateStore
+
+	// NewLockManager creates a LockManager
+	NewLockManager(name string) (LockManager, error)
+
+	// NewSharedLockManager creates a new LockManager that uses a shared Consul session.
+	// WARNING: leaky abstraction.
+	NewSessionLockManager(name string, session string) (LockManager, error)
+
+	// Ping checks for basic connectivity to the storage server. A nil error should
+	// indicate that the service was available at the time.
+	Ping() error
+}

--- a/pkg/store/update.go
+++ b/pkg/store/update.go
@@ -1,0 +1,55 @@
+package store
+
+import (
+	"time"
+)
+
+// A RollingUpdate (borrowed from kubectl's "rolling-update" command) represents a
+// transition from one replication controller to another. The IDs represent the two RCs
+// involved in the transition.
+type RollingUpdate struct {
+	// The old replication controller that will be releasing control. At the end
+	// of the Update, this RC will be deleted.
+	OldRC ReplicationControllerID `json:"OldRC"`
+
+	// Thew new replication controller that will be taking over. Updates can be
+	// uniquely identified by their new RC's ID.
+	NewRC ReplicationControllerID `json:"NewRC"`
+
+	// When the new RC's replica count equals this number, the Update is
+	// considered to be complete.
+	DesiredReplicas int `json:"DesiredReplicas"`
+
+	// During the course of the update, pods may be restarted or removed. This
+	// number specifies the minimum number of replicas that must be alive
+	// during the entire Update.
+	//
+	// The acceptable value of Minimum is subject to several constraints:
+	//   - the update will not even start until the minimum is satisfied, so if
+	//     the current number of live nodes is than the minimum, it will block
+	//     forever.
+	//   - the rollout algorithm assumes that scheduling a new pod may halt an
+	//     old one. For example, launchables based on hoist artifacts have this
+	//     behavior. Therefore, if the current number of live nodes is the same
+	//     as the minimum, the update will block. It cannot risk scheduling a
+	//     new pod because it might evict an old one and go below the minimum.
+	// Therefore, the minimum replicas must ALWAYS be less than the total number
+	// of live nodes when the update starts. Enforcing this constraint is the
+	// responsibility of the backend that executes Updates.
+	MinimumReplicas int `json:"MinimumReplicas"`
+
+	// If LeaveOld is set to true, the update will not delete the old RC when
+	// complete. Instead, the old RC will be left in whatever state it is in
+	// when the update ends. This is useful if, for example, you want to perform
+	// a partial rollout using one update, and leave the old RC so that another
+	// update can be created to finish the rollout.
+	LeaveOld bool `json:"LeaveOld"`
+
+	// RollDelay adds a period of mandatory sleep between rolling updates to the
+	// next set of nodes. This can be useful for creating a buffer period between
+	// a pod instance becoming healthy and clients to that instance resuming
+	// normal operation. In some pathological cases, applications may become
+	// unhealthy after being healthy for a short duration. Naive implementations like
+	// p2-replicate do not handle such after-the-fact unhealthiness. Default is 0.
+	RollDelay time.Duration `json:"RollDelay"`
+}


### PR DESCRIPTION
This commit is a first draft at an interface for a unified storage package.

The various "stores" in P2 have been implemented over time without any attempt
at a unified design: access methods to the intent and reality stores are
described in "pkg/kp". The data actually being stored is mainly defined in
"pkg/pods". Access to health checks is also defined in "pkg/kp", though the
main structure being stored is re-defined in "pkg/health".  Newer data type
ignore "pkg/kp" altogether. For instance replication controllers define schema
in "pkg/rc/fields", accessors in "pkg/kp/rcstore", and some type aliases in
"pkg/types". This is madness.

This new unified storage package groups everything together in a new
"pkg/store" package. Concrete data structres (pods, RCs, RUs) and all of their
type aliases are defined as structs in this package. The methods used to access
these structures are defined via interfaces to make it simpler to create different
backends.

The main definition of a storage system is the `store.Store` interface. It
contains several methods to access type-specific stores, in much the same way
a single database might have distinct tables. Grouping these stores together
can eliminate much of the redundancy involved in creating different stores
that still must share common configuration (e.g., like how a Rolling Update
farm needs access to a kp.Store, rcstore.Store, and a rollstore.Store that
all access the same Consul instance).

I expect there to be implementations of `store.Store` that are backed by
Consul and in-memory data structures (for use in testing).

Work left/open questions:
* Figure out where Labels fit into all of this...
* Consul implementation
* In-memory implementation
* Reduce "Manifest"'s reliance on other packages?
* Does this seem cleaner, safer, or easier to work with than what we have now?

*Note to reviewers*: I don't expect this to be accepted soon, if ever. I won't have time to finish implementing this myself, and I'm fine if the only outcome of this PR is that it promotes a discussion of better ways to organize our storage code. However, I do think it's important that eventually, an in-memory store exist. Our current practice of creating a bunch of weak, ad-hoc in-memory fakes inside our unit tests just means we repeat ourselves a lot in tests.