### PR TITLE
Fix a bug where a label watch wouldn't be started for some pod clusters

### DIFF
--- a/pkg/kp/pcstore/consul_store.go
+++ b/pkg/kp/pcstore/consul_store.go
@@ -490,17 +490,13 @@ func (s *consulStore) getInitialClusters(syncer ConcreteSyncer) (WatchedPodClust
 	}
 
 	for _, id := range initial {
-		existing, err := s.Get(id)
-		if err == NoPodCluster {
-			s.logger.WithField("pc_id", id).Warnf("Could not find initial cluster %v, will call DeleteCluster momentarily", id)
-			existing = fields.PodCluster{
-				ID: id,
-			}
-		} else if err != nil {
-			s.logger.WithField("pc_id", id).Errorln("Error retrieving pod cluster from consul")
-			return prevResults, err
-		}
-		prevResults.Clusters = append(prevResults.Clusters, &existing)
+		// We only populate the existing cluster with the ID. It's a little strange
+		// but this means that there will definitely be a "change" for the cluster
+		// when the watch is started, resulting in the label watch being started
+		// as well
+		prevResults.Clusters = append(prevResults.Clusters, &fields.PodCluster{
+			ID: id,
+		})
 	}
 	return prevResults, nil
 }


### PR DESCRIPTION
pcstore.WatchAndSync() calls the concrete syncer's GetInitialClusters()
function in order to notify the syncers of pod cluster deletions that
occurred when the syncer wasn't running.

However, handlePCUpdates only begins a label query on the pod cluster's
pod selector if something has changed, and there was no apparent change
since we were seeding the data with the GetInitialClusters() call.

This commit fixes that by only seeding the pod cluster changes with the
ID of the pod cluster if it was returned in GetInitialClusters().

The behavior change of this is that a watch will be started for every
pod cluster, and a SyncCluster() call will also be called once per pod
cluster even if the view of the world hasn't changed, perhaps resulting
in some performance degradation when the syncer starts up.