### PR TITLE
Launch launchables even if post-activate fails

### DIFF
--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -149,7 +149,6 @@ func (pod *Pod) Launch(manifest Manifest) (bool, error) {
 		return false, err
 	}
 
-	var successes []bool
 	for _, launchable := range launchables {
 		err := launchable.MakeCurrent()
 		if err != nil {
@@ -162,22 +161,17 @@ func (pod *Pod) Launch(manifest Manifest) (bool, error) {
 			// if a launchable's post-activate fails, we probably can't
 			// launch it, but this does not break the entire pod
 			pod.logLaunchableError(launchable.ServiceID(), err, out)
-			successes = append(successes, false)
 		} else {
 			if out != "" {
 				pod.logger.WithField("output", out).Infoln("Successfully post-activated")
 			}
-			successes = append(successes, true)
 		}
 	}
 
 	err = pod.buildRunitServices(launchables, manifest)
 
 	success := true
-	for i, launchable := range launchables {
-		if !successes[i] {
-			continue
-		}
+	for _, launchable := range launchables {
 		err = launchable.Launch(pod.ServiceBuilder, pod.SV) // TODO: make these configurable
 		switch err.(type) {
 		case nil:


### PR DESCRIPTION
Previously the behavior was to refrain from launching a launchable if
its post-activate script failed, but still consider the launch of the
pod successful. This results in a confusing user experience when the pod
is partially started due to post-activate failures.

This commit simply logs the post-activate failure but proceeds to launch
each launchable anyway. The launchable status check will hopefully
capture any actual problems resulting from post-activate failing to run,
which will cause a deploy to stall via rolling update.