### PR TITLE
Make the pcstore constructor take api.Client as a pointer

### DIFF
--- a/pkg/kp/pcstore/consul_store.go
+++ b/pkg/kp/pcstore/consul_store.go
@@ -37,9 +37,9 @@ var _ Store = &consulStore{}
 // NOTE: The "retries" concept is mimicking what is built in rcstore.
 // TODO: explore transactionality of operations and returning errors instead of
 // using retries
-func NewConsul(client api.Client, retries int, logger *logging.Logger) Store {
+func NewConsul(client *api.Client, retries int, logger *logging.Logger) Store {
 	return &consulStore{
-		applicator: labels.NewConsulApplicator(&client, retries),
+		applicator: labels.NewConsulApplicator(client, retries),
 		kv:         client.KV(),
 		logger:     *logger,
 	}


### PR DESCRIPTION
This makes it consistent with our other store types instead of being the
single case that takes a value instead of a pointer.