### PR TITLE
Check for existing Pod Clusters on creation

### DIFF
--- a/pkg/kp/constants.go
+++ b/pkg/kp/constants.go
@@ -3,6 +3,7 @@ package kp
 import (
 	"path"
 
+	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
 )
@@ -15,7 +16,6 @@ const (
 	INTENT_TREE  PodPrefix = "intent"
 	REALITY_TREE PodPrefix = "reality"
 	HOOK_TREE    PodPrefix = "hooks"
-	LOCK_TREE    string    = "lock"
 )
 
 func nodePath(podPrefix PodPrefix, nodeName string) (string, error) {
@@ -55,5 +55,5 @@ func PodLockPath(podPrefix PodPrefix, nodeName string, podId types.PodID) (strin
 		return "", err
 	}
 
-	return path.Join(LOCK_TREE, subPodPath), nil
+	return path.Join(consulutil.LOCK_TREE, subPodPath), nil
 }

--- a/pkg/kp/consulutil/session.go
+++ b/pkg/kp/consulutil/session.go
@@ -9,6 +9,10 @@ import (
 	"github.com/square/p2/pkg/util"
 )
 
+const (
+	LOCK_TREE = "lock"
+)
+
 // attempts to acquire the lock on the targeted key. keys used for
 // locking/synchronization should be ephemeral (ie their value does not matter
 // and you don't care if they're deleted)

--- a/pkg/kp/kptest/fake_session.go
+++ b/pkg/kp/kptest/fake_session.go
@@ -23,6 +23,10 @@ type fakeSession struct {
 	locksHeld map[string]bool
 }
 
