### PR TITLE
Remove a common log line in rc farm

### DIFF
--- a/pkg/rc/farm.go
+++ b/pkg/rc/farm.go
@@ -143,7 +143,6 @@ START_LOOP:
 				// the nature of this function is that we (or another farm) will come back to it and the lock will be
 				// grabbed. Shortening the length of time it takes to process a list of RCs is paramount.
 				if rcField.LockedForOwnership {
-					rcLogger.WithField("rc", rcField.ID).Infof("Ignoring RC %s because it is already locked", rcField.ID)
 					continue
 				}
 


### PR DESCRIPTION
In steady state, all RCs are locked and the RC farm was emitting a log
message for each RC it encounters that is already locked. This
contributes to a lot of log lines that are not very informative. This
commit removes that