### PR TITLE
Revert "roll: conservatively treat old unknown-health nodes as healthy"

### DIFF
--- a/pkg/roll/run_update.go
+++ b/pkg/roll/run_update.go
@@ -434,8 +434,7 @@ func (u *update) shouldRollAfterDelay(newFields rcf.RC) (int, int, error) {
 }
 
 func (u *update) rollAlgorithmParams(oldHealth, newHealth rcNodeCounts) (oldHealthy, newHealthy, currentDesired, targetDesired, minHealthy int) {
-	// We conservatively treat Unknown nodes as healthy on the old side.
-	oldHealthy = oldHealth.Healthy + oldHealth.Unknown
+	oldHealthy = oldHealth.Healthy
 	if oldHealth.Desired < oldHealthy {
 		// Because of the non-atomicity of our KV stores,
 		// we may run into this situation while decrementing old RC's count:

--- a/pkg/roll/update_test.go
+++ b/pkg/roll/update_test.go
@@ -121,7 +121,7 @@ func TestRollAlgorithmParams(t *testing.T) {
 		Desired:   2048,
 	}
 	old, new, currentDesired, targetDesired, minHealthy := u.rollAlgorithmParams(oldHealth, newHealth)
-	Assert(t).AreEqual(old, 20, "incorrect old healthy param (want old healthy + old unknown)")
+	Assert(t).AreEqual(old, 4, "incorrect old healthy param")
 	Assert(t).AreEqual(new, 256, "incorrect new healthy param")
 	Assert(t).AreEqual(currentDesired, 2080, "incorrect current desired param (want sum of desires)")
 	Assert(t).AreEqual(targetDesired, 8192, "incorrect target desired param")
@@ -498,14 +498,13 @@ func TestShouldRollInitial(t *testing.T) {
 	Assert(t).AreEqual(roll, 1, "expected to only roll one node")
 }
 
-func TestShouldRollInitialMigration(t *testing.T) {
+func TestShouldRollInitialUnknown(t *testing.T) {
 	upd, _, manifest := updateWithHealth(t, 3, 0, nil, nil, nil)
 	upd.DesiredReplicas = 3
 	upd.MinimumReplicas = 2
 
-	roll, err := upd.uniformShouldRollAfterDelay(t, rc_fields.RC{ID: upd.NewRC, Manifest: manifest})
-	Assert(t).IsNil(err, "expected no error determining nodes to roll")
-	Assert(t).AreEqual(roll, 1, "expected to roll one node")
+	roll, _ := upd.uniformShouldRollAfterDelay(t, rc_fields.RC{ID: upd.NewRC, Manifest: manifest})
+	Assert(t).AreEqual(roll, 0, "expected to roll no nodes if health is unknown")
 }
 
 func TestShouldRollInitialMigrationFromZero(t *testing.T) {
@@ -587,7 +586,7 @@ func TestShouldRollMidwayHealthy(t *testing.T) {
 	Assert(t).AreEqual(roll, 1, "expected to roll one node")
 }
 
-func TestShouldRollMidwayHealthyMigration(t *testing.T) {
+func TestShouldRollMidwayUnknkown(t *testing.T) {
 	checks := map[string]health.Result{
 		"node3": {Status: health.Passing},
 	}
@@ -597,9 +596,8 @@ func TestShouldRollMidwayHealthyMigration(t *testing.T) {
 	upd.DesiredReplicas = 3
 	upd.MinimumReplicas = 2
 
-	roll, err := upd.uniformShouldRollAfterDelay(t, rc_fields.RC{ID: upd.NewRC, Manifest: manifest})
-	Assert(t).IsNil(err, "expected no error determining nodes to roll")
-	Assert(t).AreEqual(roll, 1, "expected to roll one node")
+	roll, _ := upd.uniformShouldRollAfterDelay(t, rc_fields.RC{ID: upd.NewRC, Manifest: manifest})
+	Assert(t).AreEqual(roll, 0, "expected to roll no nodes when old nodes all have unknown health")
 }
 
 func TestShouldRollMidwayDesireLessThanHealthy(t *testing.T) {


### PR DESCRIPTION
This reverts commit 0ffe7f9987a432451a241fb7a394762c22848a3a.

The reason we thought we wanted that commit was because enables the case
of a migration from a different deployment tool onto p2. For example, if
we have three unknown nodes on the old side and minimum health is 2, we
want to roll one node at a time.

However, this code is inapplicable in a migration from a different
deployment tool, because the nodes simply will not exist on the old RC.
The old RC's desired node count will be 0, since that is the default
number for an old RC. So the unknown health code path never gets
triggered.

The proper way to support migrations from another deployment tool is
d045410ce859ab06b5c1ad46904e108de5912754.

We ran into a case today where we mistakenly rolled a node under this
condition:

```json
{
  "msg": "Adding 1 new nodes and removing 1 old nodes",
    "new": {
    "Desired": 0,
    "Current": 0,
    "Real": 0,
    "Healthy": 0,
    "Unhealthy": 0,
    "Unknown": 0

    },
  "nextAdd": 1,
  "nextRemove": 1,
  "old": {
    "Desired": 2,
    "Current": 2,
    "Real": 2,
    "Healthy": 1,
    "Unhealthy": 0,
    "Unknown": 1

  },
  "pod": "censored"
}
```

In fact, the old unknown-health node was unhealthy.

It is ALWAYS safer to NEVER include the unknown health node in the
healthy count, because increasing oldHealthy always increases headroom
whereas that headroom might not exist if the unknown health node is
actually unhealthy instead of healthy.

In an ideal world, we would be able to have selective rolling, where we
are able to say "schedule N nodes but only on unhealthy/unknown nodes",
but until we have that capability it is best to be safe.