### PR TITLE
Add helper for extracting node name and pod id from pod label key

### DIFF
--- a/bin/p2-replicate/main.go
+++ b/bin/p2-replicate/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/replication"
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/version"
 )
 
@@ -75,11 +76,17 @@ func main() {
 	if err != nil {
 		log.Fatalf("Could not retrieve user: %s", err)
 	}
+
+	nodes := make([]types.NodeName, len(*hosts))
+	for i, host := range *hosts {
+		nodes[i] = types.NodeName(host)
+	}
+
 	lockMessage := fmt.Sprintf("%q from %q at %q", thisUser.Username, thisHost, time.Now())
 	repl, err := replication.NewReplicator(
 		manifest,
 		logger,
-		*hosts,
+		nodes,
 		len(*hosts)-*minNodes,
 		store,
 		labeler,

--- a/bin/p2-rm/main.go
+++ b/bin/p2-rm/main.go
@@ -35,19 +35,19 @@ type P2RM struct {
 	Labeler labels.Applicator
 
 	LabelID  string
-	NodeName string
+	NodeName types.NodeName
 	PodName  string
 }
 
 // NewP2RM is a constructor for the P2RM type. It will generate the necessary
 // storage types based on its api.Client argument
-func NewP2RM(client *api.Client, podName, nodeName string) *P2RM {
+func NewP2RM(client *api.Client, podName string, nodeName types.NodeName) *P2RM {
 	rm := &P2RM{}
 	rm.Client = client
 	rm.Store = kp.NewConsulStore(client)
 	rm.RCStore = rcstore.NewConsul(client, 5)
 	rm.Labeler = labels.NewConsulApplicator(client, 3)
-	rm.LabelID = path.Join(nodeName, podName)
+	rm.LabelID = path.Join(nodeName.String(), podName)
 	rm.PodName = podName
 	rm.NodeName = nodeName
 
@@ -67,7 +67,7 @@ func main() {
 		*nodeName = hostname
 	}
 
-	rm := NewP2RM(kp.NewConsulClient(opts), *podName, *nodeName)
+	rm := NewP2RM(kp.NewConsulClient(opts), *podName, types.NodeName(*nodeName))
 
 	podIsManagedByRC, rcID, err := rm.checkForManagingReplicationController()
 	if err != nil {

--- a/bin/p2-schedule/main.go
+++ b/bin/p2-schedule/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/kp/flags"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/version"
 )
 
@@ -45,7 +46,7 @@ func main() {
 		if *hookGlobal {
 			podPrefix = kp.HOOK_TREE
 		}
-		duration, err := store.SetPod(podPrefix, *nodeName, manifest)
+		duration, err := store.SetPod(podPrefix, types.NodeName(*nodeName), manifest)
 		if err != nil {
 			log.Fatalf("Could not write manifest %s to intent store: %s\n", manifest.ID(), err)
 		}

--- a/bin/p2-watch/main.go
+++ b/bin/p2-watch/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/kp/flags"
+	"github.com/square/p2/pkg/types"
 
 	"github.com/square/p2/Godeps/_workspace/src/gopkg.in/alecthomas/kingpin.v2"
 	"github.com/square/p2/pkg/version"
@@ -43,7 +44,7 @@ func main() {
 	quit := make(chan struct{})
 	errChan := make(chan error)
 	podCh := make(chan []kp.ManifestResult)
-	go store.WatchPods(podPrefix, *nodeName, quit, errChan, podCh)
+	go store.WatchPods(podPrefix, types.NodeName(*nodeName), quit, errChan, podCh)
 	for {
 		select {
 		case results := <-podCh:

--- a/pkg/health/checker/checker_test.go
+++ b/pkg/health/checker/checker_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/square/p2/pkg/health"
 	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/types"
 
 	. "github.com/square/p2/Godeps/_workspace/src/github.com/anthonybishopric/gotcha"
 	"github.com/square/p2/Godeps/_workspace/src/github.com/hashicorp/consul/api"
@@ -16,8 +17,8 @@ type fakeConsulStore struct {
 	results map[string]kp.WatchResult
 }
 
-func (f fakeConsulStore) GetHealth(service, node string) (kp.WatchResult, error) {
-	return f.results[node], nil
+func (f fakeConsulStore) GetHealth(service string, node types.NodeName) (kp.WatchResult, error) {
+	return f.results[node.String()], nil
 }
 func (f fakeConsulStore) GetServiceHealth(service string) (map[string]kp.WatchResult, error) {
 	return f.results, nil

--- a/pkg/health/checker/test/fake_checker.go
+++ b/pkg/health/checker/test/fake_checker.go
@@ -5,28 +5,29 @@ import (
 
 	"github.com/square/p2/pkg/health"
 	"github.com/square/p2/pkg/health/checker"
+	"github.com/square/p2/pkg/types"
 )
 
 // TODO: replication/common_setup_test.go has some things that could be moved here
 
 type singleServiceChecker struct {
 	service string
-	health  map[string]health.Result
+	health  map[types.NodeName]health.Result
 }
 
 // NewSingleService reports a fixed health result for a single service only
-func NewSingleService(service string, health map[string]health.Result) checker.ConsulHealthChecker {
+func NewSingleService(service string, health map[types.NodeName]health.Result) checker.ConsulHealthChecker {
 	return &singleServiceChecker{
 		service: service,
 		health:  health,
 	}
 }
 
-func (s singleServiceChecker) WatchNodeService(nodename string, serviceID string, resultCh chan<- health.Result, errCh chan<- error, quitCh <-chan struct{}) {
+func (s singleServiceChecker) WatchNodeService(nodename types.NodeName, serviceID string, resultCh chan<- health.Result, errCh chan<- error, quitCh <-chan struct{}) {
 	panic("WatchNodeService not implemented")
 }
 
-func (s singleServiceChecker) WatchService(serviceID string, resultCh chan<- map[string]health.Result, errCh chan<- error, quitCh <-chan struct{}) {
+func (s singleServiceChecker) WatchService(serviceID string, resultCh chan<- map[types.NodeName]health.Result, errCh chan<- error, quitCh <-chan struct{}) {
 	panic("WatchService not implemented")
 
 }
@@ -35,7 +36,7 @@ func (s singleServiceChecker) WatchHealth(_ chan []*health.Result, errCh chan<- 
 	panic("WatchHealth not implemented")
 }
 
-func (s singleServiceChecker) Service(serviceID string) (map[string]health.Result, error) {
+func (s singleServiceChecker) Service(serviceID string) (map[types.NodeName]health.Result, error) {
 	if serviceID != s.service {
 		return nil, fmt.Errorf("Wrong service %s given, I only have health for %s", serviceID, s.service)
 	}

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -7,7 +7,7 @@ import (
 // Result stores the health state of a service.
 type Result struct {
 	ID      types.PodID
-	Node    string
+	Node    types.NodeName
 	Service string
 	Status  HealthState
 	Output  string

--- a/pkg/health/health_order.go
+++ b/pkg/health/health_order.go
@@ -1,9 +1,13 @@
 package health
 
+import (
+	"github.com/square/p2/pkg/types"
+)
+
 // SortOrder sorts the nodes in the list from least to most health.
 type SortOrder struct {
-	Nodes  []string
-	Health map[string]Result
+	Nodes  []types.NodeName
+	Health map[types.NodeName]Result
 }
 
 func (s SortOrder) Len() int {

--- a/pkg/health/store/store.go
+++ b/pkg/health/store/store.go
@@ -15,7 +15,7 @@ import (
 // It performs this by watching the health tree of consul and caching the result
 type HealthStore interface {
 	StartWatch(quitCh <-chan struct{})
-	Fetch(types.PodID, string) *health.Result
+	Fetch(types.PodID, types.NodeName) *health.Result
 }
 
 type healthStore struct {
@@ -69,8 +69,8 @@ func (hs *healthStore) cache(results []*health.Result) {
 	hs.cachedHealth = tmpCache
 }
 
-func (hs *healthStore) Fetch(podID types.PodID, node string) *health.Result {
-	cacheKey := newCacheKey(podID, types.NodeName(node))
+func (hs *healthStore) Fetch(podID types.PodID, node types.NodeName) *health.Result {
+	cacheKey := newCacheKey(podID, node)
 
 	hs.lock.RLock()
 	defer hs.lock.RUnlock()

--- a/pkg/health/store/store_test.go
+++ b/pkg/health/store/store_test.go
@@ -12,15 +12,15 @@ type FakeHealthChecker struct {
 	healthResults chan []*health.Result
 }
 
-func (hc *FakeHealthChecker) WatchNodeService(nodename string, serviceID string, resultCh chan<- health.Result, errCh chan<- error, quitCh <-chan struct{}) {
+func (hc *FakeHealthChecker) WatchNodeService(nodename types.NodeName, serviceID string, resultCh chan<- health.Result, errCh chan<- error, quitCh <-chan struct{}) {
 	panic("not implemented")
 }
 
-func (hc *FakeHealthChecker) WatchService(serviceID string, resultCh chan<- map[string]health.Result, errCh chan<- error, quitCh <-chan struct{}) {
+func (hc *FakeHealthChecker) WatchService(serviceID string, resultCh chan<- map[types.NodeName]health.Result, errCh chan<- error, quitCh <-chan struct{}) {
 	panic("not implemented")
 }
 
-func (hc *FakeHealthChecker) Service(serviceID string) (map[string]health.Result, error) {
+func (hc *FakeHealthChecker) Service(serviceID string) (map[types.NodeName]health.Result, error) {
 	panic("not implemented")
 }
 
@@ -52,7 +52,7 @@ func TestStartWatchBasic(t *testing.T) {
 		hs.StartWatch(quitCh)
 	}()
 
-	node := "abc01.sjc1"
+	node := types.NodeName("abc01.sjc1")
 	podID1 := types.PodID("podID1")
 	podID2 := types.PodID("podID2")
 

--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/square/p2/pkg/health"
 	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/types"
 )
 
 const (
@@ -15,8 +16,8 @@ const (
 )
 
 type NodePodStatus struct {
-	NodeName           string             `json:"node,omitempty"`
-	PodId              string             `json:"pod,omitempty"`
+	NodeName           types.NodeName     `json:"node,omitempty"`
+	PodId              types.PodID        `json:"pod,omitempty"`
 	IntentManifestSHA  string             `json:"intent_manifest_sha"`
 	RealityManifestSHA string             `json:"reality_manifest_sha"`
 	IntentLocations    []string           `json:"intent_locations"`
@@ -24,10 +25,10 @@ type NodePodStatus struct {
 	Health             health.HealthState `json:"health,omitempty"`
 }
 
-func AddKVPToMap(result kp.ManifestResult, source int, filterNode, filterPod string, statuses map[string]map[string]NodePodStatus) error {
+func AddKVPToMap(result kp.ManifestResult, source int, filterNode types.NodeName, filterPod types.PodID, statuses map[types.PodID]map[types.NodeName]NodePodStatus) error {
 	keySegs := strings.Split(result.Path, "/")
-	nodeName := keySegs[1]
-	podId := keySegs[2]
+	nodeName := types.NodeName(keySegs[1])
+	podId := types.PodID(keySegs[2])
 
 	if filterNode != "" && nodeName != filterNode {
 		return nil
@@ -37,7 +38,7 @@ func AddKVPToMap(result kp.ManifestResult, source int, filterNode, filterPod str
 	}
 
 	if statuses[podId] == nil {
-		statuses[podId] = make(map[string]NodePodStatus)
+		statuses[podId] = make(map[types.NodeName]NodePodStatus)
 	}
 	old := statuses[podId][nodeName]
 

--- a/pkg/kp/constants.go
+++ b/pkg/kp/constants.go
@@ -18,7 +18,7 @@ const (
 	HOOK_TREE    PodPrefix = "hooks"
 )
 
-func nodePath(podPrefix PodPrefix, nodeName string) (string, error) {
+func nodePath(podPrefix PodPrefix, nodeName types.NodeName) (string, error) {
 	// hook tree is an exception to the rule because they are not scheduled
 	// by host, and it is valid to want to watch for them agnostic to pod
 	// id. There are plans to deploy hooks by host at which time this
@@ -31,10 +31,10 @@ func nodePath(podPrefix PodPrefix, nodeName string) (string, error) {
 		}
 	}
 
-	return path.Join(string(podPrefix), nodeName), nil
+	return path.Join(string(podPrefix), nodeName.String()), nil
 }
 
-func podPath(podPrefix PodPrefix, nodeName string, podId types.PodID) (string, error) {
+func podPath(podPrefix PodPrefix, nodeName types.NodeName, podId types.PodID) (string, error) {
 	nodePath, err := nodePath(podPrefix, nodeName)
 	if err != nil {
 		return "", err
@@ -49,7 +49,7 @@ func podPath(podPrefix PodPrefix, nodeName string, podId types.PodID) (string, e
 
 // Returns the consul path to use when intending to lock a pod, e.g.
 // lock/intent/some_host/some_pod
-func PodLockPath(podPrefix PodPrefix, nodeName string, podId types.PodID) (string, error) {
+func PodLockPath(podPrefix PodPrefix, nodeName types.NodeName, podId types.PodID) (string, error) {
 	subPodPath, err := podPath(podPrefix, nodeName, podId)
 	if err != nil {
 		return "", err

--- a/pkg/kp/healthmanager.go
+++ b/pkg/kp/healthmanager.go
@@ -49,14 +49,14 @@ type consulHealthManager struct {
 	sessionPub *stream.StringValuePublisher // Publishes the current session
 	done       chan struct{}                // Close this to stop reporting health
 	client     *api.Client                  // Connection to the Consul agent
-	node       string
+	node       types.NodeName
 	logger     logging.Logger // Logger for health events
 }
 
 // NewHealthManager implements the Store interface. It creates a new HealthManager that
 // uses the Consul Key-Value store to hold app health statues.
 func (c consulStore) newSessionHealthManager(
-	node string,
+	node types.NodeName,
 	logger logging.Logger,
 ) HealthManager {
 	// Create a stream of sessions
@@ -98,7 +98,7 @@ func (m *consulHealthManager) Close() {
 // consulHealthUpdater holds the state needed for the update process to track the current
 // service health and which health it has published.
 type consulHealthUpdater struct {
-	node    string           // The node this updater is bound to
+	node    types.NodeName   // The node this updater is bound to
 	pod     types.PodID      // The pod ID this updater is bound to
 	service string           // The service this updater is bound to
 	checker chan WatchResult // Stream of health updates from a checker

--- a/pkg/kp/kptest/fake_pod_store_test.go
+++ b/pkg/kp/kptest/fake_pod_store_test.go
@@ -2,6 +2,7 @@ package kptest
 
 import (
 	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/types"
 
 	"testing"
 )
@@ -9,7 +10,7 @@ import (
 func TestFakeServiceHealth(t *testing.T) {
 	fake := FakePodStore{}
 	targetService := "paladin"
-	targetHost := "aaa2.dfw.square"
+	targetHost := types.NodeName("aaa2.dfw.square")
 	targetStatus := "healthy"
 
 	fake.healthResults = map[string]kp.WatchResult{

--- a/pkg/labels/consul_applicator.go
+++ b/pkg/labels/consul_applicator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/square/p2/Godeps/_workspace/src/k8s.io/kubernetes/pkg/labels"
 
 	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
 )
 
@@ -256,6 +257,19 @@ func (c *consulApplicator) WatchMatches(selector labels.Selector, labelType Type
 		c.aggregators[labelType] = aggregator
 	}
 	return aggregator.Watch(selector, quitCh)
+}
+
+func NodeAndPodIDFromPodLabel(labeled Labeled) (types.NodeName, types.PodID, error) {
+	if labeled.LabelType != POD {
+		return "", "", util.Errorf("Label was not a pod label, was %s", labeled.LabelType)
+	}
+
+	parts := strings.SplitN(labeled.ID, "/", 2)
+	if len(parts) < 2 {
+		return "", "", util.Errorf("malformed pod label %s", labeled.ID)
+	}
+
+	return types.NodeName(parts[0]), types.PodID(parts[1]), nil
 }
 
 // confirm at compile time that consulApplicator is an implementation of the Applicator interface

--- a/pkg/preparer/listener.go
+++ b/pkg/preparer/listener.go
@@ -10,19 +10,20 @@ import (
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/types"
 )
 
 type IntentStore interface {
 	WatchPods(
 		podPrefix kp.PodPrefix,
-		hostname string,
+		hostname types.NodeName,
 		quit <-chan struct{},
 		errCh chan<- error,
 		manifests chan<- []kp.ManifestResult,
 	)
 	ListPods(
 		podPrefix kp.PodPrefix,
-		hostname string,
+		hostname types.NodeName,
 	) ([]kp.ManifestResult, time.Duration, error)
 }
 
@@ -34,9 +35,9 @@ type HookListener struct {
 	// hostname, however there are future plans to change this behavior, so
 	// the hostname is passed to WatchPods and ListPods even though it is
 	// ignored
-	Node             string // The host to watch for hooks for
-	DestinationDir   string // The destination directory for downloaded pods that will act as hooks
-	ExecDir          string // The directory that will actually be executed by the HookDir
+	Node             types.NodeName // The host to watch for hooks for
+	DestinationDir   string         // The destination directory for downloaded pods that will act as hooks
+	ExecDir          string         // The directory that will actually be executed by the HookDir
 	Logger           logging.Logger
 	authPolicy       auth.Policy
 	artifactVerifier auth.ArtifactVerifier

--- a/pkg/preparer/listener_test.go
+++ b/pkg/preparer/listener_test.go
@@ -14,10 +14,12 @@ import (
 	. "github.com/square/p2/Godeps/_workspace/src/github.com/anthonybishopric/gotcha"
 	"github.com/square/p2/Godeps/_workspace/src/golang.org/x/crypto/openpgp"
 	"github.com/square/p2/Godeps/_workspace/src/golang.org/x/crypto/openpgp/clearsign"
+
 	"github.com/square/p2/pkg/auth"
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
 )
 
@@ -34,7 +36,7 @@ func fakeStoreWithManifests(manifests ...kp.ManifestResult) *fakeIntentStore {
 	}
 }
 
-func (f *fakeIntentStore) WatchPods(podPrefix kp.PodPrefix, nodeName string, quitCh <-chan struct{}, errCh chan<- error, podCh chan<- []kp.ManifestResult) {
+func (f *fakeIntentStore) WatchPods(podPrefix kp.PodPrefix, nodeName types.NodeName, quitCh <-chan struct{}, errCh chan<- error, podCh chan<- []kp.ManifestResult) {
 	go func() {
 		podCh <- f.manifests
 		if f.errToSend != nil {
@@ -46,7 +48,7 @@ func (f *fakeIntentStore) WatchPods(podPrefix kp.PodPrefix, nodeName string, qui
 	<-quitCh
 }
 
-func (f *fakeIntentStore) ListPods(podPrefix kp.PodPrefix, nodeName string) ([]kp.ManifestResult, time.Duration, error) {
+func (f *fakeIntentStore) ListPods(podPrefix kp.PodPrefix, nodeName types.NodeName) ([]kp.ManifestResult, time.Duration, error) {
 	return f.manifests, 0, nil
 }
 

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -34,13 +34,13 @@ type Hooks interface {
 }
 
 type Store interface {
-	ListPods(podPrefix kp.PodPrefix, nodeName string) ([]kp.ManifestResult, time.Duration, error)
-	SetPod(podPrefix kp.PodPrefix, noeName string, podManifest pods.Manifest) (time.Duration, error)
-	Pod(podPrefix kp.PodPrefix, nodeName string, podId types.PodID) (pods.Manifest, time.Duration, error)
-	DeletePod(podPrefix kp.PodPrefix, nodeName string, podId types.PodID) (time.Duration, error)
+	ListPods(podPrefix kp.PodPrefix, nodeName types.NodeName) ([]kp.ManifestResult, time.Duration, error)
+	SetPod(podPrefix kp.PodPrefix, nodeName types.NodeName, podManifest pods.Manifest) (time.Duration, error)
+	Pod(podPrefix kp.PodPrefix, nodeName types.NodeName, podId types.PodID) (pods.Manifest, time.Duration, error)
+	DeletePod(podPrefix kp.PodPrefix, nodeName types.NodeName, podId types.PodID) (time.Duration, error)
 	WatchPods(
 		podPrefix kp.PodPrefix,
-		nodeName string,
+		nodeName types.NodeName,
 		quitChan <-chan struct{},
 		errorChan chan<- error,
 		podChan chan<- []kp.ManifestResult,

--- a/pkg/preparer/orchestrate_test.go
+++ b/pkg/preparer/orchestrate_test.go
@@ -160,7 +160,7 @@ type FakeStore struct {
 	currentManifestError error
 }
 
-func (f *FakeStore) ListPods(kp.PodPrefix, string) ([]kp.ManifestResult, time.Duration, error) {
+func (f *FakeStore) ListPods(kp.PodPrefix, types.NodeName) ([]kp.ManifestResult, time.Duration, error) {
 	if f.currentManifest == nil {
 		return nil, 0, nil
 	}
@@ -172,19 +172,19 @@ func (f *FakeStore) ListPods(kp.PodPrefix, string) ([]kp.ManifestResult, time.Du
 	}, 0, nil
 }
 
-func (f *FakeStore) SetPod(kp.PodPrefix, string, pods.Manifest) (time.Duration, error) {
+func (f *FakeStore) SetPod(kp.PodPrefix, types.NodeName, pods.Manifest) (time.Duration, error) {
 	return 0, nil
 }
 
-func (f *FakeStore) Pod(kp.PodPrefix, string, types.PodID) (pods.Manifest, time.Duration, error) {
+func (f *FakeStore) Pod(kp.PodPrefix, types.NodeName, types.PodID) (pods.Manifest, time.Duration, error) {
 	return nil, 0, fmt.Errorf("not implemented")
 }
 
-func (f *FakeStore) DeletePod(kp.PodPrefix, string, types.PodID) (time.Duration, error) {
+func (f *FakeStore) DeletePod(kp.PodPrefix, types.NodeName, types.PodID) (time.Duration, error) {
 	return 0, nil
 }
 
-func (f *FakeStore) WatchPods(kp.PodPrefix, string, <-chan struct{}, chan<- error, chan<- []kp.ManifestResult) {
+func (f *FakeStore) WatchPods(kp.PodPrefix, types.NodeName, <-chan struct{}, chan<- error, chan<- []kp.ManifestResult) {
 }
 
 func testPreparer(t *testing.T, f *FakeStore) (*Preparer, *fakeHooks, string) {

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -41,7 +41,7 @@ type LogDestination struct {
 }
 
 type Preparer struct {
-	node                   string
+	node                   types.NodeName
 	store                  Store
 	hooks                  Hooks
 	hookListener           HookListener
@@ -55,7 +55,7 @@ type Preparer struct {
 }
 
 type PreparerConfig struct {
-	NodeName               string                 `yaml:"node_name"`
+	NodeName               types.NodeName         `yaml:"node_name"`
 	ConsulAddress          string                 `yaml:"consul_address"`
 	ConsulHttps            bool                   `yaml:"consul_https,omitempty"`
 	ConsulTokenPath        string                 `yaml:"consul_token_path,omitempty"`
@@ -130,7 +130,12 @@ func UnmarshalConfig(config []byte) (*PreparerConfig, error) {
 	}
 
 	if preparerConfig.NodeName == "" {
-		preparerConfig.NodeName, _ = os.Hostname()
+		hostname, err := os.Hostname()
+		if err != nil {
+			return nil, util.Errorf("Couldn't determine hostname: %s", err)
+		}
+
+		preparerConfig.NodeName = types.NodeName(hostname)
 	}
 	if preparerConfig.ConsulAddress == "" {
 		preparerConfig.ConsulAddress = DefaultConsulAddress

--- a/pkg/preparer/setup_test.go
+++ b/pkg/preparer/setup_test.go
@@ -14,7 +14,7 @@ func TestLoadConfigWillMarshalYaml(t *testing.T) {
 	preparerConfig, err := LoadConfig(configPath)
 	Assert(t).IsNil(err, "should have read config correctly")
 
-	Assert(t).AreEqual("foohost", preparerConfig.NodeName, "did not read the node name correctly")
+	Assert(t).AreEqual("foohost", preparerConfig.NodeName.String(), "did not read the node name correctly")
 	Assert(t).AreEqual("0.0.0.0", preparerConfig.ConsulAddress, "did not read the consul address correctly")
 	Assert(t).IsTrue(preparerConfig.ConsulHttps, "did not read consul HTTPS correctly (should be true)")
 	Assert(t).AreEqual("/etc/p2/hooks", preparerConfig.HooksDirectory, "did not read the hooks directory correctly")

--- a/pkg/rc/replication_controller_test.go
+++ b/pkg/rc/replication_controller_test.go
@@ -22,21 +22,21 @@ type fakeKpStore struct {
 	manifests map[string]pods.Manifest
 }
 
-func (s *fakeKpStore) SetPod(podPrefix kp.PodPrefix, nodeName string, manifest pods.Manifest) (time.Duration, error) {
-	key := path.Join(string(podPrefix), nodeName, string(manifest.ID()))
+func (s *fakeKpStore) SetPod(podPrefix kp.PodPrefix, nodeName types.NodeName, manifest pods.Manifest) (time.Duration, error) {
+	key := path.Join(string(podPrefix), nodeName.String(), string(manifest.ID()))
 	s.manifests[key] = manifest
 	return 0, nil
 }
 
-func (s *fakeKpStore) DeletePod(podPrefix kp.PodPrefix, nodeName string, podID types.PodID) (time.Duration, error) {
-	key := path.Join(string(podPrefix), nodeName, string(podID))
+func (s *fakeKpStore) DeletePod(podPrefix kp.PodPrefix, nodeName types.NodeName, podID types.PodID) (time.Duration, error) {
+	key := path.Join(string(podPrefix), nodeName.String(), podID.String())
 	delete(s.manifests, key)
 	return 0, nil
 }
 
-func (s *fakeKpStore) Pod(podPrefix kp.PodPrefix, nodeName string, podID types.PodID) (
+func (s *fakeKpStore) Pod(podPrefix kp.PodPrefix, nodeName types.NodeName, podID types.PodID) (
 	pods.Manifest, time.Duration, error) {
-	key := path.Join(string(podPrefix), nodeName, string(podID))
+	key := path.Join(string(podPrefix), nodeName.String(), podID.String())
 	if manifest, ok := s.manifests[key]; ok {
 		return manifest, 0, nil
 	}

--- a/pkg/rc/scheduler.go
+++ b/pkg/rc/scheduler.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/types"
 )
 
 // A Scheduler decides what nodes are appropriate for a pod to run on.
 // It potentially takes into account considerations such as existing load on the nodes,
 // label selectors, and more.
 type Scheduler interface {
-	EligibleNodes(pods.Manifest, klabels.Selector) ([]string, error)
+	EligibleNodes(pods.Manifest, klabels.Selector) ([]types.NodeName, error)
 }
 
 type applicatorScheduler struct {
@@ -24,15 +25,15 @@ func NewApplicatorScheduler(applicator labels.Applicator) *applicatorScheduler {
 	return &applicatorScheduler{applicator: applicator}
 }
 
-func (sel *applicatorScheduler) EligibleNodes(_ pods.Manifest, selector klabels.Selector) ([]string, error) {
+func (sel *applicatorScheduler) EligibleNodes(_ pods.Manifest, selector klabels.Selector) ([]types.NodeName, error) {
 	nodes, err := sel.applicator.GetMatches(selector, labels.NODE)
 	if err != nil {
-		return []string{}, err
+		return nil, err
 	}
 
-	result := make([]string, len(nodes))
+	result := make([]types.NodeName, len(nodes))
 	for i, node := range nodes {
-		result[i] = node.ID
+		result[i] = types.NodeName(node.ID)
 	}
 	return result, nil
 }

--- a/pkg/replication/replication_test.go
+++ b/pkg/replication/replication_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/square/p2/pkg/health"
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/labels"
+	"github.com/square/p2/pkg/types"
 )
 
 func TestEnact(t *testing.T) {
@@ -94,7 +95,7 @@ func TestWaitsForHealthy(t *testing.T) {
 	// Mark first node as unhealthy and the remainder as healthy
 	for i, node := range testNodes {
 		if i == 0 {
-			go func(node string) {
+			go func(node types.NodeName) {
 				for x := 0; x < 5; x++ {
 					resultsCh[node] <- health.Result{
 						ID:     testPodId,
@@ -113,7 +114,7 @@ func TestWaitsForHealthy(t *testing.T) {
 		} else {
 			// Mark the rest of the nodes as healthy constantly and
 			// quit once replication is over
-			go func(node string) {
+			go func(node types.NodeName) {
 				for {
 					select {
 					case resultsCh[node] <- health.Result{
@@ -188,7 +189,7 @@ func TestReplicationStopsIfCanceled(t *testing.T) {
 	// succeed successfully
 	healthFedChannel := make(chan struct{})
 	for _, node := range testNodes {
-		go func(node string) {
+		go func(node types.NodeName) {
 			for i := 0; i < 5; i++ {
 				select {
 				case resultsCh[node] <- health.Result{
@@ -297,7 +298,7 @@ func TestStopsIfLockDestroyed(t *testing.T) {
 	// Report unhealthy for all nodes so replication cannot finish without
 	// interruption
 	for _, node := range testNodes {
-		go func(node string) {
+		go func(node types.NodeName) {
 			for {
 				select {
 				case resultsCh[node] <- health.Result{

--- a/pkg/replication/replicator.go
+++ b/pkg/replication/replicator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/preparer"
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
 )
 
@@ -22,7 +23,7 @@ type Replicator interface {
 type replicator struct {
 	manifest  pods.Manifest // the manifest to replicate
 	logger    logging.Logger
-	nodes     []string
+	nodes     []types.NodeName
 	active    int // maximum number of nodes to update concurrently
 	store     kp.Store
 	labeler   labels.Applicator
@@ -35,7 +36,7 @@ type replicator struct {
 func NewReplicator(
 	manifest pods.Manifest,
 	logger logging.Logger,
-	nodes []string,
+	nodes []types.NodeName,
 	active int,
 	store kp.Store,
 	labeler labels.Applicator,

--- a/pkg/replication/replicator_test.go
+++ b/pkg/replication/replicator_test.go
@@ -195,7 +195,7 @@ func TestInitializeReplicationWithManaged(t *testing.T) {
 	// Make one node appear to be managed by a replication controller
 	err := labels.NewConsulApplicator(f.Client, 1).SetLabel(
 		labels.POD,
-		path.Join(testNodes[0], testPodId),
+		path.Join(testNodes[0].String(), testPodId),
 		rc.RCIDLabel,
 		"controller GUID ignored",
 	)

--- a/pkg/roll/run_update.go
+++ b/pkg/roll/run_update.go
@@ -141,7 +141,7 @@ func (u *update) Run(quit <-chan struct{}) (ret bool) {
 		return
 	}
 
-	hChecks := make(chan map[string]health.Result)
+	hChecks := make(chan map[types.NodeName]health.Result)
 	hErrs := make(chan error)
 	hQuit := make(chan struct{})
 	defer close(hQuit)
@@ -169,7 +169,7 @@ func (u *update) Run(quit <-chan struct{}) (ret bool) {
 }
 
 // returns true if roll succeeded, false if asked to quit.
-func (u *update) rollLoop(podID types.PodID, hChecks <-chan map[string]health.Result, hErrs <-chan error, quit <-chan struct{}) bool {
+func (u *update) rollLoop(podID types.PodID, hChecks <-chan map[types.NodeName]health.Result, hErrs <-chan error, quit <-chan struct{}) bool {
 	for {
 		select {
 		case <-quit:
@@ -367,7 +367,7 @@ type rcNodeCounts struct {
 	Unknown   int // the number of real nodes that are of unknown health
 }
 
-func (u *update) countHealthy(id rcf.ID, checks map[string]health.Result) (rcNodeCounts, error) {
+func (u *update) countHealthy(id rcf.ID, checks map[types.NodeName]health.Result) (rcNodeCounts, error) {
 	ret := rcNodeCounts{}
 	rcFields, err := u.rcs.Get(id)
 	if rcstore.IsNotExist(err) {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -3,6 +3,10 @@
 // wish to use pods.ID, an import cycle is created.
 package types
 
+import (
+	"github.com/square/p2/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/sets"
+)
+
 type NodeName string
 type PodID string
 
@@ -12,4 +16,54 @@ func (n NodeName) String() string {
 
 func (p PodID) String() string {
 	return string(p)
+}
+
+// Wraps sets.String to provide the functionality of a set when dealing with
+// the NodeName type (which is a string)
+type NodeSet struct {
+	sets.String
+}
+
+func NewNodeSet(nodes ...NodeName) NodeSet {
+	nodeStrings := make([]string, len(nodes))
+	for i, node := range nodes {
+		nodeStrings[i] = node.String()
+	}
+
+	return NodeSet{
+		String: sets.NewString(nodeStrings...),
+	}
+}
+
+func (n NodeSet) ListNodes() []NodeName {
+	strings := n.List()
+	nodes := make([]NodeName, len(strings))
+	for i, str := range strings {
+		nodes[i] = NodeName(str)
+	}
+	return nodes
+}
+
+func (n NodeSet) InsertNode(node NodeName) {
+	n.String.Insert(node.String())
+}
+
+func (n NodeSet) DeleteNode(node NodeName) {
+	n.String.Delete(node.String())
+}
+
+func (n NodeSet) Difference(other NodeSet) NodeSet {
+	diff := n.String.Difference(other.String)
+	return NodeSet{
+		String: diff,
+	}
+}
+
+func (n NodeSet) Equal(other NodeSet) bool {
+	return n.String.Equal(other.String)
+}
+
+func (n NodeSet) PopAny() (NodeName, bool) {
+	node, ok := n.String.PopAny()
+	return NodeName(node), ok
 }

--- a/pkg/watch/health.go
+++ b/pkg/watch/health.go
@@ -50,7 +50,7 @@ type PodWatch struct {
 // a status check on a particular service
 type StatusChecker struct {
 	ID     types.PodID
-	Node   string
+	Node   types.NodeName
 	URI    string
 	Client *http.Client
 }
@@ -123,7 +123,7 @@ func updatePods(
 	insecureClient *http.Client,
 	current []PodWatch,
 	reality []kp.ManifestResult,
-	node string,
+	node types.NodeName,
 	logger *logging.Logger,
 ) []PodWatch {
 	newCurrent := []PodWatch{}
@@ -160,7 +160,7 @@ func updatePods(
 		}
 
 		var client *http.Client
-		var statusHost string
+		var statusHost types.NodeName
 		if man.Manifest.GetStatusLocalhostOnly() {
 			statusHost = "localhost"
 			client = insecureClient


### PR DESCRIPTION
Due to returning a value of type types.NodeName from that function,
there was a lot of fallout of changing node names with string type to
use types.NodeName instead.