### PR TITLE
add a PodClusterAlreadyExists error type

### DIFF
--- a/pkg/kp/pcstore/consul_store.go
+++ b/pkg/kp/pcstore/consul_store.go
@@ -66,7 +66,7 @@ func (s *consulStore) Create(
 		return fields.PodCluster{}, util.Errorf("Couldn't determine if pod cluster exists already: %v", err)
 	}
 	if len(existing) > 0 {
-		return existing[0], util.Errorf("Pod cluster already exists for %v", pcCreateLockPath(podID, availabilityZone, clusterName))
+		return existing[0], PodClusterAlreadyExists
 	}
 
 	pc := fields.PodCluster{

--- a/pkg/kp/pcstore/store.go
+++ b/pkg/kp/pcstore/store.go
@@ -13,7 +13,10 @@ import (
 
 const podClusterTree string = "pod_clusters"
 
-var NoPodCluster error = errors.New("No pod cluster found")
+var (
+	NoPodCluster            error = errors.New("No pod cluster found")
+	PodClusterAlreadyExists error = errors.New("Pod cluster already exists")
+)
 
 type Session interface {
 	Lock(key string) (consulutil.Unlocker, error)
@@ -108,4 +111,8 @@ type ConcreteSyncer interface {
 
 func IsNotExist(err error) bool {
 	return err == NoPodCluster
+}
+
+func IsAlreadyExists(err error) bool {
+	return err == PodClusterAlreadyExists
 }


### PR DESCRIPTION
This allows callers to attempt to create pod clusters and have custom
handling for the case where a pod cluster creation fails due to the pod
cluster already existing. This is useful when relying on idempotent
creation for example.