### PR TITLE
Implement basic finish functionality

### DIFF
--- a/pkg/p2exec/p2_exec.go
+++ b/pkg/p2exec/p2_exec.go
@@ -38,5 +38,9 @@ func (args P2ExecArgs) CommandLine() []string {
 		cmd = append(cmd, "-w", args.WorkDir)
 	}
 
+	if len(cmd) > 0 {
+		cmd = append(cmd, "--")
+	}
+
 	return append(cmd, args.Command...)
 }

--- a/pkg/p2exec/p2_exec_test.go
+++ b/pkg/p2exec/p2_exec_test.go
@@ -25,7 +25,7 @@ func TestBuildWithArgs(t *testing.T) {
 		CgroupName:       "cgroup_name",
 	}
 
-	expected = "-n -u some_user -e some_dir -e other_dir -l some_cgroup_config_name -c cgroup_name script"
+	expected = "-n -u some_user -e some_dir -e other_dir -l some_cgroup_config_name -c cgroup_name -- script"
 	actual = strings.Join(args.CommandLine(), " ")
 	if actual != expected {
 		t.Errorf("Expected args.BuildWithArgs() to return '%s', was '%s'", expected, actual)

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -1,8 +1,6 @@
 package preparer
 
 import (
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/square/p2/Godeps/_workspace/src/github.com/Sirupsen/logrus"
@@ -191,7 +189,8 @@ func (p *Preparer) handlePods(podChan <-chan ManifestPair, quit <-chan struct{})
 				if pod.Id == POD_ID {
 					pod.DefaultTimeout = time.Duration(0)
 				}
-				pod.LogExec = logBridgeExec(pod)
+				pod.SetLogBridgeExec(p.logExec)
+				pod.SetFinishExec(p.finishExec)
 
 				// podChan is being fed values gathered from a kp.Watch() in
 				// WatchForPodManifestsForNode(). If the watch returns a new pair of
@@ -224,21 +223,6 @@ func (p *Preparer) handlePods(podChan <-chan ManifestPair, quit <-chan struct{})
 				}
 			}
 		}
-	}
-}
-
-func logBridgeExec(pod *pods.Pod) []string {
-	return []string{
-		pod.P2Exec,
-		"-u",
-		"nobody",
-		"-e",
-		pod.EnvDir(),
-		"--",
-		filepath.Join(os.Getenv("POD_HOME"), "p2-log-bridge", "current", "bin", "p2-log-bridge"),
-		"bridge",
-		"-logExec",
-		svlogdExec,
 	}
 }
 

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -48,6 +48,8 @@ type Preparer struct {
 	caFile                 string
 	authPolicy             auth.Policy
 	maxLaunchableDiskUsage size.ByteCount
+	finishExec             []string
+	logExec                []string
 }
 
 type PreparerConfig struct {
@@ -67,6 +69,8 @@ type PreparerConfig struct {
 	ExtraLogDestinations   []LogDestination       `yaml:"extra_log_destinations,omitempty"`
 	LogLevel               string                 `yaml:"log_level,omitempty"`
 	MaxLaunchableDiskUsage string                 `yaml:"max_launchable_disk_usage"`
+	FinishExec             []string               `yaml:"finish_exec,omitempty"`
+	LogExec                []string               `yaml:"log_exec,omitempty"` // If specifying a path to an executable, we assume it has been specified relative to this preparer's POD_HOME
 
 	// Params defines a collection of miscellaneous runtime parameters defined throughout the
 	// source files.
@@ -342,6 +346,20 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 		consulCAFile = preparerConfig.CAFile
 	}
 
+	var logExec []string
+	if len(preparerConfig.LogExec) > 0 {
+		logExec = preparerConfig.LogExec
+	} else {
+		logExec = pods.DefaultLogExec
+	}
+
+	var finishExec []string
+	if len(preparerConfig.FinishExec) > 0 {
+		finishExec = preparerConfig.FinishExec
+	} else {
+		finishExec = pods.DefaultFinishExec
+	}
+
 	return &Preparer{
 		node:                   preparerConfig.NodeName,
 		store:                  store,
@@ -352,5 +370,7 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 		authPolicy:             authPolicy,
 		caFile:                 consulCAFile,
 		maxLaunchableDiskUsage: maxLaunchableDiskUsage,
+		finishExec:             finishExec,
+		logExec:                logExec,
 	}, nil
 }

--- a/pkg/preparer/setup_test.go
+++ b/pkg/preparer/setup_test.go
@@ -20,6 +20,7 @@ func TestLoadConfigWillMarshalYaml(t *testing.T) {
 	Assert(t).AreEqual("/etc/p2/hooks", preparerConfig.HooksDirectory, "did not read the hooks directory correctly")
 	Assert(t).AreEqual("/etc/p2.keyring", preparerConfig.Auth["keyring"], "did not read the keyring path correctly")
 	Assert(t).AreEqual(1, len(preparerConfig.ExtraLogDestinations), "should have picked up 1 log destination")
+
 	destination := preparerConfig.ExtraLogDestinations[0]
 	Assert(t).AreEqual(logging.OutSocket, destination.Type, "should have been the socket type")
 	Assert(t).AreEqual("/var/log/p2-socket.out", destination.Path, "should have parsed path correctly")

--- a/pkg/preparer/test_preparer_config.yaml
+++ b/pkg/preparer/test_preparer_config.yaml
@@ -10,3 +10,9 @@ preparer:
   extra_log_destinations:
   - type: socket
     path: /var/log/p2-socket.out
+  log_exec:
+    - log-bridge
+    - start
+  finish_exec:
+    - touch
+    - /tmp/process_did_finish

--- a/pkg/runit/servicebuilder_test.go
+++ b/pkg/runit/servicebuilder_test.go
@@ -81,6 +81,10 @@ func TestStagedContents(t *testing.T) {
 	Assert(t).IsNil(err, "should have statted staging log main")
 	Assert(t).IsTrue(info.IsDir(), "staging log main should have been a dir")
 
+	info, err = os.Stat(filepath.Join(sb.StagingRoot, "foo", "finish"))
+	Assert(t).IsNil(err, "should have statted staging finish")
+	Assert(t).IsTrue(info.Mode()&0100 == 0100, "finish script should have been executable")
+
 	// There should be no 'down' file if the restart policy is 'always'
 	_, err = os.Stat(filepath.Join(sb.StagingRoot, "foo", "down"))
 	Assert(t).IsNotNil(err, "down file should not have existed when restart policy is 'always'")


### PR DESCRIPTION
Here's a first cut at configurable finish executables for our runit integration. Pay special attention to the changes to to servicebuilder.go wrt the process _shell_ for the call to finish (keeping in mind that the app's env will also be present at this time).

This PR assumes we will ship one version of finish for all pods. I could imagine a world in which pod's could override finish but I can't imagine the use case just yet.

I hope to write some more tests for this - though I'm hoping to get feedback on the direction first. I've verified that this works in a testing environment.