### PR TITLE
rollstore: If created an old RC, apply new RC's labels

### DIFF
--- a/pkg/kp/rollstore/consul_store.go
+++ b/pkg/kp/rollstore/consul_store.go
@@ -419,6 +419,12 @@ func (s consulStore) CreateRollingUpdateFromOneMaybeExistingWithLabelSelector(
 
 			// Any labels we wrote will be deleted by rcstore.Delete()
 		}
+
+		// Copy the new RC labels to the old RC as well
+		err = s.labeler.SetLabels(labels.RC, oldRCID.String(), newRCLabels)
+		if err != nil {
+			return roll_fields.Update{}, err
+		}
 	}
 
 	// Lock the old RC to guarantee that no new updates can use it

--- a/pkg/kp/rollstore/consul_store_test.go
+++ b/pkg/kp/rollstore/consul_store_test.go
@@ -546,6 +546,14 @@ func TestCreateRollingUpdateFromOneMaybeExistingWithLabelSelectorWhenDoesntExist
 	if rcLabels.Labels["some_key"] != "some_val" {
 		t.Errorf("Expected labels to be set on new RC")
 	}
+
+	rcLabels, err = rollstore.labeler.GetLabels(labels.RC, u.OldRC.String())
+	if err != nil {
+		t.Fatalf("Unable to fetch labels for newly created old RC: %s", err)
+	}
+	if rcLabels.Labels["some_key"] != "some_val" {
+		t.Errorf("Expected labels to be set on old RC")
+	}
 }
 
 func TestCreateRollingUpdateFromOneMaybeExistingWithLabelSelectorWhenExists(t *testing.T) {


### PR DESCRIPTION
Since we expect the old RC to be a copy of the new one, then we should
copy the labels as well, except that was not done.

Not copying the labels results in some schemes that assume the label
presence to not be able to find the old RC (since it has no labels).