### PR TITLE
roll: terminate when OLD + new healthy exceed minimum health

### DIFF
--- a/pkg/roll/run_update.go
+++ b/pkg/roll/run_update.go
@@ -159,7 +159,7 @@ ROLL_LOOP:
 				// The benefit of using >= is that it allows termination even if Run
 				// resumes from an unusual state.
 
-				if newNodes.Healthy >= u.MinimumReplicas {
+				if oldNodes.Healthy+newNodes.Healthy >= u.MinimumReplicas {
 					// We only ask for u.MinimumReplicas nodes to be healthy
 					// before declaring an upgrade to be complete.
 					// This is so that if a deployer intentionally deploys a known-bad SHA


### PR DESCRIPTION
This helps when we are in a canary deploy. Imagine a canary deploy with
2 minimum health but only 1 canary desired.

The RU will move 1 node to the new side, then wait for 2 nodes to be
healthy on the new side, which is impossible.

The old side is allowed to contribute toward health too. This will allow
the above-mentioned canary deploy to terminate.