### PR TITLE
Use pod-wide lock in replication

### DIFF
--- a/pkg/kp/constants.go
+++ b/pkg/kp/constants.go
@@ -57,3 +57,9 @@ func PodLockPath(podPrefix PodPrefix, nodeName string, podId types.PodID) (strin
 
 	return path.Join(consulutil.LOCK_TREE, subPodPath), nil
 }
+
+// Returns the consul path to use when locking out any other pkg/replication-based deploys
+// for a given pod ID
+func ReplicationLockPath(podId types.PodID) string {
+	return path.Join(consulutil.LOCK_TREE, "replication", podId.String())
+}

--- a/pkg/replication/replication_test.go
+++ b/pkg/replication/replication_test.go
@@ -266,17 +266,13 @@ func TestStopsIfLockDestroyed(t *testing.T) {
 		t.Fatalf("Unable to create initial replication session: %s", err)
 	}
 
-	for _, host := range testNodes {
-		lockPath, err := kp.PodLockPath(kp.INTENT_TREE, host, manifest.ID())
-		if err != nil {
-			t.Fatalf("Unable to compute lock path for pod: %s", err)
-		}
+	lockPath := kp.ReplicationLockPath(manifest.ID())
 
-		_, err = replication.lock(session, lockPath, false)
-		if err != nil {
-			t.Fatalf("Unable to perform initial replication lock: %s", err)
-		}
+	_, err = replication.lock(session, lockPath, false)
+	if err != nil {
+		t.Fatalf("Unable to perform initial replication lock: %s", err)
 	}
+
 	go replication.handleRenewalErrors(session, renewalErrCh)
 
 	doneCh := make(chan struct{})
@@ -350,10 +346,7 @@ func TestStopsIfLockDestroyed(t *testing.T) {
 	}
 
 	// Destroy lock holder so the next renewal will fail
-	lockPath, err := kp.PodLockPath(kp.INTENT_TREE, testNodes[0], manifest.ID())
-	if err != nil {
-		t.Fatalf("Unable to compute pod lock path")
-	}
+	lockPath = kp.ReplicationLockPath(manifest.ID())
 
 	_, id, err := store.LockHolder(lockPath)
 	if err != nil {


### PR DESCRIPTION
When using `p2-replicate` for large numbers of pods it quickly becomes burdensome to use a per-node pod lock. The original intent of per-node locking was to allow parallel deployments to multiple environments simultaneously. Now that our recommended deployment system is to use rolling updates + replication controllers, which do not use pkg/replication to achieve their work, we can focus on making `p2-replicate` effective for today's primary use cases (deploying agents). 