### PR TITLE
Make launchable.Location a url.URL type instead of a string

### DIFF
--- a/bin/p2-bin2pod/main.go
+++ b/bin/p2-bin2pod/main.go
@@ -39,7 +39,7 @@ var (
     cat example.json | jq '.["tar_path"] | xargs -I {} cp {} ~/test_file_server_dir
     cat example.json | jq '.["manifest_path"] | xargs -I {} curl -X PUT https://consul.dev:8500/api/v1/kv/intent/$(hostname)/example -d {}
     `)
-	executable    = bin2pod.Arg("executable", "the executable to turn into a hoist artifact + pod manifest. The format of executable is of a URL.").Required().String()
+	executable    = bin2pod.Arg("executable", "the executable to turn into a hoist artifact + pod manifest. The format of executable is of a URL.").Required().URL()
 	id            = bin2pod.Flag("id", "The ID of the pod. By default this is the name of the executable passed").String()
 	location      = bin2pod.Flag("location", "The location where the outputted tar will live. The characters {} will be replaced with the unique basename of the tar, including its SHA. If not provided, the location will be a file path to the resulting tar from the build, which is included in the output of this script. Users must copy the resultant tar to the new location if it is different from the default output path.").String()
 	workDirectory = bin2pod.Flag("work-dir", "A directory where the results will be written.").ExistingDir()
@@ -56,7 +56,7 @@ func podId() types.PodID {
 	if *id != "" {
 		return types.PodID(*id)
 	}
-	return types.PodID(path.Base(*executable))
+	return types.PodID(path.Base((*executable).Path))
 }
 
 func activeDir() string {
@@ -130,25 +130,30 @@ func makeTar(workingDir string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("Couldn't make a new working directory %s for tarring: %s", tarContents, err)
 	}
+
 	err = os.MkdirAll(path.Join(tarContents, "bin"), 0744)
 	if err != nil {
 		return "", fmt.Errorf("Couldn't make bin directory in %s: %s", tarContents, err)
 	}
 	launchablePath := path.Join(tarContents, "bin", "launch")
+
 	err = uri.URICopy(*executable, launchablePath)
 	if err != nil {
 		return "", fmt.Errorf("Couldn't copy from %s.: %s", *executable, err)
 	}
+
 	err = os.Chmod(launchablePath, 0755) // make file executable by all.
 	if err != nil {
 		return "", fmt.Errorf("Couldn't make %s executable: %s", launchablePath, err)
 	}
-	tarPath := path.Join(workingDir, fmt.Sprintf("%s_%s.tar.gz", path.Base(*executable), randomSuffix()))
+
+	tarPath := path.Join(workingDir, fmt.Sprintf("%s_%s.tar.gz", path.Base((**executable).Path), randomSuffix()))
 	cmd := exec.Command("tar", "-czvf", tarPath, "-C", tarContents, ".")
 	err = cmd.Run()
 	if err != nil {
 		return "", fmt.Errorf("Couldn't build tar: %s", err)
 	}
+
 	return tarPath, nil
 }
 

--- a/bin/p2-install-hook/main.go
+++ b/bin/p2-install-hook/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	manifestURI = kingpin.Arg("manifest", "a path or url to a pod manifest that will be installed and launched immediately.").String()
+	manifestURI = kingpin.Arg("manifest", "a path or url to a pod manifest that will be installed and launched immediately.").URL()
 	podRoot     = kingpin.Flag("pod-root", "the root of the pods directory").Default(pods.DEFAULT_PATH).String()
 	hookRoot    = kingpin.Flag("hook-root", "the root of the hook scripts directory").Default(hooks.DEFAULT_PATH).String()
 	hookType    = kingpin.Flag("hook-type", "the type of the hook (if unspecified, defaults to global)").String()

--- a/bin/p2-launch/main.go
+++ b/bin/p2-launch/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	manifestURI  = kingpin.Arg("manifest", "a path or url to a pod manifest that will be installed and launched immediately.").Required().ExistingFile()
+	manifestURI  = kingpin.Arg("manifest", "a path to a pod manifest that will be installed and launched immediately.").Required().URL()
 	podRoot      = kingpin.Flag("pod-root", "the root of the pods directory").Default(pods.DEFAULT_PATH).Short('p').String()
 	authType     = kingpin.Flag("auth-type", "the auth policy to use e.g. (none, keyring, user)").Short('a').Default("none").String()
 	keyring      = kingpin.Flag("keyring", "the pgp keyring to use for auth policies if --auth-type other than none is given").Short('k').ExistingFile()

--- a/bin/p2-replicate/main.go
+++ b/bin/p2-replicate/main.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	manifestUri       = kingpin.Arg("manifest", "a path or url to a pod manifest that will be replicated.").Required().String()
+	manifestUri       = kingpin.Arg("manifest", "a path or url to a pod manifest that will be replicated.").Required().URL()
 	hosts             = kingpin.Arg("hosts", "Hosts to replicate to").Required().Strings()
 	minNodes          = kingpin.Flag("min-nodes", "The minimum number of healthy nodes that must remain up while replicating.").Default("1").Short('m').Int()
 	threshold         = kingpin.Flag("threshold", "The minimum health level to treat as healthy. One of (in order) passing, warning, unknown, critical.").String()

--- a/pkg/auth/artifact_verifier_test.go
+++ b/pkg/auth/artifact_verifier_test.go
@@ -1,8 +1,8 @@
 package auth
 
 import (
-	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -45,7 +45,13 @@ func testVerifiedWithFiles(t *testing.T, files []testFile, verifier ArtifactVeri
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = verifier.VerifyHoistArtifact(localCopy, fmt.Sprintf("file://%v", filePath))
+
+	url := &url.URL{
+		Scheme: "file",
+		Path:   filePath,
+	}
+
+	err = verifier.VerifyHoistArtifact(localCopy, url)
 	if err != nil {
 		t.Fatalf("Expected files %v to pass verification, got: %v", files, err)
 	}
@@ -59,7 +65,13 @@ func testNotVerifiedWithFiles(t *testing.T, files []testFile, verifier ArtifactV
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = verifier.VerifyHoistArtifact(localCopy, fmt.Sprintf("file://%v", filePath))
+
+	url := &url.URL{
+		Scheme: "file",
+		Path:   filePath,
+	}
+
+	err = verifier.VerifyHoistArtifact(localCopy, url)
 	if err == nil {
 		t.Fatal("Expected files %v to fail verification, but didn't")
 	}

--- a/pkg/digest/verification.go
+++ b/pkg/digest/verification.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -113,16 +114,17 @@ func VerifyDir(root string, digest map[string]string) error {
 // not declare a signature path, use "".
 func ParseUris(
 	fetcher uri.Fetcher,
-	digestUri string,
-	signatureUri string,
+	digestUri *url.URL,
+	signatureUri *url.URL,
 ) (Digest, error) {
 	digest, err := fetcher.Open(digestUri)
 	if err != nil {
 		return Digest{}, err
 	}
 	defer digest.Close()
+
 	var signature io.ReadCloser
-	if signatureUri != "" {
+	if signatureUri != nil {
 		signature, err = fetcher.Open(signatureUri)
 		if err != nil {
 			return Digest{}, err

--- a/pkg/hoist/hoist_launchable_test.go
+++ b/pkg/hoist/hoist_launchable_test.go
@@ -2,6 +2,7 @@ package hoist
 
 import (
 	"io/ioutil"
+	"net/url"
 	"os"
 	"os/user"
 	"path"
@@ -25,8 +26,12 @@ func TestInstall(t *testing.T) {
 	currentUser, err := user.Current()
 	Assert(t).IsNil(err, "test setup: couldn't get current user")
 
-	testLocation := testContext.ExpandPath("hoisted-hello_def456.tar.gz")
+	testLocation := &url.URL{
+		Path: testContext.ExpandPath("hoisted-hello_def456.tar.gz"),
+	}
+
 	launchableHome, err := ioutil.TempDir("", "launchable_home")
+	Assert(t).IsNil(err, "test setup: couldn't create temp dir")
 	defer os.RemoveAll(launchableHome)
 
 	launchable := &Launchable{
@@ -43,8 +48,8 @@ func TestInstall(t *testing.T) {
 	Assert(t).IsNil(err, "there should not have been an error when installing")
 
 	Assert(t).AreEqual(
-		fetcher.SrcUri,
-		testLocation,
+		*fetcher.SrcUri,
+		*testLocation,
 		"The correct url wasn't set for the curl library",
 	)
 
@@ -60,7 +65,12 @@ func TestInstall(t *testing.T) {
 
 func TestInstallDir(t *testing.T) {
 	tempDir := os.TempDir()
-	testLocation := "http://someserver/test_launchable_abc123.tar.gz"
+	testLocation := &url.URL{
+		Scheme: "http",
+		Path:   "/test_launchable_abc123.tar.gz",
+		Host:   "someserver",
+	}
+
 	launchable := &Launchable{
 		Location:  testLocation,
 		Id:        "testLaunchable",

--- a/pkg/hoist/test_helper.go
+++ b/pkg/hoist/test_helper.go
@@ -2,6 +2,7 @@ package hoist
 
 import (
 	"io/ioutil"
+	"net/url"
 	"os"
 	"os/user"
 	"runtime"
@@ -16,7 +17,7 @@ func FakeHoistLaunchableForDir(dirName string) (*Launchable, *runit.ServiceBuild
 	launchableInstallDir := util.From(runtime.Caller(0)).ExpandPath(dirName)
 
 	launchable := &Launchable{
-		Location:  "testLaunchable.tar.gz",
+		Location:  &url.URL{Path: "testLaunchable.tar.gz"},
 		Id:        "testLaunchable",
 		ServiceId: "testPod__testLaunchable",
 		RunAs:     "testPod",

--- a/pkg/opencontainer/containers.go
+++ b/pkg/opencontainer/containers.go
@@ -9,6 +9,7 @@ package opencontainer
 import (
 	"encoding/json"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -38,7 +39,7 @@ var RuncPath = param.String("runc_path", "/usr/local/bin/runc")
 
 // Launchable represents an installation of a container.
 type Launchable struct {
-	Location        string              // A URL where we can download the artifact from.
+	Location        *url.URL            // A URL where we can download the artifact from.
 	ID_             string              // A (pod-wise) unique identifier for this launchable, used to distinguish it from other launchables in the pod
 	ServiceID_      string              // A (host-wise) unique identifier for this launchable, used when creating runit services
 	RunAs           string              // The user to assume when launching the executable
@@ -87,7 +88,7 @@ func (l *Launchable) EnvVars() map[string]string {
 // The version of the artifact is currently derived from the location, using
 // the naming scheme <the-app>_<unique-version-string>.tar.gz
 func (hl *Launchable) Version() string {
-	fileName := filepath.Base(hl.Location)
+	fileName := filepath.Base(hl.Location.Path)
 	return fileName[:len(fileName)-len(".tar.gz")]
 }
 

--- a/pkg/pods/manifest.go
+++ b/pkg/pods/manifest.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path"
 
@@ -247,7 +248,7 @@ func ManifestFromPath(path string) (Manifest, error) {
 
 // ManifestFromURI constructs a Manifest from data located at a URI. This function is a
 // helper for ManifestFromBytes().
-func ManifestFromURI(manifestUri string) (Manifest, error) {
+func ManifestFromURI(manifestUri *url.URL) (Manifest, error) {
 	f, err := uri.DefaultFetcher.Open(manifestUri)
 	if err != nil {
 		return nil, err

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -53,7 +53,7 @@ func TestGetLaunchable(t *testing.T) {
 		launchable := l.(hoist.LaunchAdapter).Launchable
 		Assert(t).AreEqual("app", launchable.Id, "Launchable Id did not have expected value")
 		Assert(t).AreEqual("hello__app", launchable.ServiceId, "Launchable ServiceId did not have expected value")
-		Assert(t).AreEqual("hoisted-hello_def456.tar.gz", launchable.Location, "Launchable location did not have expected value")
+		Assert(t).AreEqual("hoisted-hello_def456.tar.gz", launchable.Location.String(), "Launchable location did not have expected value")
 		Assert(t).AreEqual("foouser", launchable.RunAs, "Launchable run as did not have expected username")
 		Assert(t).IsTrue(launchable.ExecNoLimit, "GetLaunchable() should always set ExecNoLimit to true for hoist launchables")
 		Assert(t).AreEqual(launchable.RestartPolicy, runit.RestartPolicyAlways, "Default RestartPolicy for a launchable should be 'always'")

--- a/pkg/uri/uri_test.go
+++ b/pkg/uri/uri_test.go
@@ -1,7 +1,6 @@
 package uri
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -19,12 +18,19 @@ func TestURIWillCopyFilesCorrectly(t *testing.T) {
 	tempdir, err := ioutil.TempDir("", "cp-dest")
 	Assert(t).IsNil(err, "Couldn't create temp dir")
 	defer os.RemoveAll(tempdir)
+
 	thisFile := util.From(runtime.Caller(0)).Filename
+	url := &url.URL{
+		Path: thisFile,
+	}
+
 	copied := filepath.Join(tempdir, "copied")
-	err = URICopy(fmt.Sprintf("file:///%s", thisFile), copied)
+	err = URICopy(url, copied)
 	Assert(t).IsNil(err, "The file should have been copied")
+
 	copiedContents, err := ioutil.ReadFile(copied)
 	Assert(t).IsNil(err, "The copied file could not be read")
+
 	thisContents, err := ioutil.ReadFile(thisFile)
 	Assert(t).IsNil(err, "The original file could not be read")
 	Assert(t).AreEqual(string(thisContents), string(copiedContents), "The contents of the files do not match")
@@ -34,11 +40,19 @@ func TestURIWithNoProtocolTreatedLikeLocalPath(t *testing.T) {
 	tempdir, err := ioutil.TempDir("", "cp-dest")
 	Assert(t).IsNil(err, "Couldn't create temp dir")
 	defer os.RemoveAll(tempdir)
+
 	thisFile := util.From(runtime.Caller(0)).Filename
+	url := &url.URL{
+		Path: thisFile,
+	}
+
 	copied := filepath.Join(tempdir, "copied")
-	err = URICopy(thisFile, copied)
+	err = URICopy(url, copied)
 	Assert(t).IsNil(err, "The file should have been copied")
+
 	copiedContents, err := ioutil.ReadFile(copied)
+	Assert(t).IsNil(err, "Couldn't read file")
+
 	thisContents, err := ioutil.ReadFile(thisFile)
 	Assert(t).IsNil(err, "The original file could not be read")
 	Assert(t).AreEqual(string(thisContents), string(copiedContents), "The contents of the files do not match")
@@ -59,7 +73,7 @@ func TestCorrectlyPullsFilesOverHTTP(t *testing.T) {
 	Assert(t).IsNil(err, "should have parsed server URL")
 
 	serverURL.Path = filepath.Base(caller.Filename)
-	err = URICopy(serverURL.String(), copied)
+	err = URICopy(serverURL, copied)
 	Assert(t).IsNil(err, "the file should have been downloaded")
 
 	copiedContents, err := ioutil.ReadFile(copied)


### PR DESCRIPTION
This paves the way for an upcoming change which will allow an
alternative method of specifying artifact download.