### PR TITLE
Collect metrics on SyncCluster() time

### DIFF
--- a/bin/p2-watch/main.go
+++ b/bin/p2-watch/main.go
@@ -98,6 +98,10 @@ func (p *printSyncer) GetInitialClusters() ([]fields.ID, error) {
 	return []fields.ID{}, nil
 }
 
+func (p *printSyncer) Type() pcstore.ConcreteSyncerType {
+	return "print_syncer"
+}
+
 func watchPodClusters(client *api.Client) {
 	logger := &logging.DefaultLogger
 	logger.Infoln("Beginning pod cluster watch")

--- a/pkg/kp/pcstore/store.go
+++ b/pkg/kp/pcstore/store.go
@@ -107,6 +107,10 @@ type ConcreteSyncer interface {
 	// used. If the function results in an error, the WatchAndSync function will
 	// terminate immediately, forwarding the error.
 	GetInitialClusters() ([]fields.ID, error)
+
+	// Used to derive the syncer type from a syncer instance for things
+	// like namespacing of metrics
+	Type() ConcreteSyncerType
 }
 
 func IsNotExist(err error) bool {


### PR DESCRIPTION
For certain syncer types, it may take non-negligible amounts of time to
sync a pod cluster. This commit adds support for providing a metrics
registry to the pod cluster store. If a registry is set, a metric will
be added for pod cluster sync time and data points will be collected.