### PR TITLE
Make update.LockRCs have pointer receiver in pkg/roll/run_update.go

### DIFF
--- a/pkg/roll/run_update.go
+++ b/pkg/roll/run_update.go
@@ -235,7 +235,7 @@ ROLL_LOOP:
 	return true // finally if we make it here, we can return true
 }
 
-func (u update) lockRCs(done <-chan struct{}) error {
+func (u *update) lockRCs(done <-chan struct{}) error {
 	newUnlocker, err := u.rcs.LockForMutation(u.NewRC, u.session)
 	if _, ok := err.(kp.AlreadyLockedError); ok {
 		return fmt.Errorf("could not lock new %s", u.NewRC)


### PR DESCRIPTION
If it's a value receiver instead of pointer receiver, the struct fields
for the kp.Unlockers don't get updated, and we never end up unlocking
the held locks.