### PR TITLE
All pods get logBridgeExec

### DIFF
--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -191,11 +191,7 @@ func (p *Preparer) handlePods(podChan <-chan ManifestPair, quit <-chan struct{})
 				if pod.Id == POD_ID {
 					pod.DefaultTimeout = time.Duration(0)
 				}
-				for _, testPodId := range p.logExecTestGroup {
-					if pod.Id == testPodId {
-						pod.LogExec = logBridgeExec(pod)
-					}
-				}
+				pod.LogExec = logBridgeExec(pod)
 
 				// podChan is being fed values gathered from a kp.Watch() in
 				// WatchForPodManifestsForNode(). If the watch returns a new pair of

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -48,7 +48,6 @@ type Preparer struct {
 	caFile                 string
 	authPolicy             auth.Policy
 	maxLaunchableDiskUsage size.ByteCount
-	logExecTestGroup       []types.PodID
 }
 
 type PreparerConfig struct {
@@ -68,7 +67,6 @@ type PreparerConfig struct {
 	ExtraLogDestinations   []LogDestination       `yaml:"extra_log_destinations,omitempty"`
 	LogLevel               string                 `yaml:"log_level,omitempty"`
 	MaxLaunchableDiskUsage string                 `yaml:"max_launchable_disk_usage"`
-	LogExecTestGroup       []types.PodID          `yaml:"log_exec_test_group",omitempty`
 
 	// Params defines a collection of miscellaneous runtime parameters defined throughout the
 	// source files.
@@ -354,6 +352,5 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 		authPolicy:             authPolicy,
 		caFile:                 consulCAFile,
 		maxLaunchableDiskUsage: maxLaunchableDiskUsage,
-		logExecTestGroup:       preparerConfig.LogExecTestGroup,
 	}, nil
 }


### PR DESCRIPTION
This is based on several weeks of testing.

Editorially: I'd like to refactor this to be encapsulated inside of pod and to use the P2.ExecArgs type. I've started on that work here[1] and hope to deliver it soon.

https://github.com/square/p2/compare/master...rudle:rudle.implement-finish?expand=1