### PR TITLE
add SetMetricsRegistry to the pcstore.Store interface

### DIFF
--- a/pkg/kp/pcstore/consul_store.go
+++ b/pkg/kp/pcstore/consul_store.go
@@ -28,12 +28,6 @@ type consulKV interface {
 	List(prefix string, opts *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error)
 }
 
-// Subset of metrics.Registry interface
-type MetricsRegistry interface {
-	Get(metricName string) interface{}
-	Register(metricName string, metric interface{}) error
-}
-
 type consulStore struct {
 	kv         consulKV
 	applicator labels.Applicator

--- a/pkg/kp/pcstore/pcstoretest/fake_pcstore.go
+++ b/pkg/kp/pcstore/pcstoretest/fake_pcstore.go
@@ -144,3 +144,6 @@ func (p *FakePCStore) LockForSync(id fields.ID, syncerType pcstore.ConcreteSynce
 	key := fmt.Sprintf("%s/%s", id, syncerType)
 	return session.Lock(key)
 }
+
+func (p *FakePCStore) SetMetricsRegistry(_ pcstore.MetricsRegistry) {
+}

--- a/pkg/kp/pcstore/store.go
+++ b/pkg/kp/pcstore/store.go
@@ -33,6 +33,12 @@ type WatchedPodClusters struct {
 	Err      error
 }
 
+// Subset of metrics.Registry interface
+type MetricsRegistry interface {
+	Get(metricName string) interface{}
+	Register(metricName string, metric interface{}) error
+}
+
 type Store interface {
 	Create(
 		podID types.PodID,
@@ -61,6 +67,8 @@ type Store interface {
 	// details on how to use this function
 	WatchAndSync(syncer ConcreteSyncer, quit <-chan struct{}) error
 	LockForSync(id fields.ID, syncerType ConcreteSyncerType, session Session) (consulutil.Unlocker, error)
+
+	SetMetricsRegistry(reg MetricsRegistry)
 }
 
 // There may be multiple implementations of ConcreteSyncer that are interested


### PR DESCRIPTION
This makes it usable by code that doesn't have access to the concrete
type.