+func NewSession() kp.Session {
+	return newFakeSession(map[string]bool{}, sync.Mutex{}, make(chan error))
+}
+
 func newFakeSession(globalLocks map[string]bool, lockMutex sync.Mutex, renewalErrCh chan error) kp.Session {
 	return &fakeSession{
 		locks:        globalLocks,

--- a/pkg/kp/pcstore/consul_store.go
+++ b/pkg/kp/pcstore/consul_store.go
@@ -49,7 +49,7 @@ func (s *consulStore) Create(
 ) (fields.PodCluster, error) {
 	id := fields.ID(uuid.New())
 
-	unlocker, err := s.lockForUpdateCreation(podID, availabilityZone, clusterName, session)
+	unlocker, err := s.lockForCreation(podID, availabilityZone, clusterName, session)
 	if err != nil {
 		return fields.PodCluster{}, err
 	}
@@ -159,7 +159,7 @@ func (s *consulStore) pcPath(pcID fields.ID) (string, error) {
 	return path.Join(podClusterTree, pcID.String()), nil
 }
 
-func (s *consulStore) lockForUpdateCreation(podID types.PodID,
+func (s *consulStore) lockForCreation(podID types.PodID,
 	availabilityZone fields.AvailabilityZone,
 	clusterName fields.ClusterName,
 	session Session) (consulutil.Unlocker, error) {

--- a/pkg/kp/pcstore/consul_store.go
+++ b/pkg/kp/pcstore/consul_store.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"path"
 
-	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/pc/fields"
@@ -169,7 +168,7 @@ func (s *consulStore) lockForCreation(podID types.PodID,
 func pcCreateLockPath(podID types.PodID,
 	availabilityZone fields.AvailabilityZone,
 	clusterName fields.ClusterName) string {
-	return path.Join(kp.LOCK_TREE, podID.String(), availabilityZone.String(), clusterName.String())
+	return path.Join(consulutil.LOCK_TREE, podID.String(), availabilityZone.String(), clusterName.String())
 }
 
 func (s *consulStore) FindWhereLabeled(podID types.PodID,

--- a/pkg/kp/pcstore/pcstoretest/fake_pcstore.go
+++ b/pkg/kp/pcstore/pcstoretest/fake_pcstore.go
@@ -29,6 +29,7 @@ func (p *FakePCStore) Create(
 	clusterName fields.ClusterName,
 	podSelector klabels.Selector,
 	annotations fields.Annotations,
+	_ pcstore.Session,
 ) (fields.PodCluster, error) {
 	id := fields.ID(uuid.New())
 	pc := fields.PodCluster{
@@ -55,4 +56,20 @@ func (p *FakePCStore) Get(id fields.ID) (fields.PodCluster, error) {
 func (p *FakePCStore) Delete(id fields.ID) error {
 	delete(p.podClusters, id)
 	return nil
+}
+
+func (p *FakePCStore) FindWhereLabeled(
+	podID types.PodID,
+	availabilityZone fields.AvailabilityZone,
+	clusterName fields.ClusterName,
+) ([]fields.PodCluster, error) {
+	ret := []fields.PodCluster{}
+	for _, pc := range p.podClusters {
+		if availabilityZone == pc.AvailabilityZone &&
+			clusterName == pc.Name &&
+			podID == pc.PodID {
+			ret = append(ret, pc)
+		}
+	}
+	return ret, nil
 }

--- a/pkg/kp/rcstore/consul_store.go
+++ b/pkg/kp/rcstore/consul_store.go
@@ -593,7 +593,7 @@ func (s *consulStore) Watch(rc *fields.RC, quit <-chan struct{}) (<-chan struct{
 }
 
 func (s *consulStore) rcLockRoot() string {
-	return path.Join(kp.LOCK_TREE, rcTree)
+	return path.Join(consulutil.LOCK_TREE, rcTree)
 }
 
 func (s *consulStore) rcPath(rcID fields.ID) (string, error) {
@@ -610,7 +610,7 @@ func (s *consulStore) rcLockPath(rcID fields.ID) (string, error) {
 		return "", err
 	}
 
-	return path.Join(kp.LOCK_TREE, rcPath), nil
+	return path.Join(consulutil.LOCK_TREE, rcPath), nil
 }
 
 // The path for an ownership lock is simply the base path
@@ -691,7 +691,7 @@ func (s *consulStore) lockTypeFromKey(key string) (fields.ID, LockType, error) {
 		return "", UnknownLockType, util.Errorf("Key '%s' does not resemble an RC lock", key)
 	}
 
-	if keyParts[0] != kp.LOCK_TREE {
+	if keyParts[0] != consulutil.LOCK_TREE {
 		return "", UnknownLockType, util.Errorf("Key '%s' does not resemble an RC lock", key)
 	}
 

--- a/pkg/kp/rcstore/store_test.go
+++ b/pkg/kp/rcstore/store_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/kp/kptest"
 	"github.com/square/p2/pkg/rc/fields"
 )
@@ -25,7 +25,7 @@ func TestLockForOwnership(t *testing.T) {
 		t.Fatalf("Unable to lock rc for ownership: %s", err)
 	}
 
-	expectedKey := fmt.Sprintf("%s/%s/%s", kp.LOCK_TREE, rcTree, testRCId)
+	expectedKey := fmt.Sprintf("%s/%s/%s", consulutil.LOCK_TREE, rcTree, testRCId)
 	if unlocker.Key() != expectedKey {
 		t.Errorf("Key did not match expected: wanted '%s' but got '%s'", expectedKey, unlocker.Key())
 	}
@@ -45,7 +45,7 @@ func TestLockForMutation(t *testing.T) {
 		t.Fatalf("Unable to lock rc for mutation: %s", err)
 	}
 
-	expectedKey := fmt.Sprintf("%s/%s/%s/%s", kp.LOCK_TREE, rcTree, testRCId, mutationSuffix)
+	expectedKey := fmt.Sprintf("%s/%s/%s/%s", consulutil.LOCK_TREE, rcTree, testRCId, mutationSuffix)
 	if unlocker.Key() != expectedKey {
 		t.Errorf("Key did not match expected: wanted '%s' but got '%s'", expectedKey, unlocker.Key())
 	}
@@ -65,7 +65,7 @@ func TestLockForUpdateCreation(t *testing.T) {
 		t.Fatalf("Unable to lock rc for update creation: %s", err)
 	}
 
-	expectedKey := fmt.Sprintf("%s/%s/%s/%s", kp.LOCK_TREE, rcTree, testRCId, updateCreationSuffix)
+	expectedKey := fmt.Sprintf("%s/%s/%s/%s", consulutil.LOCK_TREE, rcTree, testRCId, updateCreationSuffix)
 	if unlocker.Key() != expectedKey {
 		t.Errorf("Key did not match expected: wanted '%s' but got '%s'", expectedKey, unlocker.Key())
 	}

--- a/pkg/kp/rollstore/consul_store.go
+++ b/pkg/kp/rollstore/consul_store.go
@@ -624,7 +624,7 @@ func RollLockPath(id roll_fields.ID) (string, error) {
 		return "", err
 	}
 
-	return path.Join(kp.LOCK_TREE, subRollPath), nil
+	return path.Join(consulutil.LOCK_TREE, subRollPath), nil
 }
 
 func kvpToRU(kvp *api.KVPair) (roll_fields.Update, error) {

--- a/pkg/kp/rollstore/consul_store_test.go
+++ b/pkg/kp/rollstore/consul_store_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/kp/kptest"
 	"github.com/square/p2/pkg/kp/rcstore"
 	"github.com/square/p2/pkg/labels"
@@ -73,7 +73,7 @@ func TestRollLockPath(t *testing.T) {
 		t.Fatalf("Unable to compute roll lock path: %s", err)
 	}
 
-	expected := fmt.Sprintf("%s/%s/%s", kp.LOCK_TREE, rollTree, testRCId)
+	expected := fmt.Sprintf("%s/%s/%s", consulutil.LOCK_TREE, rollTree, testRCId)
 	if rollLockPath != expected {
 		t.Errorf("Unexpected value for rollLockPath, wanted '%s' got '%s'",
 			expected,


### PR DESCRIPTION
This adds a required Session argument to pod cluster creation, ensuring that the pod cluster for a given 3-ple of pod ID, availability zone, and cluster name does not already exist.