### PR TITLE
Implement `WatchAndSync` for pcstore

### DIFF
--- a/pkg/kp/pcstore/consul_store.go
+++ b/pkg/kp/pcstore/consul_store.go
@@ -361,6 +361,9 @@ func (s *consulStore) WatchAndSync(syncer ConcreteSyncer, quit <-chan struct{}) 
 	return nil
 }
 
+// zipResults takes two sets of watched pod clusters and joins them such that they
+// are paired together in a map of pc ID -> change objects. Each change will be sent
+// to the respective sync channels of each pod cluster later on.
 func (s *consulStore) zipResults(current, previous WatchedPodClusters) map[fields.ID]podClusterChange {
 	allPrevious := make(map[fields.ID]*fields.PodCluster)
 	for _, prev := range previous.Clusters {
@@ -389,9 +392,6 @@ func (s *consulStore) zipResults(current, previous WatchedPodClusters) map[field
 // If a change fails to take, this function will retry that change forever until
 // it works as expected or a newer change appears on the channel. This routine also
 // executes and monitors the label watch for the pod's label selector.
-// TODO: since most of this code is generic to pod cluster syncers, this will likely
-// be extracted to github.com/square/p2. The P2 VIP agent, for f5 syncing, will still
-// implement ConcreteSyncer, whose methods are implemented below.
 func (s *consulStore) handlePCUpdates(concrete ConcreteSyncer, changes chan podClusterChange) {
 	var change podClusterChange
 	podWatch := make(chan []labels.Labeled)

--- a/pkg/kp/pcstore/consul_store.go
+++ b/pkg/kp/pcstore/consul_store.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"path"
 
+	"github.com/square/p2/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/api"
 	"github.com/square/p2/Godeps/_workspace/src/github.com/pborman/uuid"
 	klabels "github.com/square/p2/Godeps/_workspace/src/k8s.io/kubernetes/pkg/labels"
@@ -306,6 +307,145 @@ func (s *consulStore) WatchPodCluster(id fields.ID, quit <-chan struct{}) <-chan
 	}()
 
 	return outCh
+}
+
+type podClusterChange struct {
+	previous *fields.PodCluster
+	current  *fields.PodCluster
+}
+
+func (s *consulStore) WatchAndSync(syncer ConcreteSyncer, quit <-chan struct{}) error {
+	watchedRes := s.Watch(quit)
+
+	clusterUpdaters := map[fields.ID]chan podClusterChange{}
+	defer func() {
+		for _, handler := range clusterUpdaters {
+			close(handler)
+		}
+	}()
+
+	// TODO: change to a reality query when status endpoint is set up.
+	var prevResults WatchedPodClusters
+	for {
+		select {
+		case curResults := <-watchedRes:
+			if curResults.Err != nil {
+				s.logger.WithError(curResults.Err).Errorln("Could not sync pod clusters")
+				continue
+			}
+			// zip up the previous and current results, act based on the difference.
+			zipped := s.zipResults(curResults, prevResults)
+			for id, change := range zipped {
+				updater, ok := clusterUpdaters[id]
+				if !ok {
+					clusterUpdaters[id] = make(chan podClusterChange)
+					go s.handlePCUpdates(syncer, clusterUpdaters[id])
+					updater = clusterUpdaters[id]
+				}
+				select {
+				case updater <- change:
+					if change.previous != nil && change.current == nil {
+						close(clusterUpdaters[id])
+						delete(clusterUpdaters, id)
+					}
+				case <-quit:
+					return nil
+				}
+			}
+			prevResults = curResults
+		case <-quit:
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func (s *consulStore) zipResults(current, previous WatchedPodClusters) map[fields.ID]podClusterChange {
+	allPrevious := make(map[fields.ID]*fields.PodCluster)
+	for _, prev := range previous.Clusters {
+		allPrevious[prev.ID] = prev
+	}
+	ret := map[fields.ID]podClusterChange{}
+	for _, cur := range current.Clusters {
+		prev, ok := allPrevious[cur.ID]
+		ret[cur.ID] = podClusterChange{
+			previous: prev,
+			current:  cur,
+		}
+		if ok {
+			delete(allPrevious, cur.ID)
+		}
+	}
+	for _, prev := range allPrevious {
+		ret[prev.ID] = podClusterChange{
+			previous: prev,
+		}
+	}
+	return ret
+}
+
+// try forever to match the expectations as defined in the provided change channel.
+// If a change fails to take, this function will retry that change forever until
+// it works as expected or a newer change appears on the channel. This routine also
+// executes and monitors the label watch for the pod's label selector.
+// TODO: since most of this code is generic to pod cluster syncers, this will likely
+// be extracted to github.com/square/p2. The P2 VIP agent, for f5 syncing, will still
+// implement ConcreteSyncer, whose methods are implemented below.
+func (s *consulStore) handlePCUpdates(concrete ConcreteSyncer, changes chan podClusterChange) {
+	var change podClusterChange
+	podWatch := make(chan []labels.Labeled)
+	podWatchQuit := make(chan struct{})
+	defer func() {
+		close(podWatchQuit)
+	}()
+
+	for {
+		var ok bool
+
+		select {
+		case labeledPods := <-podWatch:
+			s.logger.Debugf("Calling SyncCluster with %v / %v", change.current, labeledPods)
+			concrete.SyncCluster(change.current, labeledPods)
+		case change, ok = <-changes:
+			if !ok {
+				return // we're closed for business
+			}
+
+			if change.current == nil && change.previous != nil {
+				// if no current cluster exists, but there is a previous cluster,
+				// it means we need to destroy this concrete cluster
+				s.logger.WithField("pc_id", change.previous.ID).Infof("Calling DeleteCluster with %v", change.previous)
+				err := concrete.DeleteCluster(change.previous)
+				if err != nil {
+					s.logger.Errorf("Deletion of cluster failed! %v", err)
+				} else {
+					return
+				}
+			} else if change.current != nil && change.previous != nil {
+				// if there's a current and a previous pod cluster, update concrete cluster metadata and
+				// refresh the pod selector watch if it changed
+				if change.current.PodSelector.String() != change.previous.PodSelector.String() {
+					close(podWatchQuit)
+					podWatchQuit = make(chan struct{})
+					s.logger.WithFields(logrus.Fields{
+						"pc_id":        change.current.ID,
+						"old_selector": change.previous.PodSelector.String(),
+						"new_selector": change.current.PodSelector.String(),
+					}).Debugf("Altering pod selector for %v", change.current.ID)
+					podWatch = s.applicator.WatchMatches(change.current.PodSelector, labels.POD, podWatchQuit)
+				}
+			} else {
+				// if there's no previous pod cluster but there is a current, create the concrete cluster
+				// and start a pod selector watch.
+				s.logger.WithFields(logrus.Fields{
+					"pc_id":    change.current.ID,
+					"selector": change.current.PodSelector.String(),
+				}).Debugf("Starting pod selector watch for %v", change.current.ID)
+				podWatch = s.applicator.WatchMatches(change.current.PodSelector, labels.POD, podWatchQuit)
+			}
+		}
+	}
 }
 
 func kvpsToPC(pairs api.KVPairs) ([]fields.PodCluster, error) {

--- a/pkg/kp/pcstore/consul_store_test.go
+++ b/pkg/kp/pcstore/consul_store_test.go
@@ -1,14 +1,17 @@
 package pcstore
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/square/p2/pkg/kp/kptest"
 	"github.com/square/p2/pkg/labels"
+	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pc/fields"
 	"github.com/square/p2/pkg/types"
 
+	"github.com/square/p2/Godeps/_workspace/src/github.com/Sirupsen/logrus"
 	klabels "github.com/square/p2/Godeps/_workspace/src/k8s.io/kubernetes/pkg/labels"
 )
 
@@ -313,9 +316,263 @@ func TestWatchPodCluster(t *testing.T) {
 	}
 }
 
+func TestZipPodClusterResults(t *testing.T) {
+	store := consulStore{}
+
+	previous := WatchedPodClusters{
+		[]*fields.PodCluster{
+			{
+				ID:    fields.ID("abc123"),
+				PodID: types.PodID("vvv"),
+				Name:  "old name 1",
+			},
+			{
+				ID:    fields.ID("def456"),
+				PodID: types.PodID("xxx"),
+				Name:  "old name 2",
+			},
+		},
+		nil,
+	}
+
+	current := WatchedPodClusters{
+		[]*fields.PodCluster{
+			{
+				ID:    fields.ID("abc123"),
+				PodID: types.PodID("vvv"),
+				Name:  "new name 1",
+			},
+
+			{
+				ID:    fields.ID("987fed"),
+				PodID: types.PodID("zzz"),
+				Name:  "new name 3",
+			},
+		},
+		nil,
+	}
+
+	zipped := store.zipResults(current, previous)
+
+	if len(zipped) != 3 {
+		t.Errorf("Unexpected number of clusters in zipped results: %v", len(zipped))
+	}
+
+	updated := zipped[fields.ID("abc123")]
+	if updated.previous == nil || updated.current == nil {
+		t.Fatalf("Either (%v) or (%v) is nil, but neither should be", updated.previous, updated.current)
+	}
+
+	if updated.current.Name != "new name 1" {
+		t.Errorf("%v was not the right name for the current cluster", updated.current.Name)
+	}
+
+	if updated.previous.Name != "old name 1" {
+		t.Errorf("%v was not the right name for the previous cluster", updated.previous.Name)
+	}
+
+	onlyOld := zipped[fields.ID("def456")]
+	if onlyOld.current != nil {
+		t.Error("cluster onlyOld should not have had a current cluster")
+	}
+
+	if onlyOld.previous == nil {
+		t.Fatalf("the previous cluster should not have been nil")
+	}
+
+	if onlyOld.previous.Name != "old name 2" {
+		t.Errorf("The old name %v was wrong for the cluster", onlyOld.previous.Name)
+	}
+
+	onlyNew := zipped[fields.ID("987fed")]
+	if onlyNew.previous != nil {
+		t.Error("cluster onlyNew should not have had a previous cluster")
+	}
+
+	if onlyNew.current == nil {
+		t.Fatalf("the current cluster should not have been nil")
+	}
+
+	if onlyNew.current.Name != "new name 3" {
+		t.Errorf("The old name %v was wrong for the cluster", onlyNew.current.Name)
+	}
+}
+
+type fakeSync struct {
+	syncedCluster *fields.PodCluster
+	syncedPods    []labels.Labeled
+}
+
+type fakeSyncer struct {
+	synced  chan fakeSync
+	deleted chan fakeSync
+	ignore  bool
+}
+
+func (f *fakeSyncer) SyncCluster(cluster *fields.PodCluster, pods []labels.Labeled) error {
+	if f.ignore {
+		fmt.Printf("fake: Ignoring update for %v/%v\n", cluster, pods)
+		return nil
+	}
+	f.synced <- fakeSync{
+		syncedCluster: cluster,
+		syncedPods:    pods,
+	}
+	return nil
+}
+
+func (f *fakeSyncer) DeleteCluster(cluster *fields.PodCluster) error {
+	f.deleted <- fakeSync{
+		syncedCluster: cluster,
+	}
+	return nil
+}
+
+func (f *fakeSyncer) drainSyncedAndIgnore() {
+	f.ignore = true
+	timeout := time.After(5 * time.Second)
+	for {
+		select {
+		case <-timeout:
+			panic("Couldn't drain syncer channels")
+		case synced := <-f.synced:
+			fmt.Printf("fake: Draining result for %v\n", synced)
+		default:
+			return
+		}
+	}
+}
+
+func (f *fakeSyncer) resume() {
+	f.ignore = false
+}
+
+// this test simulates creating, updating, and deleting a pod cluster.
+// the update step will change the pod selector and should result in a
+// different pod ID being returned.
+func TestConcreteSyncer(t *testing.T) {
+	store := consulStoreWithFakeKV()
+	store.logger.Logger.Level = logrus.DebugLevel
+
+	store.applicator.SetLabel(labels.POD, "1234-123-123-1234", "color", "red")
+	store.applicator.SetLabel(labels.POD, "abcd-abc-abc-abcd", "color", "blue")
+
+	syncer := &fakeSyncer{
+		make(chan fakeSync),
+		make(chan fakeSync),
+		false,
+	}
+
+	change := podClusterChange{
+		previous: nil,
+		current: &fields.PodCluster{
+			ID:               fields.ID("abc123"),
+			PodID:            types.PodID("vvv"),
+			AvailabilityZone: fields.AvailabilityZone("west"),
+			Name:             "production",
+			PodSelector:      klabels.Everything().Add("color", klabels.EqualsOperator, []string{"red"}),
+		},
+	}
+
+	changes := make(chan podClusterChange)
+	go store.handlePCUpdates(syncer, changes)
+
+	select {
+	case changes <- change:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Test timed out trying to write change to handlePCChange")
+	}
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("Test timed out trying to read from the syncer")
+	case sync := <-syncer.synced:
+		if sync.syncedCluster == nil {
+			t.Fatal("unexpectedly didn't get a cluster on the sync channel")
+		}
+		if sync.syncedCluster.ID != change.current.ID {
+			t.Fatalf("got unexpected synced cluster %v", sync.syncedCluster.ID)
+		}
+		if len(sync.syncedPods) != 1 {
+			t.Fatalf("got unexpected number of synced pods with cluster: %v", len(sync.syncedPods))
+		}
+		if sync.syncedPods[0].ID != "1234-123-123-1234" {
+			t.Fatalf("got unexpected pod ID from labeled pods sync: %v", sync.syncedPods[0].ID)
+		}
+	}
+
+	// now we send a new update that changes the pod cluster's target pod from the red one to the blue one.
+	// (from 1234-123-123-1234 to abcd-abc-abc-abcd )
+	change = podClusterChange{
+		previous: change.current,
+		current: &fields.PodCluster{
+			ID:               fields.ID("abc123"),
+			PodID:            types.PodID("vvv"),
+			AvailabilityZone: fields.AvailabilityZone("west"),
+			Name:             "production",
+			PodSelector:      klabels.Everything().Add("color", klabels.EqualsOperator, []string{"blue"}),
+		},
+	}
+
+	syncer.drainSyncedAndIgnore()
+
+	select {
+	case changes <- change:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Test timed out trying to write change to handlePCChange")
+	}
+
+	syncer.resume()
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("Test timed out trying to read from the syncer")
+	case sync := <-syncer.synced:
+		if sync.syncedCluster == nil {
+			t.Fatal("unexpectedly didn't get a cluster on the sync channel")
+		}
+		if sync.syncedCluster.ID != change.current.ID {
+			t.Fatalf("got unexpected synced cluster %v", sync.syncedCluster.ID)
+		}
+		if len(sync.syncedPods) != 1 {
+			t.Fatalf("got unexpected number of synced pods with cluster: %v", len(sync.syncedPods))
+		}
+		if sync.syncedPods[0].ID != "abcd-abc-abc-abcd" {
+			t.Fatalf("got unexpected pod ID from labeled pods sync: %v", sync.syncedPods[0].ID)
+		}
+	}
+
+	syncer.drainSyncedAndIgnore()
+
+	// appear to have deleted the cluster
+	change.previous = change.current
+	change.current = nil
+
+	select {
+	case changes <- change:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Test timed out trying to write deletion change to handlePCChange")
+	}
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("Test timed out trying to read from the syncer")
+	case sync := <-syncer.deleted:
+		if sync.syncedCluster == nil {
+			t.Fatal("unexpectedly didn't get a cluster on the sync channel")
+		}
+		if sync.syncedCluster.ID != change.previous.ID {
+			t.Fatalf("got unexpected synced cluster %v", sync.syncedCluster.ID)
+		}
+	}
+
+	close(changes)
+}
+
 func consulStoreWithFakeKV() *consulStore {
 	return &consulStore{
 		kv:         kptest.NewFakeKV(),
 		applicator: labels.NewFakeApplicator(),
+		logger:     logging.DefaultLogger,
 	}
 }

--- a/pkg/kp/pcstore/pcstoretest/fake_pcstore.go
+++ b/pkg/kp/pcstore/pcstoretest/fake_pcstore.go
@@ -2,6 +2,7 @@ package pcstoretest
 
 import (
 	"github.com/square/p2/pkg/kp/pcstore"
+	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/pc/fields"
 	"github.com/square/p2/pkg/types"
 
@@ -110,7 +111,18 @@ func (p *FakePCStore) Watch(quit <-chan struct{}) <-chan pcstore.WatchedPodClust
 }
 
 func (p *FakePCStore) WatchAndSync(concrete pcstore.ConcreteSyncer, quit <-chan struct{}) error {
-	panic("not implemented")
+	pods := p.Watch(quit)
+
+	for {
+		select {
+		case <-quit:
+			return nil
+		case watched := <-pods:
+			for _, cluster := range watched.Clusters {
+				_ = concrete.SyncCluster(cluster, []labels.Labeled{})
+			}
+		}
+	}
 }
 
 func (p *FakePCStore) WatchPodCluster(id fields.ID, quit <-chan struct{}) <-chan pcstore.WatchedPodCluster {

--- a/pkg/kp/pcstore/pcstoretest/fake_pcstore.go
+++ b/pkg/kp/pcstore/pcstoretest/fake_pcstore.go
@@ -109,6 +109,10 @@ func (p *FakePCStore) Watch(quit <-chan struct{}) <-chan pcstore.WatchedPodClust
 	return ret
 }
 
+func (p *FakePCStore) WatchAndSync(concrete pcstore.ConcreteSyncer, quit <-chan struct{}) error {
+	panic("not implemented")
+}
+
 func (p *FakePCStore) WatchPodCluster(id fields.ID, quit <-chan struct{}) <-chan pcstore.WatchedPodCluster {
 	return p.watchers[id]
 }

--- a/pkg/kp/pcstore/store.go
+++ b/pkg/kp/pcstore/store.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/square/p2/pkg/kp/consulutil"
+	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/pc/fields"
 	"github.com/square/p2/pkg/types"
 
@@ -50,6 +51,15 @@ type Store interface {
 	Delete(id fields.ID) error
 	WatchPodCluster(id fields.ID, quit <-chan struct{}) <-chan WatchedPodCluster
 	Watch(quit <-chan struct{}) <-chan WatchedPodClusters
+
+	// A convenience method that handles watching pod clusters
+	// as well as the labeled pods in each pod cluster.
+	WatchAndSync(syncer ConcreteSyncer, quit <-chan struct{}) error
+}
+
+type ConcreteSyncer interface {
+	SyncCluster(pc *fields.PodCluster, pods []labels.Labeled) error
+	DeleteCluster(pc *fields.PodCluster) error
 }
 
 func IsNotExist(err error) bool {


### PR DESCRIPTION
The code to watch both pod cluster definitions / annotations and their
labeled pods is complex enough that it warrants being factored into a
common library. Clients need only implement the `pcstore.ConcreteSyncer`
interface and pass it to `store.WatchAndSync(syncer, quitCh)` to implement
a concrete implementation of a pod cluster synchronization loop.