### PR TITLE
Fix lint errors in binaries

### DIFF
--- a/bin/p2-pcctl/main.go
+++ b/bin/p2-pcctl/main.go
@@ -21,31 +21,30 @@ import (
 )
 
 const (
-	CmdCreate = "create"
-	CmdGet    = "get"
-	CmdDelete = "delete"
-	CmdUpdate = "update"
+	cmdCreateText = "create"
+	cmdGetText    = "get"
+	cmdDeleteText = "delete"
+	cmdUpdateText = "update"
 )
 
 var (
-	cmdCreate         = kingpin.Command(CmdCreate, "Create a pod cluster. ")
+	cmdCreate         = kingpin.Command(cmdCreateText, "Create a pod cluster. ")
 	createPodID       = cmdCreate.Flag("pod", "The pod ID on the pod cluster").Required().String()
 	createAZ          = cmdCreate.Flag("az", "The availability zone of the pod cluster").Required().String()
 	createName        = cmdCreate.Flag("name", "The cluster name (ie. staging, production)").Required().String()
-	createSelector    = cmdCreate.Flag("selector", "A pod selector to use for this pod cluster. This will be generated from other arguments if not provided").String()
 	createAnnotations = cmdCreate.Flag("annotations", "Complete set of annotations - must parse as JSON!").String()
 
-	cmdGet   = kingpin.Command(CmdGet, "Show a pod cluster. ")
+	cmdGet   = kingpin.Command(cmdGetText, "Show a pod cluster. ")
 	getPodID = cmdGet.Flag("pod", "The pod ID on the pod cluster").Required().String()
 	getAZ    = cmdGet.Flag("az", "The availability zone of the pod cluster").Required().String()
 	getName  = cmdGet.Flag("name", "The cluster name (ie. staging, production)").Required().String()
 
-	cmdDelete   = kingpin.Command(CmdDelete, "Delete a pod cluster. ")
+	cmdDelete   = kingpin.Command(cmdDeleteText, "Delete a pod cluster. ")
 	deletePodID = cmdDelete.Flag("pod", "The pod ID on the pod cluster").Required().String()
 	deleteAZ    = cmdDelete.Flag("az", "The availability zone of the pod cluster").Required().String()
 	deleteName  = cmdDelete.Flag("name", "The cluster name (ie. staging, production)").Required().String()
 
-	cmdUpdate         = kingpin.Command(CmdUpdate, "Update a pod cluster. ")
+	cmdUpdate         = kingpin.Command(cmdUpdateText, "Update a pod cluster. ")
 	updatePodID       = cmdUpdate.Flag("pod", "The pod ID on the pod cluster").Required().String()
 	updateAZ          = cmdUpdate.Flag("az", "The availability zone of the pod cluster").Required().String()
 	updateName        = cmdUpdate.Flag("name", "The cluster name (ie. staging, production)").Required().String()
@@ -64,7 +63,7 @@ func main() {
 	}
 
 	switch cmd {
-	case CmdCreate:
+	case cmdCreateText:
 		az := fields.AvailabilityZone(*createAZ)
 		cn := fields.ClusterName(*createName)
 		podID := types.PodID(*createPodID)
@@ -81,7 +80,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("err: %v", err)
 		}
-	case CmdGet:
+	case cmdGetText:
 		az := fields.AvailabilityZone(*getAZ)
 		cn := fields.ClusterName(*getName)
 		podID := types.PodID(*getPodID)
@@ -98,7 +97,7 @@ func main() {
 			logger.WithError(err).Fatalln("Unable to marshal PC as JSON")
 		}
 		fmt.Printf("%s", bytes)
-	case CmdDelete:
+	case cmdDeleteText:
 		az := fields.AvailabilityZone(*deleteAZ)
 		cn := fields.ClusterName(*deleteName)
 		podID := types.PodID(*deletePodID)
@@ -111,7 +110,7 @@ func main() {
 			}
 			os.Exit(1)
 		}
-	case CmdUpdate:
+	case cmdUpdateText:
 		az := fields.AvailabilityZone(*updateAZ)
 		cn := fields.ClusterName(*updateName)
 		podID := types.PodID(*updatePodID)

--- a/bin/p2-replicate/main.go
+++ b/bin/p2-replicate/main.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	manifestUri       = kingpin.Arg("manifest", "a path or url to a pod manifest that will be replicated.").Required().URL()
+	manifestURI       = kingpin.Arg("manifest", "a path or url to a pod manifest that will be replicated.").Required().URL()
 	hosts             = kingpin.Arg("hosts", "Hosts to replicate to").Required().Strings()
 	minNodes          = kingpin.Flag("min-nodes", "The minimum number of healthy nodes that must remain up while replicating.").Default("1").Short('m').Int()
 	threshold         = kingpin.Flag("threshold", "The minimum health level to treat as healthy. One of (in order) passing, warning, unknown, critical.").String()
