### PR TITLE
Drop privs in the default log exec

### DIFF
--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -39,7 +39,6 @@ const DEFAULT_PATH = "/data/pods"
 const DefaultP2Exec = "/usr/local/bin/p2-exec"
 
 var DefaultFinishExec = []string{"/bin/true"} // type must match preparerconfig
-var DefaultLogExec = []string{"svlogd", "-tt", "./main"}
 
 func init() {
 	Log = logging.NewLogger(logrus.Fields{})
@@ -70,7 +69,7 @@ func NewPod(id types.PodID, path string) *Pod {
 		ServiceBuilder: runit.DefaultBuilder,
 		P2Exec:         DefaultP2Exec,
 		DefaultTimeout: 60 * time.Second,
-		LogExec:        DefaultLogExec,
+		LogExec:        runit.DefaultLogExec,
 		FinishExec:     DefaultFinishExec,
 	}
 }

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -265,7 +265,7 @@ func TestBuildRunitServices(t *testing.T) {
 		Id:             "testPod",
 		path:           "/data/pods/testPod",
 		ServiceBuilder: serviceBuilder,
-		LogExec:        DefaultLogExec,
+		LogExec:        runit.DefaultLogExec,
 		FinishExec:     DefaultFinishExec,
 	}
 	hl, sb := hoist.FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
@@ -287,12 +287,12 @@ func TestBuildRunitServices(t *testing.T) {
 	expectedMap := map[string]runit.ServiceTemplate{
 		executables[0].Service.Name: runit.ServiceTemplate{
 			Run:    executables[0].Exec,
-			Log:    DefaultLogExec,
+			Log:    runit.DefaultLogExec,
 			Finish: pod.FinishExecForLaunchable(testLaunchable),
 		},
 		executables[1].Service.Name: runit.ServiceTemplate{
 			Run:    executables[1].Exec,
-			Log:    DefaultLogExec,
+			Log:    runit.DefaultLogExec,
 			Finish: pod.FinishExecForLaunchable(testLaunchable),
 		},
 	}

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -19,6 +19,7 @@ import (
 	"github.com/square/p2/pkg/launch"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/runit"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
 	"github.com/square/p2/pkg/util/param"
@@ -359,7 +360,7 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 	if len(preparerConfig.LogExec) > 0 {
 		logExec = preparerConfig.LogExec
 	} else {
-		logExec = pods.DefaultLogExec
+		logExec = runit.DefaultLogExec
 	}
 
 	var finishExec []string

--- a/pkg/runit/servicebuilder.go
+++ b/pkg/runit/servicebuilder.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/square/p2/pkg/p2exec"
 	"github.com/square/p2/pkg/util"
 
 	"github.com/square/p2/Godeps/_workspace/src/gopkg.in/yaml.v2"
@@ -47,6 +48,11 @@ const (
 // To maintain compatibility with Ruby1.8's YAML serializer, a document separator with a
 // trailing space must be used.
 const yamlSeparator = "--- "
+
+var DefaultLogExec = p2exec.P2ExecArgs{
+	User:    "nobody",
+	Command: []string{"svlogd", "-tt", "./main"},
+}.CommandLine()
 
 type ServiceTemplate struct {
 	Run      []string `yaml:"run"`
@@ -95,7 +101,7 @@ func (s ServiceTemplate) logScript() ([]byte, error) {
 	if len(log) == 0 {
 		// use a default log script that makes a logdir, chowns it and execs
 		// svlogd into it
-		log = []string{"chpst", "-unobody", "svlogd", "-tt", "./main"}
+		log = DefaultLogExec
 	}
 
 	args, err := yaml.Marshal(log)


### PR DESCRIPTION
If we don't do this, we end up running a process as the root user.