### PR TITLE
Write pods to intent tree for daemon sets

### DIFF
--- a/pkg/ds/daemon_set.go
+++ b/pkg/ds/daemon_set.go
@@ -282,9 +282,9 @@ func (ds *daemonSet) schedule(node types.NodeName) error {
 
 	// Will apply the following label on the key <labels.POD>/<node>/<ds.Manifest.ID()>:
 	// 	{ DSIDLabel : ds.ID() }
-	// eg node/127.0.0.1[daemon_set_id] := test_ds_id
+	// eg node/127.0.0.1/test_pod[daemon_set_id] := test_ds_id
 	// This is for indicating that this pod path belongs to this daemon set
-	id := MakePodLabelKey(node, ds.Manifest.ID())
+	id := labels.MakePodLabelKey(node, ds.Manifest.ID())
 	err := ds.applicator.SetLabel(labels.POD, id, DSIDLabel, ds.ID().String())
 	if err != nil {
 		return util.Errorf("Error setting label: %v", err)
@@ -312,7 +312,7 @@ func (ds *daemonSet) unschedule(node types.NodeName) error {
 
 	// Will remove the following label on the key <labels.POD>/<node>/<ds.Manifest.ID()>: DSIDLabel
 	// This is for indicating that this pod path no longer belongs to this daemon set
-	id := MakePodLabelKey(node, ds.Manifest.ID())
+	id := labels.MakePodLabelKey(node, ds.Manifest.ID())
 	err = ds.applicator.RemoveLabel(labels.POD, id, DSIDLabel)
 	if err != nil {
 		return util.Errorf("Error removing label: %v", err)
@@ -344,8 +344,4 @@ func (ds *daemonSet) CurrentPods() (PodLocations, error) {
 	}
 
 	return result, nil
-}
-
-func MakePodLabelKey(node types.NodeName, podID types.PodID) string {
-	return node.String() + "/" + podID.String()
 }

--- a/pkg/ds/daemon_set.go
+++ b/pkg/ds/daemon_set.go
@@ -1,0 +1,351 @@
+package ds
+
+import (
+	"time"
+
+	"github.com/square/p2/pkg/util"
+
+	klabels "k8s.io/kubernetes/pkg/labels"
+
+	"github.com/square/p2/pkg/ds/fields"
+	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/kp/dsstore"
+	"github.com/square/p2/pkg/labels"
+	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/scheduler"
+	"github.com/square/p2/pkg/types"
+)
+
+const (
+	// This label is applied to pods owned by an RC.
+	DSIDLabel = "daemon_set_id"
+)
+
+type DaemonSet interface {
+	ID() fields.ID
+
+	WatchDesires(
+		quitCh <-chan struct{},
+		updatedCh <-chan fields.DaemonSet,
+		deletedCh <-chan struct{},
+		nodesChangedCh <-chan struct{},
+	) <-chan error
+
+	// CurrentPods() returns all nodes that are scheduled by this daemon set
+	CurrentPods() (PodLocations, error)
+}
+
+type PodLocation struct {
+	Node  types.NodeName
+	PodID types.PodID
+}
+type PodLocations []PodLocation
+
+// Nodes returns a list of just the locations' nodes.
+func (l PodLocations) Nodes() []types.NodeName {
+	nodes := make([]types.NodeName, len(l))
+	for i, pod := range l {
+		nodes[i] = pod.Node
+	}
+	return nodes
+}
+
+// These methods are the same as the methods of the same name in kp.Store.
+// This interface makes writing unit tests easier as daemon sets do not
+// use any functions not listed here
+type kpStore interface {
+	SetPod(
+		podPrefix kp.PodPrefix,
+		nodeName types.NodeName,
+		manifest pods.Manifest,
+	) (time.Duration, error)
+
+	DeletePod(podPrefix kp.PodPrefix,
+		nodeName types.NodeName,
+		manifestID types.PodID,
+	) (time.Duration, error)
+}
+
+type daemonSet struct {
+	fields.DaemonSet
+
+	logger     logging.Logger
+	kpStore    kpStore
+	scheduler  scheduler.Scheduler
+	dsStore    dsstore.Store
+	applicator labels.Applicator
+}
+
+func New(
+	fields fields.DaemonSet,
+	dsStore dsstore.Store,
+	kpStore kpStore,
+	applicator labels.Applicator,
+	logger logging.Logger,
+) DaemonSet {
+	return &daemonSet{
+		DaemonSet: fields,
+
+		dsStore:    dsStore,
+		kpStore:    kpStore,
+		logger:     logger,
+		applicator: applicator,
+		scheduler:  scheduler.NewApplicatorScheduler(applicator),
+	}
+}
+
+func (ds *daemonSet) ID() fields.ID {
+	return ds.DaemonSet.ID
+}
+
+// WatchDesires watches for changes to its daemon set, then schedule/unschedule
+// pods to to the nodes that it is responsible for
+//
+// Whatever calls WatchDesires is responsible for sending signals for whether
+// the daemon set updated or deleted
+//
+// When this is first called, it assumes that the daemon set is created
+//
+// The caller is responsible for sending signals when something has been changed
+func (ds *daemonSet) WatchDesires(
+	quitCh <-chan struct{},
+	updatedCh <-chan fields.DaemonSet,
+	deletedCh <-chan struct{},
+	nodesChangedCh <-chan struct{},
+) <-chan error {
+	errCh := make(chan error)
+
+	// Do something whenever something is changed
+	go func() {
+		var err error
+		defer close(errCh)
+
+		// Try to schedule pods when this begins watching
+		if !ds.Disabled {
+			ds.logger.NoFields().Infof("Received new daemon set: %v", *ds)
+			err = ds.addPods()
+			if err != nil {
+				err = util.Errorf("Unable to add pods to intent tree: %v", err)
+			}
+		}
+
+		for {
+			if err != nil {
+				select {
+				case errCh <- err:
+				case <-quitCh:
+				}
+			}
+
+			select {
+			case newDS := <-updatedCh:
+				ds.logger.NoFields().Infof("Received daemon set update signal: %v", newDS)
+				if ds.ID() != newDS.ID {
+					err = util.Errorf("Expected uuid to be the same, expected '%v', got '%v'", ds.ID(), newDS.ID)
+					continue
+				}
+				ds.DaemonSet = newDS
+
+				if ds.Disabled {
+					continue
+				}
+				err := ds.removePods()
+				if err != nil {
+					err = util.Errorf("Unable to remove pods from intent tree: %v", err)
+					continue
+				}
+				err = ds.addPods()
+				if err != nil {
+					err = util.Errorf("Unable to add pods to intent tree: %v", err)
+					continue
+				}
+
+			case <-deletedCh:
+				ds.logger.NoFields().Infof("Received daemon set delete signal")
+				err = ds.clearPods()
+				if err != nil {
+					err = util.Errorf("Unable to clear pods from intent tree: %v", err)
+					select {
+					case errCh <- err:
+					case <-quitCh:
+					}
+				}
+				return
+
+			case <-nodesChangedCh:
+				ds.logger.NoFields().Infof("Received node update signal")
+				if ds.Disabled {
+					continue
+				}
+				err := ds.removePods()
+				if err != nil {
+					err = util.Errorf("Unable to remove pods from intent tree: %v", err)
+					continue
+				}
+				err = ds.addPods()
+				if err != nil {
+					err = util.Errorf("Unable to add pods to intent tree: %v", err)
+					continue
+				}
+
+			case <-quitCh:
+				return
+			}
+		}
+	}()
+
+	return errCh
+}
+
+// addPods schedules pods for all unscheduled nodes selected by ds.nodeSelector
+func (ds *daemonSet) addPods() error {
+	podLocations, err := ds.CurrentPods()
+	if err != nil {
+		return util.Errorf("Error retrieving pod locations from daemon set: %v", err)
+	}
+	currentNodes := podLocations.Nodes()
+
+	eligible, err := ds.scheduler.EligibleNodes(ds.Manifest, ds.NodeSelector)
+	if err != nil {
+		return util.Errorf("Error retrieving eligible nodes for daemon set: %v", err)
+	}
+
+	// Get the difference in nodes that we need to schedule on and then sort them
+	// for deterministic ordering
+	toScheduleSorted := types.NewNodeSet(eligible...).Difference(types.NewNodeSet(currentNodes...)).ListNodes()
+	ds.logger.NoFields().Infof("Need to schedule %d nodes", len(toScheduleSorted))
+
+	for _, node := range toScheduleSorted {
+		err := ds.schedule(node)
+		if err != nil {
+			return util.Errorf("Error scheduling node: %v", err)
+		}
+	}
+	return nil
+}
+
+// removePods unschedules pods for all scheduled nodes not selected
+// by ds.nodeSelector
+func (ds *daemonSet) removePods() error {
+	podLocations, err := ds.CurrentPods()
+	if err != nil {
+		return util.Errorf("Error retrieving pod locations from daemon set: %v", err)
+	}
+	currentNodes := podLocations.Nodes()
+
+	eligible, err := ds.scheduler.EligibleNodes(ds.Manifest, ds.NodeSelector)
+	if err != nil {
+		return util.Errorf("Error retrieving eligible nodes for daemon set: %v", err)
+	}
+
+	// Get the difference in nodes that we need to unschedule on and then sort them
+	// for deterministic ordering
+	toUnscheduleSorted := types.NewNodeSet(currentNodes...).Difference(types.NewNodeSet(eligible...)).ListNodes()
+	ds.logger.NoFields().Infof("Need to unschedule %d nodes", len(toUnscheduleSorted))
+
+	for _, node := range toUnscheduleSorted {
+		err := ds.unschedule(node)
+		if err != nil {
+			return util.Errorf("Error unscheduling node: %v", err)
+		}
+	}
+	return nil
+}
+
+// clearPods unschedules pods for all the nodes that have been scheduled by
+// this daemon set by using CurrentPods()
+// This should only be used when a daemon set is deleted
+func (ds *daemonSet) clearPods() error {
+	podLocations, err := ds.CurrentPods()
+	if err != nil {
+		return util.Errorf("Error retrieving pod locations from daemon set: %v", err)
+	}
+	currentNodes := podLocations.Nodes()
+
+	// Get the difference in nodes that we need to unschedule on and then sort them
+	// for deterministic ordering
+	toUnscheduleSorted := types.NewNodeSet(currentNodes...).ListNodes()
+	ds.logger.NoFields().Infof("Need to unschedule %d nodes", len(toUnscheduleSorted))
+
+	for _, node := range toUnscheduleSorted {
+		err := ds.unschedule(node)
+		if err != nil {
+			return util.Errorf("Error scheduling node: %v", err)
+		}
+	}
+	return nil
+}
+
+func (ds *daemonSet) schedule(node types.NodeName) error {
+	ds.logger.NoFields().Infof("Scheduling on %s", node)
+
+	// Will apply the following label on the key <labels.POD>/<node>/<ds.Manifest.ID()>:
+	// 	{ DSIDLabel : ds.ID() }
+	// eg node/127.0.0.1[daemon_set_id] := test_ds_id
+	// This is for indicating that this pod path belongs to this daemon set
+	id := MakePodLabelKey(node, ds.Manifest.ID())
+	err := ds.applicator.SetLabel(labels.POD, id, DSIDLabel, ds.ID().String())
+	if err != nil {
+		return util.Errorf("Error setting label: %v", err)
+	}
+
+	// Will set the following the value, ds.Manifest, to the following key:
+	// <kp.INTENT_TREE>/<node>/<ds.Manifest.ID()>
+	// eg intent/127.0.0.1/test = test_pod
+	_, err = ds.kpStore.SetPod(kp.INTENT_TREE, node, ds.Manifest)
+	if err != nil {
+		return util.Errorf("Error adding pod to intent tree: %v", err)
+	}
+	return nil
+}
+
+func (ds *daemonSet) unschedule(node types.NodeName) error {
+	ds.logger.NoFields().Infof("Unscheduling from %s", node)
+
+	// Will remove the following key:
+	// <kp.INTENT_TREE>/<node>/<ds.Manifest.ID()>
+	_, err := ds.kpStore.DeletePod(kp.INTENT_TREE, node, ds.Manifest.ID())
+	if err != nil {
+		return util.Errorf("Unable to delete pod from intent tree: %v", err)
+	}
+
+	// Will remove the following label on the key <labels.POD>/<node>/<ds.Manifest.ID()>: DSIDLabel
+	// This is for indicating that this pod path no longer belongs to this daemon set
+	id := MakePodLabelKey(node, ds.Manifest.ID())
+	err = ds.applicator.RemoveLabel(labels.POD, id, DSIDLabel)
+	if err != nil {
+		return util.Errorf("Error removing label: %v", err)
+	}
+
+	return nil
+}
+
+func (ds *daemonSet) CurrentPods() (PodLocations, error) {
+	// Changing DaemonSet.ID is not permitted, so as long as there is no uuid
+	// collision, this will always get the current pod path that this daemon set
+	// had scheduled on
+	selector := klabels.Everything().Add(DSIDLabel, klabels.EqualsOperator, []string{ds.ID().String()})
+
+	podMatches, err := ds.applicator.GetMatches(selector, labels.POD)
+	if err != nil {
+		return nil, util.Errorf("Unable to get matches on pod tree: %v", err)
+	}
+
+	result := make(PodLocations, len(podMatches))
+	for i, podMatch := range podMatches {
+		// ID will be something like <node>/<PodID>
+		node, podID, err := labels.NodeAndPodIDFromPodLabel(podMatch)
+		if err != nil {
+			return nil, err
+		}
+		result[i].Node = node
+		result[i].PodID = podID
+	}
+
+	return result, nil
+}
+
+func MakePodLabelKey(node types.NodeName, podID types.PodID) string {
+	return node.String() + "/" + podID.String()
+}

--- a/pkg/ds/daemon_set_test.go
+++ b/pkg/ds/daemon_set_test.go
@@ -1,0 +1,314 @@
+package ds
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/util"
+
+	"github.com/square/p2/pkg/kp/dsstore"
+	"github.com/square/p2/pkg/kp/dsstore/dsstoretest"
+	"github.com/square/p2/pkg/kp/kptest"
+	"github.com/square/p2/pkg/labels"
+	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/types"
+
+	. "github.com/anthonybishopric/gotcha"
+	ds_fields "github.com/square/p2/pkg/ds/fields"
+	klabels "k8s.io/kubernetes/pkg/labels"
+)
+
+func scheduledPods(t *testing.T, ds *daemonSet) []labels.Labeled {
+	selector := klabels.Everything().Add(DSIDLabel, klabels.EqualsOperator, []string{ds.ID().String()})
+	labeled, err := ds.applicator.GetMatches(selector, labels.POD)
+	Assert(t).IsNil(err, "expected no error matching pods")
+	return labeled
+}
+
+func waitForNodes(
+	t *testing.T,
+	ds DaemonSet,
+	desired int,
+	desiresErrCh <-chan error,
+	changesErrCh <-chan error,
+) int {
+	timeout := time.After(1 * time.Second)
+	podLocations, err := ds.CurrentPods()
+	Assert(t).IsNil(err, "expected no error getting pod locations")
+	timedOut := false
+
+	// This for loop runs until you either time out or len(podLocations) == desired
+	// then return the length of whatever ds.CurrentNodes() is
+	for len(podLocations) != desired && !timedOut {
+		select {
+		case <-time.Tick(100 * time.Millisecond):
+			// Also check for errors
+			var err error
+			podLocations, err = ds.CurrentPods()
+			Assert(t).IsNil(err, "expected no error getting pod locations nodes")
+
+			select {
+			case err = <-desiresErrCh:
+				Assert(t).IsNil(err, "expected no error watches desires")
+			case err = <-changesErrCh:
+				Assert(t).IsNil(err, "expected no error watching for changes")
+			default:
+			}
+
+		case <-timeout:
+			timedOut = true
+		}
+	}
+	return len(podLocations)
+}
+
+// Watches for changes to daemon sets and sends update and delete signals
+// since these are unit tests and have little daemon sets, we will watch
+// the entire tree for each daemon set for now
+func watchDSChanges(
+	t *testing.T,
+	ds *daemonSet,
+	dsStore dsstore.Store,
+	quitCh <-chan struct{},
+	updatedCh chan<- ds_fields.DaemonSet,
+	deletedCh chan<- struct{},
+) <-chan error {
+	errCh := make(chan error)
+	changesCh := dsStore.Watch(quitCh)
+
+	go func() {
+		defer close(errCh)
+
+		for {
+			var watched dsstore.WatchedDaemonSets
+
+			// Get some changes
+			select {
+			case watched = <-changesCh:
+			case <-quitCh:
+				return
+			}
+
+			if watched.Err != nil {
+				errCh <- util.Errorf("Error occured when watching daemon sets: %v", watched.Err)
+			}
+
+			// Signal daemon set when changes have been made,
+			// creations are handled when WatchDesires is called, so ignore them here
+			for _, changedDS := range watched.Updated {
+				if ds.ID() == changedDS.ID {
+					ds.logger.NoFields().Infof("Watched daemon set get updated: %v", *changedDS)
+					updatedCh <- *changedDS
+				}
+			}
+			for _, changedDS := range watched.Deleted {
+				if ds.ID() == changedDS.ID {
+					ds.logger.NoFields().Infof("Watched daemon set get deleted: %v", changedDS)
+					deletedCh <- struct{}{}
+				}
+			}
+		}
+	}()
+	return errCh
+}
+
+// TestSchedule checks consecutive scheduling and unscheduling for:
+//	- creation of a daemon set
+// 	- different node selectors
+//	- changes to nodes allocations
+// 	- mutations to a daemon set
+//	- deleting a daemon set
+func TestSchedule(t *testing.T) {
+	//
+	// Setup fixture and schedule a pod
+	//
+	dsStore := dsstoretest.NewFake()
+
+	podID := types.PodID("testPod")
+	minHealth := 0
+	clusterName := ds_fields.ClusterName("some_name")
+
+	manifestBuilder := pods.NewManifestBuilder()
+	manifestBuilder.SetID(podID)
+	manifest := manifestBuilder.GetManifest()
+
+	nodeSelector := klabels.Everything().Add("nodeQuality", klabels.EqualsOperator, []string{"good"})
+
+	dsData, err := dsStore.Create(manifest, minHealth, clusterName, nodeSelector, podID)
+	Assert(t).IsNil(err, "expected no error creating request")
+
+	kpStore := kptest.NewFakePodStore(make(map[kptest.FakePodStoreKey]pods.Manifest), make(map[string]kp.WatchResult))
+	applicator := labels.NewFakeApplicator()
+
+	ds := New(
+		dsData,
+		dsStore,
+		kpStore,
+		applicator,
+		logging.DefaultLogger,
+	).(*daemonSet)
+
+	scheduled := scheduledPods(t, ds)
+	Assert(t).AreEqual(len(scheduled), 0, "expected no pods to have been labeled")
+	manifestResults, _, err := kpStore.AllPods(kp.INTENT_TREE)
+	if err != nil {
+		t.Fatalf("Unable to get all pods from pod store: %v", err)
+	}
+	Assert(t).AreEqual(len(manifestResults), 0, "expected no manifests to have been scheduled")
+
+	err = applicator.SetLabel(labels.NODE, "node1", "nodeQuality", "bad")
+	Assert(t).IsNil(err, "expected no error labeling node1")
+	err = applicator.SetLabel(labels.NODE, "node2", "nodeQuality", "good")
+	Assert(t).IsNil(err, "expected no error labeling node2")
+
+	//
+	// Adds a watch that will automatically send a signal when a change was made
+	// to the daemon set
+	//
+	quitCh := make(chan struct{})
+	updatedCh := make(chan ds_fields.DaemonSet)
+	deletedCh := make(chan struct{})
+	nodesChangedCh := make(chan struct{})
+	defer close(quitCh)
+	defer close(updatedCh)
+	defer close(deletedCh)
+	defer close(nodesChangedCh)
+	desiresErrCh := ds.WatchDesires(quitCh, updatedCh, deletedCh, nodesChangedCh)
+	changesErrCh := watchDSChanges(t, ds, dsStore, quitCh, updatedCh, deletedCh)
+
+	//
+	// Verify that the pod has been scheduled
+	//
+	numNodes := waitForNodes(t, ds, 1, desiresErrCh, changesErrCh)
+	Assert(t).AreEqual(numNodes, 1, "took too long to schedule")
+
+	scheduled = scheduledPods(t, ds)
+	Assert(t).AreEqual(len(scheduled), 1, "expected a node to have been labeled")
+	Assert(t).AreEqual(scheduled[0].ID, "node2/testPod", "expected node labeled with the daemon set's id")
+
+	// Verify that the scheduled pod is correct
+	manifestResults, _, err = kpStore.AllPods(kp.INTENT_TREE)
+	if err != nil {
+		t.Fatalf("Unable to get all pods from pod store: %v", err)
+	}
+	for _, val := range manifestResults {
+		Assert(t).AreEqual(val.Path, "intent/node2/testPod", "expected manifest scheduled on the right node")
+		Assert(t).AreEqual(string(val.Manifest.ID()), "testPod", "expected manifest with correct ID")
+	}
+
+	//
+	// Add 10 good nodes and 10 bad nodes then verify
+	//
+	for i := 0; i < 10; i++ {
+		nodeName := fmt.Sprintf("good_node%v", i)
+		err := applicator.SetLabel(labels.NODE, nodeName, "nodeQuality", "good")
+		Assert(t).IsNil(err, "expected no error labeling node")
+	}
+
+	for i := 0; i < 10; i++ {
+		nodeName := fmt.Sprintf("bad_node%v", i)
+		err := applicator.SetLabel(labels.NODE, nodeName, "nodeQuality", "bad")
+		Assert(t).IsNil(err, "expected no error labeling node")
+	}
+
+	// Manually signal that nodes have been changed since a watch for that has
+	// not been implemented yet
+	nodesChangedCh <- struct{}{}
+
+	numNodes = waitForNodes(t, ds, 11, desiresErrCh, changesErrCh)
+	Assert(t).AreEqual(numNodes, 11, "took too long to schedule")
+
+	scheduled = scheduledPods(t, ds)
+	Assert(t).AreEqual(len(scheduled), 11, "expected a lot of nodes to have been labeled")
+
+	//
+	// Add a node with the labels nodeQuality=good and cherry=pick
+	//
+	err = applicator.SetLabel(labels.NODE, "nodeOk", "nodeQuality", "good")
+	Assert(t).IsNil(err, "expected no error labeling nodeOk")
+	err = applicator.SetLabel(labels.NODE, "nodeOk", "cherry", "pick")
+	Assert(t).IsNil(err, "expected no error labeling nodeOk")
+	fmt.Println(applicator.GetLabels(labels.NODE, "nodeOk"))
+
+	// Manually signal that nodes have been changed since a watch for that has
+	// not been implemented yet
+	nodesChangedCh <- struct{}{}
+
+	numNodes = waitForNodes(t, ds, 12, desiresErrCh, changesErrCh)
+	Assert(t).AreEqual(numNodes, 12, "took too long to schedule")
+
+	// Schedule only a node that is both nodeQuality=good and cherry=pick
+	mutator := func(dsToChange ds_fields.DaemonSet) (ds_fields.DaemonSet, error) {
+		dsToChange.NodeSelector = klabels.Everything().
+			Add("nodeQuality", klabels.EqualsOperator, []string{"good"}).
+			Add("cherry", klabels.EqualsOperator, []string{"pick"})
+		return dsToChange, nil
+	}
+	_, err = dsStore.MutateDS(ds.ID(), mutator)
+	Assert(t).IsNil(err, "Unxpected error trying to mutate daemon set")
+
+	numNodes = waitForNodes(t, ds, 1, desiresErrCh, changesErrCh)
+	Assert(t).AreEqual(numNodes, 1, "took too long to schedule")
+
+	// Verify that the scheduled pod is correct
+	manifestResults, _, err = kpStore.AllPods(kp.INTENT_TREE)
+	if err != nil {
+		t.Fatalf("Unable to get all pods from pod store: %v", err)
+	}
+	for _, val := range manifestResults {
+		Assert(t).AreEqual(val.Path, "intent/nodeOk/testPod", "expected manifest scheduled on the right node")
+		Assert(t).AreEqual(string(val.Manifest.ID()), "testPod", "expected manifest with correct ID")
+	}
+
+	//
+	// Disabling the daemon set and making a change should not do anything
+	//
+	mutator = func(dsToChange ds_fields.DaemonSet) (ds_fields.DaemonSet, error) {
+		dsToChange.Disabled = true
+		dsToChange.NodeSelector = klabels.Everything().
+			Add("nodeQuality", klabels.EqualsOperator, []string{"good"})
+		return dsToChange, nil
+	}
+	_, err = dsStore.MutateDS(ds.ID(), mutator)
+	Assert(t).IsNil(err, "Unxpected error trying to mutate daemon set")
+
+	numNodes = waitForNodes(t, ds, 1, desiresErrCh, changesErrCh)
+	Assert(t).AreEqual(numNodes, 1, "took too long to unschedule")
+
+	//
+	// Now re-enable it and try to schedule everything
+	//
+	mutator = func(dsToChange ds_fields.DaemonSet) (ds_fields.DaemonSet, error) {
+		dsToChange.NodeSelector = klabels.Everything()
+		dsToChange.Disabled = false
+		return dsToChange, nil
+	}
+	_, err = dsStore.MutateDS(ds.ID(), mutator)
+	Assert(t).IsNil(err, "Unxpected error trying to mutate daemon set")
+
+	// 11 good nodes 11 bad nodes, and 1 good cherry picked node = 23 nodes
+	numNodes = waitForNodes(t, ds, 23, desiresErrCh, changesErrCh)
+	Assert(t).AreEqual(numNodes, 23, "took too long to schedule")
+
+	//
+	// Deleting the daemon set should unschedule all of its nodes
+	//
+	ds.logger.NoFields().Info("Deleting daemon set...")
+	err = dsStore.Delete(ds.ID())
+	if err != nil {
+		t.Fatalf("Unable to delete daemon set: %v", err)
+	}
+	numNodes = waitForNodes(t, ds, 0, desiresErrCh, changesErrCh)
+	Assert(t).AreEqual(numNodes, 0, "took too long to unschedule")
+
+	scheduled = scheduledPods(t, ds)
+	Assert(t).AreEqual(len(scheduled), 0, "expected all nodes to have been unlabeled")
+	manifestResults, _, err = kpStore.AllPods(kp.INTENT_TREE)
+	if err != nil {
+		t.Fatalf("Unable to get all pods from pod store: %v", err)
+	}
+	Assert(t).AreEqual(len(manifestResults), 0, "expected all manifests to have been unscheduled")
+}

--- a/pkg/labels/consul_applicator.go
+++ b/pkg/labels/consul_applicator.go
@@ -259,6 +259,14 @@ func (c *consulApplicator) WatchMatches(selector labels.Selector, labelType Type
 	return aggregator.Watch(selector, quitCh)
 }
 
+// these utility functions are used primarily while we exist in a mutable
+// deployment world. We will need to figure out how to replace these with
+// different datasources to allow RCs and DSs to continue to function correctly
+// in the future.
+func MakePodLabelKey(node types.NodeName, podID types.PodID) string {
+	return node.String() + "/" + podID.String()
+}
+
 func NodeAndPodIDFromPodLabel(labeled Labeled) (types.NodeName, types.PodID, error) {
 	if labeled.LabelType != POD {
 		return "", "", util.Errorf("Label was not a pod label, was %s", labeled.LabelType)

--- a/pkg/rc/replication_controller.go
+++ b/pkg/rc/replication_controller.go
@@ -360,7 +360,7 @@ func (rc *replicationController) CurrentPods() (PodLocations, error) {
 // If forEachLabel encounters any error applying the function, it returns that error immediately.
 // The function is not further applied to subsequent labels on an error.
 func (rc *replicationController) forEachLabel(node types.NodeName, f func(id, k, v string) error) error {
-	id := MakePodLabelKey(node, rc.Manifest.ID())
+	id := labels.MakePodLabelKey(node, rc.Manifest.ID())
 
 	// user-requested labels.
 	for k, v := range rc.PodLabels {
@@ -400,13 +400,4 @@ func (rc *replicationController) unschedule(node types.NodeName) error {
 	return rc.forEachLabel(node, func(podID, k, _ string) error {
 		return rc.podApplicator.RemoveLabel(labels.POD, podID, k)
 	})
-}
-
-// these utility functions are used primarily while we exist in a mutable
-// deployment world. We will need to figure out how to replace these with
-// different datasources to allow RCs to continue to function correctly
-// in the future.
-
-func MakePodLabelKey(node types.NodeName, podID types.PodID) string {
-	return node.String() + "/" + podID.String()
 }

--- a/pkg/rc/replication_controller_test.go
+++ b/pkg/rc/replication_controller_test.go
@@ -408,7 +408,7 @@ func TestReservedLabels(t *testing.T) {
 	err = rc.meetDesires()
 	Assert(t).IsNil(err, "unexpected error scheduling nodes")
 
-	labeled, err := applicator.GetLabels(labels.POD, MakePodLabelKey("node1", "testPod"))
+	labeled, err := applicator.GetLabels(labels.POD, labels.MakePodLabelKey("node1", "testPod"))
 	Assert(t).IsNil(err, "unexpected error getting pod labels")
 
 	Assert(t).AreEqual(labeled.Labels[rcstore.PodIDLabel], "testPod", "Pod label not set as expected")

--- a/pkg/roll/update_test.go
+++ b/pkg/roll/update_test.go
@@ -788,7 +788,7 @@ func transferNode(node types.NodeName, manifest pods.Manifest, upd update) error
 	if _, err := upd.kps.SetPod(kp.REALITY_TREE, node, manifest); err != nil {
 		return err
 	}
-	return upd.labeler.SetLabel(labels.POD, rc.MakePodLabelKey(node, manifest.ID()), rc.RCIDLabel, string(upd.NewRC))
+	return upd.labeler.SetLabel(labels.POD, labels.MakePodLabelKey(node, manifest.ID()), rc.RCIDLabel, string(upd.NewRC))
 }
 
 func assertRCUpdates(t *testing.T, rc *rc_fields.RC, upd <-chan struct{}, expect int, desc string) {


### PR DESCRIPTION
This commit will:
Provide functionality for writing to the intent tree for daemon sets
Provide unit tests for this functionality
Fix kp/dsstore/fake_dsstore.go so that in-memory tests will work