### PR TITLE
Use a histogram instead of a gauge for recording pod cluster sync time

### DIFF
--- a/pkg/kp/pcstore/consul_store_test.go
+++ b/pkg/kp/pcstore/consul_store_test.go
@@ -622,7 +622,7 @@ func TestConcreteSyncer(t *testing.T) {
 	}
 
 	changes := make(chan podClusterChange)
-	go store.handlePCUpdates(syncer, changes, metrics.NewGauge())
+	go store.handlePCUpdates(syncer, changes, metrics.NewHistogram(metrics.NewExpDecaySample(1028, 0.015)))
 
 	select {
 	case changes <- change:
@@ -743,7 +743,7 @@ func TestConcreteSyncerWithPrevious(t *testing.T) {
 	}
 
 	changes := make(chan podClusterChange)
-	go store.handlePCUpdates(syncer, changes, metrics.NewGauge())
+	go store.handlePCUpdates(syncer, changes, metrics.NewHistogram(metrics.NewExpDecaySample(1028, 0.015)))
 
 	select {
 	case changes <- change:
@@ -902,7 +902,7 @@ func TestClosedChangeChannelResultsInTermination(t *testing.T) {
 	closed := make(chan struct{})
 
 	go func() {
-		store.handlePCUpdates(syncer, changes, metrics.NewGauge())
+		store.handlePCUpdates(syncer, changes, metrics.NewHistogram(metrics.NewExpDecaySample(1028, 0.015)))
 		close(closed)
 	}()
 


### PR DESCRIPTION
A histogram makes more sense here because pod cluster updates will be
frequent and fast, while a metrics graphing library may only sample
metrics every 30 seconds for example. A histogram metric will provide a
more useful average with an exponentially decaying window to smooth out
outliers.