### PR TITLE
Fix rollstore by populating all member fields in constructor

### DIFF
--- a/pkg/kp/rollstore/consul_store.go
+++ b/pkg/kp/rollstore/consul_store.go
@@ -68,6 +68,8 @@ func NewConsul(c *api.Client, logger *logging.Logger) Store {
 		kv:      c.KV(),
 		rcstore: rcstore.NewConsul(c, 3),
 		logger:  *logger,
+		labeler: labels.NewConsulApplicator(c, 3),
+		store:   kp.NewConsulStore(c),
 	}
 }
 

--- a/pkg/kp/rollstore/consul_store_test.go
+++ b/pkg/kp/rollstore/consul_store_test.go
@@ -24,6 +24,26 @@ const (
 	testRCId2 = rc_fields.ID("def-456")
 )
 
+func TestNewConsul(t *testing.T) {
+	store := NewConsul(&api.Client{}, nil)
+	rollstore := store.(consulStore)
+	if rollstore.kv == nil {
+		t.Fatal("kv should not be nil for constructed rollstore")
+	}
+
+	if rollstore.rcstore == nil {
+		t.Fatal("rcstore should not be nil for constructed rollstore")
+	}
+
+	if rollstore.labeler == nil {
+		t.Fatal("labeler should not be nil for constructed rollstore")
+	}
+
+	if rollstore.store == nil {
+		t.Fatal("store should not be nil for constructed rollstore")
+	}
+}
+
 func TestRollPath(t *testing.T) {
 	rollPath, err := RollPath(fields.ID(testRCId))
 	if err != nil {


### PR DESCRIPTION
Some rollstore operations depend on member fields that were not being
set in the rollstore constructor. This commit fixes that.