### PR TITLE
pcstore implements Watch()

### DIFF
--- a/pkg/kp/consulutil/watch.go
+++ b/pkg/kp/consulutil/watch.go
@@ -22,6 +22,7 @@ func WatchPrefix(
 	done <-chan struct{},
 	outErrors chan<- error,
 ) {
+	// TODO return this for closing on the client side
 	defer close(outPairs)
 	var currentIndex uint64
 	timer := time.NewTimer(time.Duration(0))

--- a/pkg/kp/kptest/fake_kv.go
+++ b/pkg/kp/kptest/fake_kv.go
@@ -22,7 +22,7 @@ func NewFakeKV() *FakeKV {
 }
 
 func (f *FakeKV) Get(key string, opts *api.QueryOptions) (*api.KVPair, *api.QueryMeta, error) {
-	return f.kvPairs[key], nil, nil
+	return f.kvPairs[key], &api.QueryMeta{}, nil
 }
 
 func (f *FakeKV) List(prefix string, opts *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error) {
@@ -33,7 +33,7 @@ func (f *FakeKV) List(prefix string, opts *api.QueryOptions) (api.KVPairs, *api.
 		}
 	}
 
-	return res, nil, nil
+	return res, &api.QueryMeta{}, nil
 }
 
 // The fake implementation of this is just the same as writing a key, we expect

--- a/pkg/kp/pcstore/store.go
+++ b/pkg/kp/pcstore/store.go
@@ -18,9 +18,15 @@ type Session interface {
 	Lock(key string) (consulutil.Unlocker, error)
 }
 
+// WatchedPodCluster is an Either type: it will have 1 one of pc xor err
+type WatchedPodCluster struct {
+	PodCluster *fields.PodCluster
+	Err        error
+}
+
 type Store interface {
 	Create(
-		podId types.PodID,
+		podID types.PodID,
 		availabilityZone fields.AvailabilityZone,
 		clusterName fields.ClusterName,
 		podSelector klabels.Selector,
@@ -37,6 +43,8 @@ type Store interface {
 		clusterName fields.ClusterName,
 	) ([]fields.PodCluster, error)
 	Delete(id fields.ID) error
+	WatchPodCluster(id fields.ID, quit <-chan struct{}) <-chan WatchedPodCluster
+	Watch(quit <-chan struct{}) <-chan WatchedPodCluster
 }
 
 func IsNotExist(err error) bool {


### PR DESCRIPTION
This is an early pass at implement Watch() for pcstore. It is explicitly missing a filter on the ID parameter inside of the watch function. I'm likely to do the naive thing unless someone suggests something more clever.