### PR TITLE
don't warn if log agent is KILLed

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -203,7 +203,7 @@ func (hl *Launchable) start(serviceBuilder *runit.ServiceBuilder, sv runit.SV) e
 			return err
 		}
 
-		if _, err = sv.Restart(&executable.LogAgent, runit.DefaultTimeout); err != nil {
+		if _, err = sv.Restart(&executable.LogAgent, runit.DefaultTimeout); err != nil && err != runit.Killed {
 			return err
 		}
 


### PR DESCRIPTION
This fixes a case where forcibly terminating the log agent would prevent the `enable` part of the Hoist launchable lifecycle from executing. This allows this case to proceed without error.