### PR TITLE
Log bridge metrics

### DIFF
--- a/bin/p2-log-bridge/main.go
+++ b/bin/p2-log-bridge/main.go
@@ -54,7 +54,7 @@ func main() {
 	go func(r io.Reader, durableWriter, lossyWriter io.Writer, logger logging.Logger) {
 		defer wg.Done()
 
-		lb := logbridge.NewLogBridge(r, durableWriter, lossyWriter, logger, nil)
+		lb := logbridge.NewLogBridge(r, durableWriter, lossyWriter, logger, nil, "log_lines", "logged_bytes")
 
 		lb.Tee()
 		logging.DefaultLogger.NoFields().Infoln("logbridge Tee returned. Shutting down subordinate log command.")

--- a/bin/p2-log-bridge/main.go
+++ b/bin/p2-log-bridge/main.go
@@ -54,7 +54,9 @@ func main() {
 	go func(r io.Reader, durableWriter, lossyWriter io.Writer, logger logging.Logger) {
 		defer wg.Done()
 
-		logbridge.Tee(r, durableWriter, lossyWriter, logger)
+		lb := logbridge.NewLogBridge(r, durableWriter, lossyWriter, logger, nil)
+
+		lb.Tee()
 		logging.DefaultLogger.NoFields().Infoln("logbridge Tee returned. Shutting down subordinate log command.")
 		durablePipe.Close()
 	}(os.Stdin, durablePipe, os.Stdout, logging.DefaultLogger)


### PR DESCRIPTION
logbridge needs a metric registry so we can understand log lines per unit time and log bytes per unit time.