### PR TITLE
Only call `SyncCluster` if pods or cluster change.

### DIFF
--- a/pkg/kp/pcstore/consul_store_test.go
+++ b/pkg/kp/pcstore/consul_store_test.go
@@ -138,7 +138,7 @@ func TestGet(t *testing.T) {
 	}
 
 	if pc.PodID == "" {
-		t.Errorf("pod cluster should have an id")
+		t.Errorf("pod cluster should have a pod id")
 	}
 
 	if pc.PodID != podID {

--- a/pkg/kp/pcstore/store.go
+++ b/pkg/kp/pcstore/store.go
@@ -77,10 +77,12 @@ type ConcreteSyncer interface {
 	// When a ConcreteSyncer is passed to WatchAndSync, SyncCluster is called
 	// every time the set of labeled pods change, the pod cluster's metadata
 	// changes, or when the long-lived watch on the pod cluster store returns.
-	// This function is expected to be idempotent. Returned errors do not change
-	// the rules for invocation of this function.
+	// This function is expected to be idempotent.
 	//
 	// SyncCluster will be called for every pod cluster present in the store.
+	// If this function returns an error, SyncCluster will be called again later
+	// with the same cluster and pods, assuming that no changes occur in the intervening
+	// period.
 	//
 	// ConcreteSyncers will be called concurrently and must operate safely.
 	SyncCluster(pc *fields.PodCluster, pods []labels.Labeled) error


### PR DESCRIPTION
`SyncCluster` would previously be called on every return from the
label watch. Clients were implementing their own variation of rate
limiting and throttling to deal with the flow of calls. This change
reduces the frequency of unnecessary calls to `SyncCluster`.

`SyncCluster` is still expected to be idempotent. It is still guaranteed
to be called (possibly redundantly) when the watch against the pcstore
expires.