### PR TITLE
Support rcFarmSelector in RC farm

### DIFF
--- a/bin/p2-rctl-server/main.go
+++ b/bin/p2-rctl-server/main.go
@@ -119,7 +119,7 @@ func main() {
 	}
 
 	// Run the farms!
-	go rc.NewFarm(kpStore, rcStore, scheduler, labeler, rcSub.Chan(), logger, alerter).Start(nil)
+	go rc.NewFarm(kpStore, rcStore, scheduler, labeler, rcSub.Chan(), logger, klabels.Everything(), alerter).Start(nil)
 	roll.NewFarm(roll.UpdateFactory{
 		KPStore:       kpStore,
 		RCStore:       rcStore,


### PR DESCRIPTION
Previously only roll farms supported a selector to use to partition work
into a test environment. It's also useful to have this capability for RC
farms.