### PR TITLE
Label watch optimizations

### DIFF
--- a/pkg/labels/applicator.go
+++ b/pkg/labels/applicator.go
@@ -54,11 +54,6 @@ func (l Labeled) SameAs(o Labeled) bool {
 	return l.ID == o.ID && l.LabelType == o.LabelType
 }
 
-type WatchResult struct {
-	Labeled []Labeled
-	Valid   bool // Will be false if the underlying watcher has terminated
-}
-
 // General purpose backing store for labels and assignment
 // to P2 objects
 type Applicator interface {
@@ -86,7 +81,7 @@ type Applicator interface {
 	//
 	// The watch may be terminated by the underlying implementation without signaling on
 	// the quit channel - this will be indicated by the closing of the result channel. For
-	// this reason, the resulting WatchResult have a Valid flag to help determine if
-	// the channel has been closed.
-	WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan WatchResult
+	// this reason, callers should **always** verify that the channel is closed by checking
+	// the "ok" boolean or using `range`.
+	WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan []Labeled
 }

--- a/pkg/labels/applicator.go
+++ b/pkg/labels/applicator.go
@@ -54,6 +54,11 @@ func (l Labeled) SameAs(o Labeled) bool {
 	return l.ID == o.ID && l.LabelType == o.LabelType
 }
 
+type WatchResult struct {
+	Labeled []Labeled
+	Valid   bool // Will be false if the underlying watcher has terminated
+}
+
 // General purpose backing store for labels and assignment
 // to P2 objects
 type Applicator interface {
@@ -81,7 +86,7 @@ type Applicator interface {
 	//
 	// The watch may be terminated by the underlying implementation without signaling on
 	// the quit channel - this will be indicated by the closing of the result channel. For
-	// this reason, the safest way to process the result of this channel is to use
-	// it in a for loop. Alternatively, you may check for nullity of the result []Labeled
-	WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan *[]Labeled
+	// this reason, the resulting WatchResult have a Valid flag to help determine if
+	// the channel has been closed.
+	WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan WatchResult
 }

--- a/pkg/labels/consul_aggregator_test.go
+++ b/pkg/labels/consul_aggregator_test.go
@@ -40,16 +40,16 @@ func TestTwoClients(t *testing.T) {
 		select {
 		case <-time.After(time.Second):
 			t.Fatal("Should not have taken a second to get results")
-		case labeledPtr := <-labeledChannel1:
-			Assert(t).IsNotNil(labeledPtr, "ptr should not have been nil")
-			labeled := *labeledPtr
+		case labeledWatch := <-labeledChannel1:
+			Assert(t).IsTrue(labeledWatch.Valid, "valid should not have been true")
+			labeled := labeledWatch.Labeled
 			Assert(t).AreNotEqual("green", checked, "Should not have already checked the green selector result")
 			checked = "green" // ensure that both sides get checked
 			Assert(t).AreEqual(1, len(labeled), "Should have received one result from the color watch")
 			Assert(t).AreEqual("emeralda", labeled[0].ID, "should have received the emerald app")
-		case labeledPtr := <-labeledChannel2:
-			Assert(t).IsNotNil(labeledPtr, "ptr should not have been nil")
-			labeled := *labeledPtr
+		case labeledWatch := <-labeledChannel2:
+			Assert(t).IsTrue(labeledWatch.Valid, "valid should not have been true")
+			labeled := labeledWatch.Labeled
 			Assert(t).AreNotEqual("canary", checked, "Should not have already checked the canary selector result")
 			checked = "canary" // ensure that both sides get checked
 			Assert(t).AreEqual(2, len(labeled), "Should have received two results from the canary watch")
@@ -134,9 +134,9 @@ func TestQuitIndividualWatch(t *testing.T) {
 		select {
 		case <-time.After(time.Second):
 			t.Fatalf("Should not have taken a second to get results on iteration %v", i)
-		case labeledPtr := <-labeledChannel2:
-			Assert(t).IsNotNil(labeledPtr, "ptr should not have been nil")
-			labeled := *labeledPtr
+		case labeledWatch := <-labeledChannel2:
+			Assert(t).IsTrue(labeledWatch.Valid, "valid should not have been true")
+			labeled := labeledWatch.Labeled
 			Assert(t).AreEqual(1, len(labeled), "Should have one result with a production deployment")
 			Assert(t).AreEqual("maroono", labeled[0].ID, "Should have received maroono as the one production deployment")
 		}

--- a/pkg/labels/consul_aggregator_test.go
+++ b/pkg/labels/consul_aggregator_test.go
@@ -40,16 +40,14 @@ func TestTwoClients(t *testing.T) {
 		select {
 		case <-time.After(time.Second):
 			t.Fatal("Should not have taken a second to get results")
-		case labeledWatch := <-labeledChannel1:
-			Assert(t).IsTrue(labeledWatch.Valid, "valid should not have been true")
-			labeled := labeledWatch.Labeled
+		case labeled, ok := <-labeledChannel1:
+			Assert(t).IsTrue(ok, "should have been okay")
 			Assert(t).AreNotEqual("green", checked, "Should not have already checked the green selector result")
 			checked = "green" // ensure that both sides get checked
 			Assert(t).AreEqual(1, len(labeled), "Should have received one result from the color watch")
 			Assert(t).AreEqual("emeralda", labeled[0].ID, "should have received the emerald app")
-		case labeledWatch := <-labeledChannel2:
-			Assert(t).IsTrue(labeledWatch.Valid, "valid should not have been true")
-			labeled := labeledWatch.Labeled
+		case labeled, ok := <-labeledChannel2:
+			Assert(t).IsTrue(ok, "should have been okay")
 			Assert(t).AreNotEqual("canary", checked, "Should not have already checked the canary selector result")
 			checked = "canary" // ensure that both sides get checked
 			Assert(t).AreEqual(2, len(labeled), "Should have received two results from the canary watch")
@@ -107,8 +105,9 @@ func TestQuitAggregateBeforeResults(t *testing.T) {
 	aggreg.Quit()
 
 	select {
-	case labeled := <-res:
-		Assert(t).IsNotNil(labeled, "Should not have received any results")
+	case labeled, ok := <-res:
+		Assert(t).IsFalse(ok, "should have been okay")
+		Assert(t).IsTrue(labeled == nil, "Should not have received any results")
 	case <-time.After(time.Second):
 		t.Fatal("Should still be waiting or processing results after a second")
 	}
@@ -134,9 +133,8 @@ func TestQuitIndividualWatch(t *testing.T) {
 		select {
 		case <-time.After(time.Second):
 			t.Fatalf("Should not have taken a second to get results on iteration %v", i)
-		case labeledWatch := <-labeledChannel2:
-			Assert(t).IsTrue(labeledWatch.Valid, "valid should not have been true")
-			labeled := labeledWatch.Labeled
+		case labeled, ok := <-labeledChannel2:
+			Assert(t).IsTrue(ok, "should have been okay")
 			Assert(t).AreEqual(1, len(labeled), "Should have one result with a production deployment")
 			Assert(t).AreEqual("maroono", labeled[0].ID, "Should have received maroono as the one production deployment")
 		}
@@ -179,9 +177,9 @@ func TestCachedValueImmediatelySent(t *testing.T) {
 	// that the cached value we have added will be present on the result channel.
 
 	select {
-	case res := <-watch:
-		Assert(t).IsTrue(res.Valid, "Should have had a valid result")
-		Assert(t).AreEqual(res.Labeled[0].ID, "heyo", "should have matched heyo based on the query")
+	case res, ok := <-watch:
+		Assert(t).IsTrue(ok, "Should have had a valid result")
+		Assert(t).AreEqual(res[0].ID, "heyo", "should have matched heyo based on the query")
 	case <-time.After(time.Second):
 		t.Fatal("Could not read result from new watch channel")
 	}

--- a/pkg/labels/consul_applicator.go
+++ b/pkg/labels/consul_applicator.go
@@ -231,7 +231,7 @@ func convertLabeledToKVP(l Labeled) (*api.KVPair, error) {
 // to the cost of querying for this subtree on any sizeable fleet of machines. Instead, preparers should
 // use the httpApplicator from a server that exposes the results of this (or another)
 // implementation's watch.
-func (c *consulApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan WatchResult {
+func (c *consulApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan []Labeled {
 	c.aggregatorMux.Lock()
 	defer c.aggregatorMux.Unlock()
 	aggregator, ok := c.aggregators[labelType]

--- a/pkg/labels/consul_applicator.go
+++ b/pkg/labels/consul_applicator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path"
 	"strings"
+	"sync"
 
 	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/api"
 	"github.com/square/p2/Godeps/_workspace/src/k8s.io/kubernetes/pkg/labels"
@@ -32,10 +33,11 @@ type consulKV interface {
 }
 
 type consulApplicator struct {
-	kv          consulKV
-	logger      logging.Logger
-	retries     int
-	aggregators map[Type]*consulAggregator
+	kv            consulKV
+	logger        logging.Logger
+	retries       int
+	aggregators   map[Type]*consulAggregator
+	aggregatorMux sync.Mutex
 }
 
 func NewConsulApplicator(client *api.Client, retries int) *consulApplicator {
@@ -229,7 +231,9 @@ func convertLabeledToKVP(l Labeled) (*api.KVPair, error) {
 // to the cost of querying for this subtree on any sizeable fleet of machines. Instead, preparers should
 // use the httpApplicator from a server that exposes the results of this (or another)
 // implementation's watch.
-func (c *consulApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan *[]Labeled {
+func (c *consulApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan WatchResult {
+	c.aggregatorMux.Lock()
+	defer c.aggregatorMux.Unlock()
 	aggregator, ok := c.aggregators[labelType]
 	if !ok {
 		aggregator = NewConsulAggregator(labelType, c.kv, c.logger)

--- a/pkg/labels/fake_applicator.go
+++ b/pkg/labels/fake_applicator.go
@@ -102,15 +102,15 @@ func (app *fakeApplicator) GetMatches(selector labels.Selector, labelType Type) 
 	return results, nil
 }
 
-func (app *fakeApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan WatchResult {
-	ch := make(chan WatchResult)
+func (app *fakeApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan []Labeled {
+	ch := make(chan []Labeled)
 	go func() {
 		for {
 			res, _ := app.GetMatches(selector, labelType)
 			select {
 			case <-quitCh:
 				return
-			case ch <- WatchResult{res, true}:
+			case ch <- res:
 			}
 		}
 	}()

--- a/pkg/labels/fake_applicator.go
+++ b/pkg/labels/fake_applicator.go
@@ -102,15 +102,15 @@ func (app *fakeApplicator) GetMatches(selector labels.Selector, labelType Type) 
 	return results, nil
 }
 
-func (app *fakeApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan *[]Labeled {
-	ch := make(chan *[]Labeled)
+func (app *fakeApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan WatchResult {
+	ch := make(chan WatchResult)
 	go func() {
 		for {
 			res, _ := app.GetMatches(selector, labelType)
 			select {
 			case <-quitCh:
 				return
-			case ch <- &res:
+			case ch <- WatchResult{res, true}:
 			}
 		}
 	}()

--- a/pkg/labels/http_applicator.go
+++ b/pkg/labels/http_applicator.go
@@ -95,7 +95,7 @@ func (h *httpApplicator) GetMatches(selector labels.Selector, labelType Type) ([
 	return labeled, nil
 }
 
-func (h *httpApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan *[]Labeled {
+func (h *httpApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan WatchResult {
 	panic("Not implemented")
 	return nil
 }

--- a/pkg/labels/http_applicator.go
+++ b/pkg/labels/http_applicator.go
@@ -95,7 +95,7 @@ func (h *httpApplicator) GetMatches(selector labels.Selector, labelType Type) ([
 	return labeled, nil
 }
 
-func (h *httpApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan WatchResult {
+func (h *httpApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan []Labeled {
 	panic("Not implemented")
 	return nil
 }


### PR DESCRIPTION
These are two commits that improve the performance of label watches, see commit messages for details.

