### PR TITLE
Return a TLS config that trusts nothing instead of nil to prevent NPE

### DIFF
--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -192,10 +192,6 @@ func getTLSConfig(certFile, keyFile, caFile string) (*tls.Config, error) {
 		}
 	}
 
-	if len(certs) == 0 && cas == nil {
-		return nil, nil
-	}
-
 	tlsConfig := &tls.Config{
 		Certificates: certs,
 		ClientCAs:    cas,


### PR DESCRIPTION
Prevents an NPE on `tlsConfig.InsecureSkipVerify` in the following code in `pkg/preparer/setup.go` by returning a `tls.Config` that trusts nothing instead of `nil`:

```
func (c *PreparerConfig) GetInsecureClient(cxnTimeout time.Duration) (*http.Client, error) {
	tlsConfig, err := getTLSConfig(c.CertFile, c.KeyFile, c.CAFile)
	if err != nil {
		return nil, err
	}
	tlsConfig.InsecureSkipVerify = true
	...
```