### PR TITLE
Add functions to rcstore for various rc locks

### DIFF
--- a/pkg/kp/rcstore/fake_store.go
+++ b/pkg/kp/rcstore/fake_store.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/square/p2/Godeps/_workspace/src/k8s.io/kubernetes/pkg/labels"
+	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/rc/fields"
 	"github.com/square/p2/pkg/util"
@@ -189,4 +190,16 @@ func (s *fakeStore) Watch(rc *fields.RC, quit <-chan struct{}) (<-chan struct{},
 	}()
 
 	return updatesOut, errors
+}
+
+func (s *fakeStore) LockForMutation(rcID fields.ID, session kp.Session) (kp.Unlocker, error) {
+	panic("LockForMutation not implemented")
+}
+
+func (s *fakeStore) LockForOwnership(rcID fields.ID, session kp.Session) (kp.Unlocker, error) {
+	panic("LockForOwnership not implemented")
+}
+
+func (s *fakeStore) LockForUpdateCreation(rcID fields.ID, session kp.Session) (kp.Unlocker, error) {
+	panic("LockForUpdateCreation not implemented")
 }

--- a/pkg/kp/rcstore/store.go
+++ b/pkg/kp/rcstore/store.go
@@ -2,14 +2,12 @@ package rcstore
 
 import (
 	"errors"
-	"path"
 
 	"github.com/square/p2/Godeps/_workspace/src/k8s.io/kubernetes/pkg/labels"
 
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/rc/fields"
-	"github.com/square/p2/pkg/util"
 )
 
 const rcTree string = "replication_controllers"
@@ -54,36 +52,20 @@ type Store interface {
 	// Send a value on `quitChannel` to stop watching.
 	// The two output channels will be closed in response.
 	Watch(rc *fields.RC, quit <-chan struct{}) (<-chan struct{}, <-chan error)
-}
 
-func rcPath(rcId fields.ID) (string, error) {
-	if rcId == "" {
-		return "", util.Errorf("rcId not specified when computing rc path")
-	}
-	return path.Join(rcTree, string(rcId)), nil
-}
+	// Locks an RC for ownership, e.g. by a process carrying out the intent
+	// of a replication controller by ensuring that ReplicasDesired copies
+	// of Manifest are running
+	LockForOwnership(rcID fields.ID, session kp.Session) (kp.Unlocker, error)
 
-func RCLockPath(rcId fields.ID) (string, error) {
-	subRCPath, err := rcPath(rcId)
-	if err != nil {
-		return "", err
-	}
+	// Locks an RC for mutation, e.g. by a running rolling update or any
+	// tool making a change
+	LockForMutation(rcID fields.ID, session kp.Session) (kp.Unlocker, error)
 
-	return path.Join(kp.LOCK_TREE, subRCPath), nil
-}
-
-// Replication controllers have potential for two locks:
-// 1) the key itself, held by a replication controller goroutine that is
-// responsible for making sure its desires are met
-// 2) an "update" key under the replication controller key, held by the
-// goroutine running a rolling update that will mutate a replication controller
-func RCUpdateLockPath(rcId fields.ID) (string, error) {
-	rcPath, err := rcPath(rcId)
-	if err != nil {
-		return "", err
-	}
-
-	return path.Join(kp.LOCK_TREE, rcPath, "update"), nil
+	// Locks an RC for the purposes of RU creation. We want to guarantee
+	// that no two RUs are admitted that operate on the same RCs, which is
+	// accomplished by locking them first
+	LockForUpdateCreation(rcID fields.ID, session kp.Session) (kp.Unlocker, error)
 }
 
 func IsNotExist(err error) bool {

--- a/pkg/rc/farm.go
+++ b/pkg/rc/farm.go
@@ -105,13 +105,7 @@ START_LOOP:
 					continue
 				}
 
-				lockPath, err := rcstore.RCLockPath(rcField.ID)
-				if err != nil {
-					rcf.logger.WithError(err).Errorln("Could not compute path for rc lock")
-					continue
-				}
-
-				rcUnlocker, err := rcf.session.Lock(lockPath)
+				rcUnlocker, err := rcf.rcStore.LockForOwnership(rcField.ID, rcf.session)
 				if _, ok := err.(kp.AlreadyLockedError); ok {
 					// someone else must have gotten it first - log and move to
 					// the next one

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -5,12 +5,6 @@ package types
 
 type PodID string
 
-type RCID string
-
 func (p PodID) String() string {
 	return string(p)
-}
-
-func (r RCID) String() string {
-	return string(r)
 }


### PR DESCRIPTION
There are 3 kinds of locks that are applied to a replication controller:

1) an "ownership" lock, which should be held by the goroutine that
carries out the intent of the replication controller. These goroutines
are spawned by an rc farm.
2) a "mutation" lock. This should be held by any tool that intends to
modify a replication controller. This could be a commandline tool, or an
rolling update goroutine spawned by the roll farm, for instance.
3) an "update creation" lock. This is not currently used, but is useful
for guaranteeing that no conflicting rolling updates are admitted to the
store. A process trying to schedule a rolling update should first grab
the update creation lock for each replication controller it will operate
on, then confirm there are no rolling updates that refer to either of
the replication controllers, and then create the update and release the
locks.