### PR TITLE
Implement checker.WatchHealth

### DIFF
--- a/pkg/health/checker/checker.go
+++ b/pkg/health/checker/checker.go
@@ -7,9 +7,9 @@ import (
 	"github.com/square/p2/pkg/health"
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/kp/consulutil"
+	"github.com/square/p2/pkg/util"
 
 	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/api"
-	"github.com/square/p2/pkg/util"
 )
 
 type ConsulHealthChecker interface {

--- a/pkg/health/checker/checker.go
+++ b/pkg/health/checker/checker.go
@@ -2,6 +2,7 @@ package checker
 
 import (
 	"encoding/json"
+	"square/up/util"
 	"time"
 
 	"github.com/square/p2/pkg/health"
@@ -192,7 +193,7 @@ func kvpsToResult(kvs api.KVPairs) ([]*health.Result, error) {
 		tmp := &health.Result{}
 		err = json.Unmarshal(kv.Value, &tmp)
 		if err != nil {
-			return nil, err
+			return nil, util.Errorf("Could not unmarshal health at %s: %v", kv.Key, err)
 		}
 		result[i] = tmp
 	}

--- a/pkg/health/checker/checker.go
+++ b/pkg/health/checker/checker.go
@@ -11,17 +11,6 @@ import (
 	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/api"
 )
 
-// Subset of kp.Store
-type healthStore interface {
-	GetHealth(service, node string) (kp.WatchResult, error)
-	GetServiceHealth(service string) (map[string]kp.WatchResult, error)
-}
-
-type consulHealthChecker struct {
-	client      *api.Client
-	consulStore healthStore
-}
-
 type ConsulHealthChecker interface {
 	WatchNodeService(
 		nodename string,
@@ -35,9 +24,28 @@ type ConsulHealthChecker interface {
 		resultCh chan<- map[string]health.Result,
 		errCh chan<- error,
 		quitCh <-chan struct{})
+	WatchHealth(
+		resultCh chan<- []*health.Result,
+		errCh chan<- error,
+		quitCh <-chan struct{})
 	Service(serviceID string) (map[string]health.Result, error)
 }
 
+// Subset of kp.Store
+type healthStore interface {
+	GetHealth(service, node string) (kp.WatchResult, error)
+	GetServiceHealth(service string) (map[string]kp.WatchResult, error)
+}
+
+type healthKV interface {
+	List(prefix string, opts *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error)
+}
+
+type consulHealthChecker struct {
+	client      *api.Client
+	kv          healthKV
+	consulStore healthStore
+}
 type consulHealth interface {
 	Node(string, *api.QueryOptions) ([]*api.HealthCheck, *api.QueryMeta, error)
 }
@@ -45,6 +53,7 @@ type consulHealth interface {
 func NewConsulHealthChecker(client *api.Client) ConsulHealthChecker {
 	return consulHealthChecker{
 		client:      client,
+		kv:          client.KV(),
 		consulStore: kp.NewConsulStore(client),
 	}
 }
@@ -69,6 +78,36 @@ func (c consulHealthChecker) WatchNodeService(
 			} else {
 				resultCh <- consulWatchToResult(kvCheck)
 			}
+		}
+	}
+}
+
+// Watch the health tree and write the whole subtree on the chan passed by caller
+func (c consulHealthChecker) WatchHealth(
+	resultCh chan<- []*health.Result,
+	errCh chan<- error,
+	quitCh <-chan struct{},
+) {
+	defer close(resultCh)
+
+	res := make(chan api.KVPairs)
+	defer close(res)
+
+	quitWatch := make(<-chan struct{})
+
+	go consulutil.WatchPrefix("health/", c.kv, res, quitWatch, errCh)
+
+	var results api.KVPairs
+	for {
+		select {
+		case <-quitCh:
+			return
+		case results = <-res:
+			healthResults, err := kvpsToResult(results)
+			if err != nil {
+				return
+			}
+			resultCh <- healthResults
 		}
 	}
 }
@@ -135,4 +174,21 @@ func consulWatchToResult(w kp.WatchResult) health.Result {
 		Status:  health.ToHealthState(w.Status),
 		Output:  w.Output,
 	}
+}
+
+// Maps a list of KV Pairs into a slice of health.Results
+// Halts and returns upon encountering an error
+func kvpsToResult(kvs api.KVPairs) ([]*health.Result, error) {
+	result := make([]*health.Result, len(kvs))
+	var err error
+	for i, kv := range kvs {
+		tmp := &health.Result{}
+		err = json.Unmarshal(kv.Value, &tmp)
+		if err != nil {
+			return nil, err
+		}
+		result[i] = tmp
+	}
+
+	return result, nil
 }

--- a/pkg/health/checker/checker.go
+++ b/pkg/health/checker/checker.go
@@ -2,7 +2,6 @@ package checker
 
 import (
 	"encoding/json"
-	"square/up/util"
 	"time"
 
 	"github.com/square/p2/pkg/health"
@@ -10,6 +9,7 @@ import (
 	"github.com/square/p2/pkg/kp/consulutil"
 
 	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/api"
+	"github.com/square/p2/pkg/util"
 )
 
 type ConsulHealthChecker interface {

--- a/pkg/health/checker/checker.go
+++ b/pkg/health/checker/checker.go
@@ -105,9 +105,16 @@ func (c consulHealthChecker) WatchHealth(
 		case results = <-res:
 			healthResults, err := kvpsToResult(results)
 			if err != nil {
-				return
+				select {
+				case errCh <- err:
+				default:
+				}
+			} else {
+				select {
+				case resultCh <- healthResults:
+				default:
+				}
 			}
-			resultCh <- healthResults
 		}
 	}
 }

--- a/pkg/health/checker/test/fake_checker.go
+++ b/pkg/health/checker/test/fake_checker.go
@@ -31,6 +31,10 @@ func (s singleServiceChecker) WatchService(serviceID string, resultCh chan<- map
 
 }
 
+func (s singleServiceChecker) WatchHealth(_ chan<- []*health.Result, errCh chan<- error, quitCh <-chan struct{}) {
+	panic("WatchHealth not implemented")
+}
+
 func (s singleServiceChecker) Service(serviceID string) (map[string]health.Result, error) {
 	if serviceID != s.service {
 		return nil, fmt.Errorf("Wrong service %s given, I only have health for %s", serviceID, s.service)

--- a/pkg/replication/common_setup_test.go
+++ b/pkg/replication/common_setup_test.go
@@ -113,6 +113,12 @@ func (h alwaysHappyHealthChecker) WatchService(
 	}
 }
 
+func (h alwaysHappyHealthChecker) WatchHealth(_ chan<- []*health.Result,
+	errCh chan<- error,
+	quitCh <-chan struct{}) {
+	panic("not implemented")
+}
+
 // creates an implementation of checker.ConsulHealthChecker that always reports
 // satisfied health checks for testing purposes
 func happyHealthChecker() checker.ConsulHealthChecker {
@@ -170,6 +176,13 @@ func (h channelBasedHealthChecker) WatchService(
 		case resultCh <- map[string]health.Result{}:
 		}
 	}
+}
+
+func (h channelBasedHealthChecker) WatchHealth(
+	resultCh chan<- []*health.Result,
+	errCh chan<- error,
+	quitCh <-chan struct{}) {
+	panic("not implemented")
 }
 
 // returns an implementation of checker.ConsulHealthChecker that will provide


### PR DESCRIPTION
With a single watch, we can observe all changes to the health tree.

Discerning the delta is left up to the caller. In the use case I have, computing the delta is not interesting but presenting fresh data is. I chose to keep this simple to minimize consul load and code complexity.

