### PR TITLE
When watching the pod cluster tree, return the full set of pod clusters

### DIFF
--- a/pkg/kp/pcstore/pcstoretest/fake_pcstore.go
+++ b/pkg/kp/pcstore/pcstoretest/fake_pcstore.go
@@ -76,8 +76,8 @@ func (p *FakePCStore) FindWhereLabeled(
 	return ret, nil
 }
 
-func (p *FakePCStore) Watch(quit <-chan struct{}) <-chan pcstore.WatchedPodCluster {
-	ret := make(chan pcstore.WatchedPodCluster)
+func (p *FakePCStore) Watch(quit <-chan struct{}) <-chan pcstore.WatchedPodClusters {
+	ret := make(chan pcstore.WatchedPodClusters)
 
 	go func() {
 		for {
@@ -86,12 +86,20 @@ func (p *FakePCStore) Watch(quit <-chan struct{}) <-chan pcstore.WatchedPodClust
 				return
 			default:
 			}
+
+			clusters := pcstore.WatchedPodClusters{}
 			for _, ch := range p.watchers {
 				select {
-				case pc := <-ch:
-					ret <- pc
+				case watched := <-ch:
+					clusters.Clusters = append(clusters.Clusters, watched.PodCluster)
 				default:
 				}
+			}
+
+			select {
+			case ret <- clusters:
+			case <-quit:
+				return
 			}
 		}
 	}()

--- a/pkg/kp/pcstore/store.go
+++ b/pkg/kp/pcstore/store.go
@@ -24,6 +24,11 @@ type WatchedPodCluster struct {
 	Err        error
 }
 
+type WatchedPodClusters struct {
+	Clusters []*fields.PodCluster
+	Err      error
+}
+
 type Store interface {
 	Create(
 		podID types.PodID,
@@ -44,7 +49,7 @@ type Store interface {
 	) ([]fields.PodCluster, error)
 	Delete(id fields.ID) error
 	WatchPodCluster(id fields.ID, quit <-chan struct{}) <-chan WatchedPodCluster
-	Watch(quit <-chan struct{}) <-chan WatchedPodCluster
+	Watch(quit <-chan struct{}) <-chan WatchedPodClusters
 }
 
 func IsNotExist(err error) bool {


### PR DESCRIPTION
the full set of all pod clusters, not just individuals.

This makes the pc store match the same pattern as the
preparer's pod watch, allowing both addition and deletion
to be supported.