### PR TITLE
add function to pcstore to allow locking a pod cluster for sync

### DIFF
--- a/pkg/kp/consulutil/session.go
+++ b/pkg/kp/consulutil/session.go
@@ -130,7 +130,7 @@ func NewManagedSession(client *api.Client, session string, name string, quitCh c
 	return sess
 }
 
-// Creates a Session struc{{t using an existing consul session, and does
+// Creates a Session struct using an existing consul session, and does
 // not set up auto-renewal. Use this constructor when the underlying session
 // already exists and should not be managed here.
 func NewUnmanagedSession(client *api.Client, session, name string) Session {

--- a/pkg/kp/consulutil/session.go
+++ b/pkg/kp/consulutil/session.go
@@ -149,6 +149,11 @@ func (err AlreadyLockedError) Error() string {
 	return fmt.Sprintf("Key %q is already locked", err.Key)
 }
 
+func IsAlreadyLocked(err error) bool {
+	_, ok := err.(AlreadyLockedError)
+	return ok
+}
+
 // refresh the TTL on this lock
 func (s Session) Renew() error {
 	entry, _, err := s.client.Session().Renew(s.session, nil)

--- a/pkg/kp/pcstore/consul_store.go
+++ b/pkg/kp/pcstore/consul_store.go
@@ -177,6 +177,10 @@ func pcCreateLockPath(podID types.PodID,
 	return path.Join(consulutil.LOCK_TREE, podID.String(), availabilityZone.String(), clusterName.String())
 }
 
+func pcSyncLockPath(id fields.ID, syncerType ConcreteSyncerType) string {
+	return path.Join(consulutil.LOCK_TREE, podClusterTree, id.String(), syncerType.String())
+}
+
 func (s *consulStore) FindWhereLabeled(podID types.PodID,
 	availabilityZone fields.AvailabilityZone,
 	clusterName fields.ClusterName) ([]fields.PodCluster, error) {
@@ -452,6 +456,10 @@ func (s *consulStore) handlePCUpdates(concrete ConcreteSyncer, changes chan podC
 			}
 		}
 	}
+}
+
+func (s *consulStore) LockForSync(id fields.ID, syncerType ConcreteSyncerType, session Session) (consulutil.Unlocker, error) {
+	return session.Lock(pcSyncLockPath(id, syncerType))
 }
 
 func kvpsToPC(pairs api.KVPairs) ([]fields.PodCluster, error) {

--- a/pkg/kp/pcstore/pcstoretest/fake_pcstore.go
+++ b/pkg/kp/pcstore/pcstoretest/fake_pcstore.go
@@ -1,6 +1,9 @@
 package pcstoretest
 
 import (
+	"fmt"
+
+	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/kp/pcstore"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/pc/fields"
@@ -127,4 +130,9 @@ func (p *FakePCStore) WatchAndSync(concrete pcstore.ConcreteSyncer, quit <-chan 
 
 func (p *FakePCStore) WatchPodCluster(id fields.ID, quit <-chan struct{}) <-chan pcstore.WatchedPodCluster {
 	return p.watchers[id]
+}
+
+func (p *FakePCStore) LockForSync(id fields.ID, syncerType pcstore.ConcreteSyncerType, session pcstore.Session) (consulutil.Unlocker, error) {
+	key := fmt.Sprintf("%s/%s", id, syncerType)
+	return session.Lock(key)
 }

--- a/pkg/kp/pcstore/store.go
+++ b/pkg/kp/pcstore/store.go
@@ -55,7 +55,17 @@ type Store interface {
 	// A convenience method that handles watching pod clusters
 	// as well as the labeled pods in each pod cluster.
 	WatchAndSync(syncer ConcreteSyncer, quit <-chan struct{}) error
+	LockForSync(id fields.ID, syncerType ConcreteSyncerType, session Session) (consulutil.Unlocker, error)
 }
+
+// There may be multiple implementations of ConcreteSyncer that are interested
+// in pod cluster updates, and wish to acquire a pod cluster lock to guarantee
+// exclusive right to sync an update. ConcreteSyncerType is used to namespace a
+// lock by implementation type so that two different concrete syncer
+// implementations may sync the same pod cluster at the same time
+type ConcreteSyncerType string
+
+func (t ConcreteSyncerType) String() string { return string(t) }
 
 type ConcreteSyncer interface {
 	SyncCluster(pc *fields.PodCluster, pods []labels.Labeled) error


### PR DESCRIPTION
This will allow multiple copies of the same implementation of
ConcreteSyncer for pod clusters to run and use locking to ensure that
only one instance is handling an update for a given pod cluster.