### PR TITLE
Add p2-rctl-server to integration test

### DIFF
--- a/bin/p2-rctl/main.go
+++ b/bin/p2-rctl/main.go
@@ -48,6 +48,7 @@ const (
 var (
 	labelEndpoint = kingpin.Flag("labels", "An HTTP endpoint to use for labels, instead of using Consul.").String()
 	logLevel      = kingpin.Flag("log", "Logging level to display.").String()
+	logJSON       = kingpin.Flag("log-json", "Log messages will be JSON formatted").Bool()
 
 	cmdCreate       = kingpin.Command(CMD_CREATE, "Create a new replication controller")
 	createManifest  = cmdCreate.Flag("manifest", "manifest file to use for this replication controller").Short('m').Required().String()
@@ -95,7 +96,11 @@ func main() {
 	cmd, opts := flags.ParseWithConsulOptions()
 
 	logger := logging.NewLogger(logrus.Fields{})
-	logger.Logger.Formatter = &logrus.TextFormatter{}
+	if *logJSON {
+		logger.Logger.Formatter = &logrus.JSONFormatter{}
+	} else {
+		logger.Logger.Formatter = &logrus.TextFormatter{}
+	}
 	if *logLevel != "" {
 		lv, err := logrus.ParseLevel(*logLevel)
 		if err != nil {

--- a/integration/travis.sh
+++ b/integration/travis.sh
@@ -11,6 +11,7 @@ sudo /sbin/start runsvdir
 sudo mkdir -p /etc/servicebuilder.d /var/service-stage /var/service
 
 sudo cp $GOPATH/bin/p2-exec /usr/local/bin
+PATH=$PATH:$GOPATH/bin
 
 # make ssl certs
 subj="

--- a/integration/travis.sh
+++ b/integration/travis.sh
@@ -4,6 +4,7 @@ set -ex
 
 sudo groupadd nobody
 sudo useradd hello
+sudo useradd p2-rctl-server
 
 sudo /sbin/stop runsvdir
 sudo sed -i -e 's;/usr/sbin/runsvdir-start;/usr/bin/runsvdir /var/service;g' /etc/init/runsvdir.conf

--- a/pkg/labels/consul_applicator.go
+++ b/pkg/labels/consul_applicator.go
@@ -237,6 +237,7 @@ func (c *consulApplicator) WatchMatches(selector labels.Selector, labelType Type
 	aggregator, ok := c.aggregators[labelType]
 	if !ok {
 		aggregator = NewConsulAggregator(labelType, c.kv, c.logger)
+		go aggregator.Aggregate()
 		c.aggregators[labelType] = aggregator
 	}
 	return aggregator.Watch(selector, quitCh)


### PR DESCRIPTION
This change expands the role of the integration test to run
a p2-rctl-server. Instead of scheduling a `hello` pod directly
on the host, we instead create a `hello` replication controller
and verify that hello gets correctly scheduled on the host
running the integration test.

One of the new conditions verified is that the `hello` pod gets
labeled with the RC that scheduled it in the label tree. This
exercises the relatively new label aggregation and watch behavior.

This change was relatively painless. The next step is to actually
attempt a rolling update through the same p2-rctl-server.