### PR TITLE
Failsafes for rc farms

### DIFF
--- a/pkg/rc/farm_test.go
+++ b/pkg/rc/farm_test.go
@@ -1,0 +1,76 @@
+package rc
+
+import (
+	"testing"
+
+	"github.com/square/p2/pkg/alerting"
+	"github.com/square/p2/pkg/rc/fields"
+
+	. "github.com/square/p2/Godeps/_workspace/src/github.com/anthonybishopric/gotcha"
+)
+
+type failsafeAlerter struct {
+	savedInfo alerting.AlertInfo
+}
+
+func (f *failsafeAlerter) Alert(info alerting.AlertInfo) error {
+	f.savedInfo = info
+	return nil
+}
+
+func TestNoRCsWillCausePanic(t *testing.T) {
+	alerter := &failsafeAlerter{}
+	rcf := &Farm{
+		alerter: alerter,
+	}
+
+	defer func() {
+		if p := recover(); p == nil {
+			t.Fatal("Should have panicked at sight of no RCs")
+		}
+		Assert(t).AreEqual("no_rcs_found", alerter.savedInfo.IncidentKey, "should have had a fired alert")
+	}()
+	rcf.failsafe([]fields.RC{})
+}
+
+func TestRCsWithCountsWillBeFine(t *testing.T) {
+	alerter := &failsafeAlerter{}
+	rcf := &Farm{
+		alerter: alerter,
+	}
+
+	rcs := []fields.RC{
+		fields.RC{
+			ReplicasDesired: 5,
+		},
+	}
+
+	defer func() {
+		if p := recover(); p != nil {
+			t.Fatal("Should not have panicked since everything is fine")
+		}
+		Assert(t).AreEqual("", alerter.savedInfo.IncidentKey, "should not have had a fired alert")
+	}()
+	rcf.failsafe(rcs)
+}
+
+func TestRCsWithZeroCountsWillTriggerIncident(t *testing.T) {
+	alerter := &failsafeAlerter{}
+	rcf := &Farm{
+		alerter: alerter,
+	}
+
+	rcs := []fields.RC{
+		fields.RC{
+			ReplicasDesired: 0,
+		},
+	}
+
+	defer func() {
+		if p := recover(); p == nil {
+			t.Fatal("Should have panicked due to no replicas")
+		}
+		Assert(t).AreEqual("zero_replicas_found", alerter.savedInfo.IncidentKey, "should have had a fired alert")
+	}()
+	rcf.failsafe(rcs)
+}


### PR DESCRIPTION
This PR adds two failsafes to the RC farms to prevent
catastrophic unscheduling of pods across the cluster. This
situation is generally hypothetical, but I'd rather be safe
than sorry.

The first situation is - the farm will panic if zero RCs have
been scheduled in Consul. This currently doesn't prevent any
specific behavior other than the farm abandoning working on RCs,
but is worth signaling that it has occurred.

The second situation would be genuinely catastrophic. If replica
counts were all 0, the RC farm would go on a killing spree across
the cluster, unscheduling all services. In practice this should
never happen.