### PR TITLE
Fixes bug in pcstore.Watch()

### DIFF
--- a/pkg/kp/pcstore/consul_store.go
+++ b/pkg/kp/pcstore/consul_store.go
@@ -240,7 +240,10 @@ func (s *consulStore) Watch(quit <-chan struct{}) <-chan WatchedPodClusters {
 			}
 
 			for _, pc := range pcs {
-				clusters.Clusters = append(clusters.Clusters, &pc)
+				// We can't just use &pc because that would be a pointer to
+				// the iteration variable
+				pcPtr := pc
+				clusters.Clusters = append(clusters.Clusters, &pcPtr)
 			}
 
 			select {


### PR DESCRIPTION
Watch() gives a list of *pcfields.PodCluster, but was unintentionally
populating the list with a pointer to a loop variable that gets
rewritten so that all values passed would be pointers to the same value
(the last value in the for loop).