@@ -53,7 +53,7 @@ func main() {
 	labeler := labels.NewConsulApplicator(client, 3)
 	healthChecker := checker.NewConsulHealthChecker(client)
 
-	manifest, err := pods.ManifestFromURI(*manifestUri)
+	manifest, err := pods.ManifestFromURI(*manifestURI)
 	if err != nil {
 		log.Fatalf("%s", err)
 	}

--- a/bin/p2-restart/main.go
+++ b/bin/p2-restart/main.go
@@ -29,7 +29,7 @@ $ p2-restart --pod-dir /custom/pod/home
 
 func main() {
 	restart.Version(version.VERSION)
-	restart.Parse(os.Args[1:])
+	kingpin.MustParse(restart.Parse(os.Args[1:]))
 
 	pods.Log.Logger.Formatter = &logrus.TextFormatter{
 		DisableTimestamp: false,

--- a/bin/p2-rm/main.go
+++ b/bin/p2-rm/main.go
@@ -146,7 +146,11 @@ func (rm *P2RM) decrementDesiredCount(id fields.ID) error {
 		os.Exit(1)
 	}
 
-	rm.RCStore.AddDesiredReplicas(id, -1)
+	err = rm.RCStore.AddDesiredReplicas(id, -1)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to decrement RC count: %v", err)
+		os.Exit(1)
+	}
 
 	err = rm.RCStore.Enable(id)
 	if err != nil {

--- a/bin/p2-run-hooks/main.go
+++ b/bin/p2-run-hooks/main.go
@@ -13,28 +13,28 @@ import (
 )
 
 var (
-	PodDir    = kingpin.Arg("pod", "A path to a pod that exists on disk already.").Required().String()
-	Lifecycle = kingpin.Arg("hook-type", "Execute one of the given hook types").Required().String()
-	HookDir   = kingpin.Flag("hook-dir", "The root of the hooks").Default(hooks.DEFAULT_PATH).String()
-	Manifest  = kingpin.Flag("manifest", "The manifest to use (this is useful when we are in the before_install phase)").ExistingFile()
+	podDir       = kingpin.Arg("pod", "A path to a pod that exists on disk already.").Required().String()
+	hookType     = kingpin.Arg("hook-type", "Execute one of the given hook types").Required().String()
+	hookDir      = kingpin.Flag("hook-dir", "The root of the hooks").Default(hooks.DEFAULT_PATH).String()
+	manifestPath = kingpin.Flag("manifest", "The manifest to use (this is useful when we are in the before_install phase)").ExistingFile()
 )
 
 func main() {
 	kingpin.Version(version.VERSION)
 	kingpin.Parse()
 
-	dir := hooks.Hooks(*HookDir, &logging.DefaultLogger)
+	dir := hooks.Hooks(*hookDir, &logging.DefaultLogger)
 
-	hookType, err := hooks.AsHookType(*Lifecycle)
+	hookType, err := hooks.AsHookType(*hookType)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	pod := pods.NewPod(types.PodID(path.Base(*PodDir)), *PodDir)
+	pod := pods.NewPod(types.PodID(path.Base(*podDir)), *podDir)
 
 	var manifest pods.Manifest
-	if *Manifest != "" {
-		manifest, err = pods.ManifestFromPath(*Manifest)
+	if *manifestPath != "" {
+		manifest, err = pods.ManifestFromPath(*manifestPath)
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/bin/p2-sum/main.go
+++ b/bin/p2-sum/main.go
@@ -27,10 +27,10 @@ Flags:
 `
 
 func init() {
-	flag.Usage = Usage
+	flag.Usage = usage
 }
 
-func Usage() {
+func usage() {
 	fmt.Fprintf(os.Stderr, usageMsg, filepath.Base(os.Args[0]))
 	flag.PrintDefaults()
 }
@@ -78,7 +78,7 @@ func main() {
 	flag.Parse()
 	progName := filepath.Base(os.Args[0])
 	if *help {
-		Usage()
+		usage()
 		os.Exit(0)
 	}
 	args := flag.Args()

--- a/bin/p2-watch/main.go
+++ b/bin/p2-watch/main.go
@@ -63,7 +63,9 @@ func main() {
 					fmt.Println(fmt.Sprintf("No manifests exist for %s under %s (they may have been deleted)", *nodeName, podPrefix))
 				} else {
 					for _, result := range results {
-						result.Manifest.Write(os.Stdout)
+						if err := result.Manifest.Write(os.Stdout); err != nil {
+							log.Fatalf("write error: %v", err)
+						}
 					}
 				}
 			case err := <-errChan:
@@ -116,5 +118,7 @@ func watchPodClusters(client *api.Client) {
 		close(quitCh)
 	}()
 
-	pcStore.WatchAndSync(&printSyncer{logger}, quitCh)
+	if err := pcStore.WatchAndSync(&printSyncer{logger}, quitCh); err != nil {
+		log.Fatalf("error watching pod cluster: %v", err)
+	}
 }


### PR DESCRIPTION
Fixes a bunch of warnings raised by running "gometalinter" on all the
binary packages. Changes mostly eliminate dead code, check error
return values, and adjust variable names/cases.