### PR TITLE
Fix bug in flaky unit test

### DIFF
--- a/pkg/kp/rcstore/consul_store_test.go
+++ b/pkg/kp/rcstore/consul_store_test.go
@@ -21,8 +21,10 @@ func TestPublishLatestRCs(t *testing.T) {
 	go func() {
 		select {
 		case <-quitCh:
-		case err := <-errCh:
-			t.Fatalf("Unexpected error on errCh: %s", err)
+		case err, ok := <-errCh:
+			if ok {
+				t.Fatalf("Unexpected error on errCh: %s", err)
+			}
 		}
 	}()
 


### PR DESCRIPTION
The TestPublishLatestRCs unit test failed with the following output:

    Unexpected error on errCh: <nil>

The probable immediate cause is that the channel was closed while the
unit test was stopping. Once `quitCh` is closed, the goroutine that
feeds into `errCh` will eventually close that channel too. If the
error-monitoring goroutine exists after that happens, and if the
select statement receives from `errCh` instead of `quitCh`, the test
will unnecessarily fail.