### PR TITLE
Return a specific error type if oldRCSelector is ambiguous

### DIFF
--- a/pkg/kp/rollstore/consul_store.go
+++ b/pkg/kp/rollstore/consul_store.go
@@ -392,11 +392,7 @@ func (s consulStore) CreateRollingUpdateFromOneMaybeExistingWithLabelSelector(
 
 	var oldRCID rc_fields.ID
 	if len(matches) > 1 {
-		return roll_fields.Update{}, util.Errorf(
-			"Can't create update: old RC selector %s was ambiguous, provided %d matches",
-			oldRCSelector.String(),
-			len(matches),
-		)
+		return roll_fields.Update{}, AmbiguousRCSelector
 	} else if len(matches) == 1 {
 		oldRCID = rc_fields.ID(matches[0].ID)
 	} else {

--- a/pkg/kp/rollstore/store.go
+++ b/pkg/kp/rollstore/store.go
@@ -1,6 +1,7 @@
 package rollstore
 
 import (
+	"errors"
 	"time"
 
 	"github.com/square/p2/pkg/pods"
@@ -9,6 +10,12 @@ import (
 
 	klabels "github.com/square/p2/Godeps/_workspace/src/k8s.io/kubernetes/pkg/labels"
 )
+
+var AmbiguousRCSelector error = errors.New("The old RC selector was ambigous and produced > 1 matches")
+
+func IsAmbiguousRCSelector(err error) bool {
+	return err == AmbiguousRCSelector
+}
 
 // Store persists Updates into Consul. Updates are uniquely identified by their
 // new RC's ID.


### PR DESCRIPTION
One way to specify the old RC to use when creating an RU is by using a
label selector. If the selector matches more than one RC, an error is
returned.

This commit makes the roll store return a special error type in this
case so that callers can detect this error type and generate more useful
error messages. In Square's application of this function, an error of
this type means that a deploy is already in progress and thus there are
two RCs that match the selector.