### PR TITLE
Fix a potential deadlock in fake pcstore

### DIFF
--- a/pkg/kp/pcstore/pcstoretest/fake_pcstore.go
+++ b/pkg/kp/pcstore/pcstoretest/fake_pcstore.go
@@ -43,7 +43,9 @@ func (p *FakePCStore) Create(
 	}
 
 	p.podClusters[id] = pc
-	p.watchers[id] <- pcstore.WatchedPodCluster{PodCluster: &pc, Err: nil}
+	if watcher, ok := p.watchers[id]; ok {
+		watcher <- pcstore.WatchedPodCluster{PodCluster: &pc, Err: nil}
+	}
 	return pc, nil
 }
 


### PR DESCRIPTION
The Create() function on the fake pcstore does not check if a watcher
exists before attempting to write to it, which can cause deadlocks in
tests that depend on it.