### PR TITLE
Use a metrics.Gauge to measure pod cluster sync time

### DIFF
--- a/pkg/kp/pcstore/consul_store_test.go
+++ b/pkg/kp/pcstore/consul_store_test.go
@@ -622,7 +622,7 @@ func TestConcreteSyncer(t *testing.T) {
 	}
 
 	changes := make(chan podClusterChange)
-	go store.handlePCUpdates(syncer, changes, metrics.NewTimer())
+	go store.handlePCUpdates(syncer, changes, metrics.NewGauge())
 
 	select {
 	case changes <- change:
@@ -743,7 +743,7 @@ func TestConcreteSyncerWithPrevious(t *testing.T) {
 	}
 
 	changes := make(chan podClusterChange)
-	go store.handlePCUpdates(syncer, changes, metrics.NewTimer())
+	go store.handlePCUpdates(syncer, changes, metrics.NewGauge())
 
 	select {
 	case changes <- change:
@@ -902,7 +902,7 @@ func TestClosedChangeChannelResultsInTermination(t *testing.T) {
 	closed := make(chan struct{})
 
 	go func() {
-		store.handlePCUpdates(syncer, changes, metrics.NewTimer())
+		store.handlePCUpdates(syncer, changes, metrics.NewGauge())
 		close(closed)
 	}()
 


### PR DESCRIPTION
Previously a metrics.Timer was used, but it is more straightforward to
use a Gauge. The most recent processing time can be extracted with
gauge.Value()