### PR TITLE
implement GetInitialClusters()

### DIFF
--- a/pkg/kp/pcstore/consul_store_test.go
+++ b/pkg/kp/pcstore/consul_store_test.go
@@ -437,9 +437,9 @@ func (f *fakeSyncer) SyncCluster(cluster *fields.PodCluster, pods []labels.Label
 	return nil
 }
 
-func (f *fakeSyncer) DeleteCluster(cluster *fields.PodCluster) error {
+func (f *fakeSyncer) DeleteCluster(id fields.ID) error {
 	f.deleted <- fakeSync{
-		syncedCluster: cluster,
+		syncedCluster: &fields.PodCluster{ID: id},
 	}
 	return nil
 }

--- a/pkg/kp/pcstore/consul_store_test.go
+++ b/pkg/kp/pcstore/consul_store_test.go
@@ -590,6 +590,31 @@ func TestConcreteSyncer(t *testing.T) {
 	close(changes)
 }
 
+func TestInitialClusters(t *testing.T) {
+	store := consulStoreWithFakeKV()
+
+	syncer := &fakeSyncer{
+		[]fields.ID{"abc-123"},
+		make(chan fakeSync),
+		make(chan fakeSync),
+		false,
+	}
+
+	clusters, err := store.getInitialClusters(syncer)
+
+	if err != nil {
+		t.Fatalf("Did not expect error to occur getting clusters: %v", err)
+	}
+
+	if len(clusters.Clusters) != 1 {
+		t.Fatalf("Got unexpected number of clusters (%v)", len(clusters.Clusters))
+	}
+
+	if clusters.Clusters[0].ID != fields.ID("abc-123") {
+		t.Fatalf("Got unexpected initial cluster %v", clusters.Clusters[0].ID)
+	}
+}
+
 func TestLockForSync(t *testing.T) {
 	id := fields.ID("abc123")
 	store := consulStoreWithFakeKV()

--- a/pkg/kp/pcstore/store.go
+++ b/pkg/kp/pcstore/store.go
@@ -52,8 +52,9 @@ type Store interface {
 	WatchPodCluster(id fields.ID, quit <-chan struct{}) <-chan WatchedPodCluster
 	Watch(quit <-chan struct{}) <-chan WatchedPodClusters
 
-	// A convenience method that handles watching pod clusters
-	// as well as the labeled pods in each pod cluster.
+	// A convenience method that handles watching pod clusters as well as the
+	// labeled pods in each pod cluster. See the ConcreteSyncer interface for
+	// details on how to use this function
 	WatchAndSync(syncer ConcreteSyncer, quit <-chan struct{}) error
 	LockForSync(id fields.ID, syncerType ConcreteSyncerType, session Session) (consulutil.Unlocker, error)
 }
@@ -68,8 +69,35 @@ type ConcreteSyncerType string
 func (t ConcreteSyncerType) String() string { return string(t) }
 
 type ConcreteSyncer interface {
+	// SyncCluster implements a concrete synchronization of the pod cluster to
+	// some real world implementation of a load balancer, credential management
+	// system, or service discovery implementation.
+	//
+	// When a ConcreteSyncer is passed to WatchAndSync, SyncCluster is called
+	// every time the set of labeled pods change, the pod cluster's metadata
+	// changes, or when the long-lived watch on the pod cluster store returns.
+	// This function is expected to be idempotent. Returned errors do not change
+	// the rules for invocation of this function.
+	//
+	// SyncCluster will be called for every pod cluster present in the store.
+	//
+	// ConcreteSyncers will be called concurrently and must operate safely.
 	SyncCluster(pc *fields.PodCluster, pods []labels.Labeled) error
+
+	// DeleteCluster is called when a pod cluster is observed to have been removed
+	// from the store. DeleteCluster can be invoked in two circumstances: first,
+	// if the cluster was present in a first watch, then absent in a subsequent watch,
+	// then it is assumed it was deleted from the pcstore. Second, if the call
+	// to GetInitialClusters() returns a pod cluster ID that is not present in the very
+	// first watch result, DeleteCluster will be invoked with that pod cluster. In the
+	// latter case, only the pod cluster's ID will be set on the passed `pc` object.
 	DeleteCluster(pc *fields.PodCluster) error
+
+	// GetInitialClusters is called at the beginning of the WatchAndSync
+	// routine. See DeleteCluster() for an explanation of how its results are
+	// used. If the function results in an error, the WatchAndSync function will
+	// terminate immediately, forwarding the error.
+	GetInitialClusters() ([]fields.ID, error)
 }
 
 func IsNotExist(err error) bool {

--- a/pkg/kp/pcstore/store.go
+++ b/pkg/kp/pcstore/store.go
@@ -89,9 +89,12 @@ type ConcreteSyncer interface {
 	// if the cluster was present in a first watch, then absent in a subsequent watch,
 	// then it is assumed it was deleted from the pcstore. Second, if the call
 	// to GetInitialClusters() returns a pod cluster ID that is not present in the very
-	// first watch result, DeleteCluster will be invoked with that pod cluster. In the
-	// latter case, only the pod cluster's ID will be set on the passed `pc` object.
-	DeleteCluster(pc *fields.PodCluster) error
+	// first watch result, DeleteCluster will be invoked with that pod cluster.
+	//
+	// If the passed ID is used to retrieve the pod cluster via store.Get(), it will
+	// return ErrNoPodCluster. Clients should track any relevant metadata to the pod
+	// cluster ID in the status store or in vendor-specific code.
+	DeleteCluster(pc fields.ID) error
 
 	// GetInitialClusters is called at the beginning of the WatchAndSync
 	// routine. See DeleteCluster() for an explanation of how its results are


### PR DESCRIPTION
This change requires implementations of `pcstore.ConcreteSyncer` to implement `GetInitialClusters()`. 

The use case for this function is to enable concrete syncers to be notified of potential deletions that may have occurred during period of downtime or lack of connectivity. Assume the following scenario:

1. Pod cluster A is created
2. ConcreteSyncer S synchronizes A
3. S shuts down for maintenance
4. A is deleted
5. S resumes, unaware of A's deletion

The desired behavior above is to synchronize the deletion of A, but this is not possible because the `WatchAndSync` function can only watch the generic pcstore as defined in this project. Syncers track their own status information in their own implementation-specific ways. Soon we'll be adding a `StatusStore`, but that too must allow vendor-specific status data to be written. For comparison, the P2 Preparer is able to fully use Consul to do syncing without fear of missing deletions because there are no vendors external to P2 to synchronize.