### PR TITLE
Replace rollstore.Put() function

### DIFF
--- a/pkg/kp/rollstore/store.go
+++ b/pkg/kp/rollstore/store.go
@@ -22,6 +22,10 @@ type Store interface {
 	Get(fields.ID) (fields.Update, error)
 	// retrieve all updates
 	List() ([]fields.Update, error)
+	// DEPRECATED: creates a rollstore with no guarantees about atomic
+	// creation of RCs. It's easy to generate inconsistent data when using
+	// this
+	Put(u fields.Update) error
 	// Creates a rolling update from two existing RCs. Will check that the
 	// RCs actually exist before applying the update, and acquire locks on
 	// them in a deterministic order to guarantee that no two RUs will


### PR DESCRIPTION
This was the only operation provided in the past for creating rolling
updates. Its use is discouraged because it does not provide any safety
guarantees around consistency of data (e.g. a RU being created with
references to RCs which don't exist).

It is being resurrected to ease clients of this library onto the new
functions without forcing.