### PR TITLE
Implement cached health store

### DIFF
--- a/pkg/health/checker/checker.go
+++ b/pkg/health/checker/checker.go
@@ -125,7 +125,6 @@ func publishLatestHealth(inCh <-chan api.KVPairs, quitCh <-chan struct{}, result
 				}
 			default:
 			}
-
 			// Now we check the quit chan and try to write to our resultCh
 			select {
 			case <-quitCh:

--- a/pkg/health/checker/checker.go
+++ b/pkg/health/checker/checker.go
@@ -129,9 +129,8 @@ func publishLatestHealth(inCh <-chan api.KVPairs, quitCh <-chan struct{}, result
 			select {
 			case <-quitCh:
 				return
-			default:
+			case resultCh <- results:
 			}
-			resultCh <- results
 		}
 	}()
 

--- a/pkg/health/checker/checker.go
+++ b/pkg/health/checker/checker.go
@@ -83,6 +83,7 @@ func (c consulHealthChecker) WatchNodeService(
 	}
 }
 
+// publishLatestHealth is not thread safe - do not start more than one of these per resultCH
 func publishLatestHealth(inCh <-chan api.KVPairs, quitCh <-chan struct{}, resultCh chan []*health.Result) chan error {
 	errCh := make(chan error)
 
@@ -108,7 +109,7 @@ func publishLatestHealth(inCh <-chan api.KVPairs, quitCh <-chan struct{}, result
 			if err != nil {
 				select {
 				case errCh <- err:
-					// The most recent update is in error.
+					// The most recent update is an error.
 					// We go back to the start in this case
 					continue
 				case <-quitCh:

--- a/pkg/health/checker/checker_test.go
+++ b/pkg/health/checker/checker_test.go
@@ -78,7 +78,7 @@ func TestPublishLatestHealth(t *testing.T) {
 	}
 	hrOldJSON, err := json.Marshal(hrOld)
 	if err != nil {
-		t.Fatal("json marshal err: %v", err)
+		t.Fatalf("json marshal err: %v", err)
 	}
 	oldKV := &api.KVPair{Key: "health/service/node1.example.com", Value: hrOldJSON}
 
@@ -87,11 +87,12 @@ func TestPublishLatestHealth(t *testing.T) {
 	}
 	hrNewJSON, err := json.Marshal(hrNew)
 	if err != nil {
-		t.Fatal("json marshal err: %v", err)
+		t.Fatalf("json marshal err: %v", err)
 	}
 	newKV := &api.KVPair{Key: "health/service/node1.example.com", Value: hrNewJSON}
 
 	// Basic test that publishLatestHealth drains the channels correctly
+	// We write three times to ensure that at least one of the newKV values has flushed through the channel
 	select {
 	case healthListChan <- api.KVPairs{oldKV}:
 	case <-time.After(1 * time.Second):
@@ -105,9 +106,15 @@ func TestPublishLatestHealth(t *testing.T) {
 	}
 
 	select {
+	case healthListChan <- api.KVPairs{newKV}:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Failed to write to chan. Deadlock?")
+	}
+
+	select {
 	case result := <-outCh:
-		if len(result) == 0 {
-			t.Fatal("expected some results")
+		if len(result) < 1 {
+			t.Fatalf("Got wrong number of results. Expected 1, got %d", len(result))
 		}
 		if result[0].Status != newStatus {
 			t.Fatalf("expected status to match %s, was %s", newStatus, result[0].Status)

--- a/pkg/health/checker/test/fake_checker.go
+++ b/pkg/health/checker/test/fake_checker.go
@@ -31,7 +31,7 @@ func (s singleServiceChecker) WatchService(serviceID string, resultCh chan<- map
 
 }
 
-func (s singleServiceChecker) WatchHealth(_ chan<- []*health.Result, errCh chan<- error, quitCh <-chan struct{}) {
+func (s singleServiceChecker) WatchHealth(_ chan []*health.Result, errCh chan<- error, quitCh <-chan struct{}) {
 	panic("WatchHealth not implemented")
 }
 

--- a/pkg/health/store/store.go
+++ b/pkg/health/store/store.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/square/p2/Godeps/_workspace/src/github.com/Sirupsen/logrus"
@@ -63,7 +62,7 @@ func (hs *healthStore) cache(results []*health.Result) {
 	// duplicate key is undefined behavior
 	for _, result := range results {
 		result := result
-		tmpCache[computeCacheKey(result.ID, types.NodeName(result.Node))] = result
+		tmpCache[newCacheKey(result.ID, types.NodeName(result.Node))] = result
 	}
 
 	hs.lock.Lock()
@@ -73,7 +72,7 @@ func (hs *healthStore) cache(results []*health.Result) {
 }
 
 func (hs *healthStore) Fetch(podID types.PodID, node string) *health.Result {
-	cacheKey := computeCacheKey(podID, types.NodeName(node))
+	cacheKey := newCacheKey(podID, types.NodeName(node))
 
 	hs.lock.RLock()
 	defer hs.lock.RUnlock()
@@ -86,8 +85,11 @@ func (hs *healthStore) Fetch(podID types.PodID, node string) *health.Result {
 	return res
 }
 
-type cacheKey string
+type cacheKey struct {
+	pod  types.PodID
+	node types.NodeName
+}
 
-func computeCacheKey(podID types.PodID, node types.NodeName) cacheKey {
-	return cacheKey(fmt.Sprintf("%s/%s", podID, node))
+func newCacheKey(podID types.PodID, node types.NodeName) cacheKey {
+	return cacheKey{pod: podID, node: node}
 }

--- a/pkg/health/store/store.go
+++ b/pkg/health/store/store.go
@@ -41,7 +41,7 @@ func (hs *healthStore) StartWatch(quitCh <-chan struct{}) {
 	errCh := make(chan error)
 	defer close(errCh)
 
-	hs.healthChecker.WatchHealth(healthUpdates, errCh, quitCh)
+	go func() { hs.healthChecker.WatchHealth(healthUpdates, errCh, quitCh) }()
 
 	select {
 	case updates := <-healthUpdates:

--- a/pkg/health/store/store.go
+++ b/pkg/health/store/store.go
@@ -1,0 +1,94 @@
+package store
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/square/p2/Godeps/_workspace/src/github.com/Sirupsen/logrus"
+
+	"github.com/square/p2/pkg/health"
+	"github.com/square/p2/pkg/health/checker"
+	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/types"
+)
+
+// Health can answer questions about the health of a particular pod on a node
+// It performs this by watching the health tree of consul and caching the result
+type HealthStore interface {
+	StartWatch(quitCh <-chan struct{})
+	Fetch(types.PodID, string) *health.Result
+}
+
+type healthStore struct {
+	cachedHealth  map[cacheKey]*health.Result
+	healthChecker checker.ConsulHealthChecker
+	lock          *sync.RWMutex
+	logger        logging.Logger
+}
+
+var _ HealthStore = &healthStore{}
+
+func NewHealthStore(healthChecker checker.ConsulHealthChecker) HealthStore {
+	return &healthStore{
+		healthChecker: healthChecker,
+		lock:          &sync.RWMutex{},
+		logger:        logging.DefaultLogger,
+	}
+}
+
+func (hs *healthStore) StartWatch(quitCh <-chan struct{}) {
+	healthUpdates := make(chan []*health.Result, 1)
+	defer close(healthUpdates)
+	errCh := make(chan error)
+	defer close(errCh)
+
+	go hs.healthChecker.WatchHealth(healthUpdates, errCh, quitCh)
+
+	for {
+		select {
+		case updates := <-healthUpdates:
+			hs.cache(updates)
+		case <-quitCh:
+			hs.logger.Errorln("Quitting...")
+			return
+		case err := <-errCh:
+			hs.logger.WithError(err).Errorln("Consul Watch error")
+		default:
+		}
+	}
+}
+
+func (hs *healthStore) cache(results []*health.Result) {
+	tmpCache := make(map[cacheKey]*health.Result, len(results))
+
+	// duplicate key is undefined behavior
+	for _, result := range results {
+		result := result
+		tmpCache[computeCacheKey(result.ID, types.NodeName(result.Node))] = result
+	}
+
+	hs.lock.Lock()
+	defer hs.lock.Unlock()
+
+	hs.cachedHealth = tmpCache
+}
+
+func (hs *healthStore) Fetch(podID types.PodID, node string) *health.Result {
+	cacheKey := computeCacheKey(podID, types.NodeName(node))
+
+	hs.lock.RLock()
+	defer hs.lock.RUnlock()
+
+	res, ok := hs.cachedHealth[cacheKey]
+	if !ok {
+		hs.logger.WithFields(logrus.Fields{"cachedHealth": len(hs.cachedHealth)}).Errorln("Cache miss!!")
+		return nil
+	}
+	return res
+}
+
+type cacheKey string
+
+func computeCacheKey(podID types.PodID, node types.NodeName) cacheKey {
+	return cacheKey(fmt.Sprintf("%s/%s", podID, node))
+}

--- a/pkg/health/store/store.go
+++ b/pkg/health/store/store.go
@@ -41,18 +41,16 @@ func (hs *healthStore) StartWatch(quitCh <-chan struct{}) {
 	errCh := make(chan error)
 	defer close(errCh)
 
-	go hs.healthChecker.WatchHealth(healthUpdates, errCh, quitCh)
+	hs.healthChecker.WatchHealth(healthUpdates, errCh, quitCh)
 
-	for {
-		select {
-		case updates := <-healthUpdates:
-			hs.cache(updates)
-		case <-quitCh:
-			hs.logger.Errorln("Quitting...")
-			return
-		case err := <-errCh:
-			hs.logger.WithError(err).Errorln("Consul Watch error")
-		}
+	select {
+	case updates := <-healthUpdates:
+		hs.cache(updates)
+	case <-quitCh:
+		hs.logger.Errorln("Quitting...")
+		return
+	case err := <-errCh:
+		hs.logger.WithError(err).Errorln("Consul Watch error")
 	}
 }
 

--- a/pkg/health/store/store.go
+++ b/pkg/health/store/store.go
@@ -12,7 +12,7 @@ import (
 	"github.com/square/p2/pkg/types"
 )
 
-// Health can answer questions about the health of a particular pod on a node
+// HealthStore can answer questions about the health of a particular pod on a node
 // It performs this by watching the health tree of consul and caching the result
 type HealthStore interface {
 	StartWatch(quitCh <-chan struct{})
@@ -22,7 +22,7 @@ type HealthStore interface {
 type healthStore struct {
 	cachedHealth  map[cacheKey]*health.Result
 	healthChecker checker.ConsulHealthChecker
-	lock          *sync.RWMutex
+	lock          sync.RWMutex
 	logger        logging.Logger
 }
 
@@ -31,7 +31,7 @@ var _ HealthStore = &healthStore{}
 func NewHealthStore(healthChecker checker.ConsulHealthChecker) HealthStore {
 	return &healthStore{
 		healthChecker: healthChecker,
-		lock:          &sync.RWMutex{},
+		lock:          sync.RWMutex{},
 		logger:        logging.DefaultLogger,
 	}
 }

--- a/pkg/health/store/store.go
+++ b/pkg/health/store/store.go
@@ -53,7 +53,6 @@ func (hs *healthStore) StartWatch(quitCh <-chan struct{}) {
 			return
 		case err := <-errCh:
 			hs.logger.WithError(err).Errorln("Consul Watch error")
-		default:
 		}
 	}
 }

--- a/pkg/health/store/store_test.go
+++ b/pkg/health/store/store_test.go
@@ -61,6 +61,18 @@ func TestStartWatchBasic(t *testing.T) {
 		t.Errorf("expected cache to start empty, found %v", result)
 	}
 
+	// Write to this channel three times to ensure that the 1st write is processed before
+	// we validate the behaviour. Testing concurrent code is difficult
+	healthResults <- []*health.Result{
+		&health.Result{ID: podID1, Node: node},
+		&health.Result{ID: podID2, Node: node},
+	}
+
+	healthResults <- []*health.Result{
+		&health.Result{ID: podID1, Node: node},
+		&health.Result{ID: podID2, Node: node},
+	}
+
 	healthResults <- []*health.Result{
 		&health.Result{ID: podID1, Node: node},
 		&health.Result{ID: podID2, Node: node},

--- a/pkg/health/store/store_test.go
+++ b/pkg/health/store/store_test.go
@@ -30,7 +30,6 @@ func (hc *FakeHealthChecker) WatchHealth(resultCh chan []*health.Result, errCh c
 			resultCh <- result
 		case <-quitCh:
 			return
-		default:
 		}
 	}
 }

--- a/pkg/health/store/store_test.go
+++ b/pkg/health/store/store_test.go
@@ -1,0 +1,79 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/square/p2/pkg/health"
+	"github.com/square/p2/pkg/types"
+)
+
+type FakeHealthChecker struct {
+	healthResults chan []*health.Result
+}
+
+func (hc *FakeHealthChecker) WatchNodeService(nodename string, serviceID string, resultCh chan<- health.Result, errCh chan<- error, quitCh <-chan struct{}) {
+	panic("not implemented")
+}
+
+func (hc *FakeHealthChecker) WatchService(serviceID string, resultCh chan<- map[string]health.Result, errCh chan<- error, quitCh <-chan struct{}) {
+	panic("not implemented")
+}
+
+func (hc *FakeHealthChecker) Service(serviceID string) (map[string]health.Result, error) {
+	panic("not implemented")
+}
+
+func (hc *FakeHealthChecker) WatchHealth(resultCh chan<- []*health.Result, errCh chan<- error, quitCh <-chan struct{}) {
+	for {
+		select {
+		case result := <-hc.healthResults:
+			resultCh <- result
+		case <-quitCh:
+			return
+		default:
+		}
+	}
+}
+
+func NewFakeHealthStore() (healthChecker HealthStore, healthValues chan []*health.Result) {
+	healthResults := make(chan []*health.Result) // real clients should use a buffered chan. This is unbuffered to simplify concurrency in this test
+	hc := &FakeHealthChecker{
+		healthResults: healthResults,
+	}
+	hs := NewHealthStore(hc)
+
+	return hs, healthResults
+}
+
+func TestStartWatchBasic(t *testing.T) {
+	hs, healthResults := NewFakeHealthStore()
+	quitCh := make(chan struct{})
+
+	go func() {
+		hs.StartWatch(quitCh)
+	}()
+
+	node := "abc01.sjc1"
+	podID1 := types.PodID("podID1")
+	podID2 := types.PodID("podID2")
+
+	result := hs.Fetch(podID1, node)
+	if result != nil {
+		t.Errorf("expected cache to start empty, found %v", result)
+	}
+
+	healthResults <- []*health.Result{
+		&health.Result{ID: podID1, Node: node},
+		&health.Result{ID: podID2, Node: node},
+	}
+
+	result = hs.Fetch(podID1, node)
+	if result == nil {
+		t.Errorf("expected health store to have %s", podID1)
+	}
+
+	result = hs.Fetch(podID2, node)
+	if result == nil {
+		t.Errorf("expected health store to have %s", podID2)
+	}
+}

--- a/pkg/health/store/store_test.go
+++ b/pkg/health/store/store_test.go
@@ -23,7 +23,7 @@ func (hc *FakeHealthChecker) Service(serviceID string) (map[string]health.Result
 	panic("not implemented")
 }
 
-func (hc *FakeHealthChecker) WatchHealth(resultCh chan<- []*health.Result, errCh chan<- error, quitCh <-chan struct{}) {
+func (hc *FakeHealthChecker) WatchHealth(resultCh chan []*health.Result, errCh chan<- error, quitCh <-chan struct{}) {
 	for {
 		select {
 		case result := <-hc.healthResults:

--- a/pkg/kp/consulutil/watch.go
+++ b/pkg/kp/consulutil/watch.go
@@ -22,7 +22,6 @@ func WatchPrefix(
 	done <-chan struct{},
 	outErrors chan<- error,
 ) {
-	// TODO return this for closing on the client side
 	defer close(outPairs)
 	var currentIndex uint64
 	timer := time.NewTimer(time.Duration(0))

--- a/pkg/replication/common_setup_test.go
+++ b/pkg/replication/common_setup_test.go
@@ -113,7 +113,7 @@ func (h alwaysHappyHealthChecker) WatchService(
 	}
 }
 
-func (h alwaysHappyHealthChecker) WatchHealth(_ chan<- []*health.Result,
+func (h alwaysHappyHealthChecker) WatchHealth(_ chan []*health.Result,
 	errCh chan<- error,
 	quitCh <-chan struct{}) {
 	panic("not implemented")
@@ -179,7 +179,7 @@ func (h channelBasedHealthChecker) WatchService(
 }
 
 func (h channelBasedHealthChecker) WatchHealth(
-	resultCh chan<- []*health.Result,
+	resultCh chan []*health.Result,
 	errCh chan<- error,
 	quitCh <-chan struct{}) {
 	panic("not implemented")


### PR DESCRIPTION
This allows clients to lookup health without introducing load on the
datastore.

Also improve the channel semantics in &checker.WatchHealth().
  We value fresh values over the durability of messages in this channel.

The `types.NodeName` references are as small as possible now, I will follow up with a better rename in a subsequent PR.

Additionally, we have discussed changing the pattern of channels as arguments. Since this change will affect all of health on its clients it is a little risky. I will introduce this in a subsequent PR.