### PR TITLE
remove unused variable

### DIFF
--- a/pkg/runit/servicebuilder.go
+++ b/pkg/runit/servicebuilder.go
@@ -121,7 +121,6 @@ func (s ServiceTemplate) finishScript() ([]byte, error) {
 		finish_exec = []string{"/bin/true", "# finish not implemented"}
 	}
 	finishScript := fmt.Sprintf(`#!/bin/bash
-exit_code=$1
 %s
 `, strings.Join(finish_exec, " "))
 


### PR DESCRIPTION
```    finish_exec:
      - /data/pods/p2-preparer/p2-finish/current/bin/extract_from_env.rb
      - '$1'
      - '$2'
      - '|'
      - base64
      - '-w0'
      - '|'
      - socat
      - '-'
      - UNIX-CONNECT:/data/pods/p2-preparer/tmp/p2-finish.sock```

Is what we're using in production.