### PR TITLE
roll: log message change, blocking for NEW nodes not OLD

### DIFF
--- a/pkg/roll/run_update.go
+++ b/pkg/roll/run_update.go
@@ -175,7 +175,7 @@ ROLL_LOOP:
 					u.logger.WithFields(logrus.Fields{
 						"old": oldNodes,
 						"new": newNodes,
-					}).Debugln("Upgrade almost complete, blocking for more healthy old nodes")
+					}).Debugln("Upgrade almost complete, blocking for more healthy new nodes")
 					break
 				}
 			}


### PR DESCRIPTION
Sorry for making a mistake in ef9e8fcc4c80d4231c30a154ecaedc44c6946efc