### PR TITLE
Recover from panics in a goroutine spawned by a farm

### DIFF
--- a/pkg/rc/farm.go
+++ b/pkg/rc/farm.go
@@ -9,6 +9,7 @@ import (
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/rc/fields"
+	"github.com/square/p2/pkg/util"
 )
 
 // The Farm is responsible for spawning and reaping replication controllers
@@ -139,6 +140,14 @@ START_LOOP:
 				foundChildren[rcField.ID] = struct{}{}
 
 				go func() {
+					defer func() {
+						if r := recover(); r != nil {
+							err := util.Errorf("Caught panic in rc farm: %s", r)
+							rcLogger.WithError(err).
+								WithField("rc_id", rcField.ID).
+								Errorln("Caught panic in rc farm")
+						}
+					}()
 					// disabled-ness is handled in watchdesires
 					for err := range newChild.WatchDesires(childQuit) {
 						rcLogger.WithError(err).Errorln("Got error in replication controller loop")

--- a/pkg/roll/farm.go
+++ b/pkg/roll/farm.go
@@ -206,6 +206,14 @@ START_LOOP:
 				foundChildren[rlField.NewRC] = struct{}{}
 
 				go func(id fields.ID) {
+					defer func() {
+						if r := recover(); r != nil {
+							err := util.Errorf("Caught panic in roll farm: %s", r)
+							rlLogger.WithError(err).
+								WithField("new_rc", rlField.NewRC).
+								Errorln("Caught panic in roll farm")
+						}
+					}()
 					if !newChild.Run(childQuit) {
 						// returned false, farm must have asked us to quit
 						return


### PR DESCRIPTION
A farm will spawn many goroutines that are activated by changes in
consul data, and it is common to run multiple farms on a server (e.g.
rc farm and roll farm). Since consul data is not transactional, there
have been repeated issues of null pointer dereferences in farm
goroutines crashing the entire process.

While pointers are now pessimistically dereferenced to avoid these
issues, it is probably good to have an additional level of protection to
stop bad data in consul from grinding the farms to a halt if a nil
pointer dereference is missed.