### PR TITLE
Move scheduler to its own package

### DIFF
--- a/bin/p2-rctl/main.go
+++ b/bin/p2-rctl/main.go
@@ -26,10 +26,10 @@ import (
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
-	"github.com/square/p2/pkg/rc"
 	rc_fields "github.com/square/p2/pkg/rc/fields"
 	"github.com/square/p2/pkg/roll"
 	roll_fields "github.com/square/p2/pkg/roll/fields"
+	"github.com/square/p2/pkg/scheduler"
 	"github.com/square/p2/pkg/version"
 )
 
@@ -112,7 +112,7 @@ func main() {
 	httpClient := cleanhttp.DefaultClient()
 	client := kp.NewConsulClient(opts)
 	labeler := labels.NewConsulApplicator(client, 3)
-	sched := rc.NewApplicatorScheduler(labeler)
+	sched := scheduler.NewApplicatorScheduler(labeler)
 	if *labelEndpoint != "" {
 		endpoint, err := url.Parse(*labelEndpoint)
 		if err != nil {
@@ -124,7 +124,7 @@ func main() {
 		if err != nil {
 			logging.DefaultLogger.WithError(err).Fatalln("Could not create label applicator from endpoint")
 		}
-		sched = rc.NewApplicatorScheduler(httpLabeler)
+		sched = scheduler.NewApplicatorScheduler(httpLabeler)
 	}
 	rctl := rctlParams{
 		httpClient: httpClient,
@@ -179,7 +179,7 @@ type rctlParams struct {
 	baseClient *api.Client
 	rcs        rcstore.Store
 	rls        rollstore.Store
-	sched      rc.Scheduler
+	sched      scheduler.Scheduler
 	labeler    labels.Applicator
 	kps        kp.Store
 	hcheck     checker.ConsulHealthChecker

--- a/pkg/kp/consulutil/watch.go
+++ b/pkg/kp/consulutil/watch.go
@@ -229,6 +229,8 @@ func WatchDiff(
 	outCh := make(chan *WatchedChanges)
 
 	go func() {
+		defer close(outCh)
+
 		// Keep track of what we have seen so that we know when something was changed
 		keys := make(map[string]*api.KVPair)
 

--- a/pkg/rc/farm.go
+++ b/pkg/rc/farm.go
@@ -15,6 +15,7 @@ import (
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/rc/fields"
 	"github.com/square/p2/pkg/rc/rcmetrics"
+	"github.com/square/p2/pkg/scheduler"
 	"github.com/square/p2/pkg/util"
 )
 
@@ -32,7 +33,7 @@ type Farm struct {
 	// constructor arguments for rcs created by this farm
 	kpStore   kp.Store
 	rcStore   rcstore.Store
-	scheduler Scheduler
+	scheduler scheduler.Scheduler
 	labeler   labels.Applicator
 
 	// session stream for the rcs locked by this farm
@@ -58,7 +59,7 @@ type childRC struct {
 func NewFarm(
 	kpStore kp.Store,
 	rcs rcstore.Store,
-	scheduler Scheduler,
+	scheduler scheduler.Scheduler,
 	labeler labels.Applicator,
 	sessions <-chan string,
 	logger logging.Logger,

--- a/pkg/rc/replication_controller.go
+++ b/pkg/rc/replication_controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/rc/fields"
+	"github.com/square/p2/pkg/scheduler"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
 )
@@ -83,7 +84,7 @@ type replicationController struct {
 
 	kpStore       kpStore
 	rcStore       rcstore.Store
-	scheduler     Scheduler
+	scheduler     scheduler.Scheduler
 	podApplicator labels.Applicator
 	alerter       alerting.Alerter
 }
@@ -92,7 +93,7 @@ func New(
 	fields fields.RC,
 	kpStore kpStore,
 	rcStore rcstore.Store,
-	scheduler Scheduler,
+	scheduler scheduler.Scheduler,
 	podApplicator labels.Applicator,
 	logger logging.Logger,
 	alerter alerting.Alerter,

--- a/pkg/rc/replication_controller_test.go
+++ b/pkg/rc/replication_controller_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/scheduler"
 	"github.com/square/p2/pkg/types"
 
 	. "github.com/anthonybishopric/gotcha"
@@ -71,7 +72,7 @@ func setup(t *testing.T) (
 		rcData,
 		&kpStore,
 		rcStore,
-		NewApplicatorScheduler(applicator),
+		scheduler.NewApplicatorScheduler(applicator),
 		applicator,
 		logging.DefaultLogger,
 		alerter,

--- a/pkg/roll/farm.go
+++ b/pkg/roll/farm.go
@@ -14,9 +14,9 @@ import (
 	"github.com/square/p2/pkg/kp/rollstore"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
-	"github.com/square/p2/pkg/rc"
 	"github.com/square/p2/pkg/rc/fields"
 	roll_fields "github.com/square/p2/pkg/roll/fields"
+	"github.com/square/p2/pkg/scheduler"
 	"github.com/square/p2/pkg/util"
 
 	klabels "k8s.io/kubernetes/pkg/labels"
@@ -31,7 +31,7 @@ type UpdateFactory struct {
 	RCStore       rcstore.Store
 	HealthChecker checker.ConsulHealthChecker
 	Labeler       labels.Applicator
-	Scheduler     rc.Scheduler
+	Scheduler     scheduler.Scheduler
 }
 
 func (f UpdateFactory) New(u roll_fields.Update, l logging.Logger, session kp.Session, alerter alerting.Alerter) Update {

--- a/pkg/roll/run_update.go
+++ b/pkg/roll/run_update.go
@@ -18,6 +18,7 @@ import (
 	"github.com/square/p2/pkg/rc"
 	rcf "github.com/square/p2/pkg/rc/fields"
 	"github.com/square/p2/pkg/roll/fields"
+	"github.com/square/p2/pkg/scheduler"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
 )
@@ -29,7 +30,7 @@ type update struct {
 	rcs     rcstore.Store
 	hcheck  checker.ConsulHealthChecker
 	labeler labels.Applicator
-	sched   rc.Scheduler
+	sched   scheduler.Scheduler
 
 	logger  logging.Logger
 	alerter alerting.Alerter
@@ -41,7 +42,7 @@ type update struct {
 }
 
 // Create a new Update. The kp.Store, rcstore.Store, labels.Applicator and
-// rc.Scheduler arguments should be the same as those of the RCs themselves. The
+// scheduler.Scheduler arguments should be the same as those of the RCs themselves. The
 // session must be valid for the lifetime of the Update; maintaining this is the
 // responsibility of the caller.
 func NewUpdate(
@@ -50,7 +51,7 @@ func NewUpdate(
 	rcs rcstore.Store,
 	hcheck checker.ConsulHealthChecker,
 	labeler labels.Applicator,
-	sched rc.Scheduler,
+	sched scheduler.Scheduler,
 	logger logging.Logger,
 	session kp.Session,
 	alerter alerting.Alerter,

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1,4 +1,4 @@
-package rc
+package scheduler
 
 import (
 	klabels "k8s.io/kubernetes/pkg/labels"


### PR DESCRIPTION
Move rc/scheduler.go to its own package

scheduler.go used to be in the rc package, but because it will now
be used with daemon sets, it would make more sense for it to be
in its own package.

This will also fix the issues with the watch for daemon sets.