### PR TITLE
Modify auth.ArtifactVerifier interface to take VerificationData struct

### DIFF
--- a/bin/p2-bin2pod/main.go
+++ b/bin/p2-bin2pod/main.go
@@ -78,7 +78,7 @@ func main() {
 	manifestBuilder := pods.NewManifestBuilder()
 	manifestBuilder.SetID(podID())
 
-	stanza := pods.LaunchableStanza{}
+	stanza := types.LaunchableStanza{}
 	stanza.LaunchableId = podID().String()
 	stanza.LaunchableType = "hoist"
 
@@ -99,7 +99,7 @@ func main() {
 		res.FinalLocation = tarLocation
 	}
 
-	manifestBuilder.SetLaunchables(map[string]pods.LaunchableStanza{
+	manifestBuilder.SetLaunchables(map[string]types.LaunchableStanza{
 		podID().String(): stanza,
 	})
 

--- a/bin/p2-verify-artifact/main.go
+++ b/bin/p2-verify-artifact/main.go
@@ -10,6 +10,7 @@ import (
 
 	"gopkg.in/alecthomas/kingpin.v2"
 
+	"github.com/square/p2/pkg/artifact"
 	"github.com/square/p2/pkg/auth"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/uri"
@@ -60,11 +61,12 @@ func main() {
 		BuildErr       string `json:"build_error,omitempty"`
 	}{}
 
+	verificationData := artifact.VerificationDataForLocation(locationForSignature)
 	manifestVerifier, buildErr := auth.NewBuildManifestVerifier(*gpgKeyringPath, uri.DefaultFetcher, &logging.DefaultLogger)
 	buildVerifier, manErr := auth.NewBuildVerifier(*gpgKeyringPath, uri.DefaultFetcher, &logging.DefaultLogger)
 
 	if buildErr == nil {
-		err := buildVerifier.VerifyHoistArtifact(localCopy, locationForSignature)
+		err := buildVerifier.VerifyHoistArtifact(localCopy, verificationData)
 		if err == nil {
 			res.SignedBuild = true
 		} else {
@@ -77,7 +79,7 @@ func main() {
 	_, _ = localCopy.Seek(0, os.SEEK_SET)
 
 	if manErr == nil {
-		err := manifestVerifier.VerifyHoistArtifact(localCopy, locationForSignature)
+		err := manifestVerifier.VerifyHoistArtifact(localCopy, verificationData)
 		if err == nil {
 			res.SignedManifest = true
 		} else {

--- a/integration/single-node-slug-deploy/check.go
+++ b/integration/single-node-slug-deploy/check.go
@@ -319,7 +319,7 @@ func getConsulManifest(dir string) (string, error) {
 	)
 	builder := pods.NewManifestBuilder()
 	builder.SetID("consul")
-	stanzas := map[string]pods.LaunchableStanza{
+	stanzas := map[string]types.LaunchableStanza{
 		"consul": {
 			LaunchableId:   "consul",
 			LaunchableType: "hoist",
@@ -396,7 +396,7 @@ func createHelloReplicationController(dir string) (fields.ID, error) {
 	builder := pods.NewManifestBuilder()
 	builder.SetID("hello")
 	builder.SetStatusPort(43770)
-	stanzas := map[string]pods.LaunchableStanza{
+	stanzas := map[string]types.LaunchableStanza{
 		"hello": {
 			LaunchableId:   "hello",
 			LaunchableType: "hoist",

--- a/pkg/artifact/registry.go
+++ b/pkg/artifact/registry.go
@@ -1,0 +1,78 @@
+package artifact
+
+import (
+	"net/url"
+
+	"github.com/square/p2/pkg/auth"
+	"github.com/square/p2/pkg/types"
+	"github.com/square/p2/pkg/util"
+)
+
+// interface for running operations against an artifact registry.
+type Registry interface {
+	// Given a LaunchableStanza from a pod manifest, returns a URL from which the
+	// artifact can be fetched an a struct containing the locations of files that
+	// can be used to verify artifact integrity
+	LocationDataForLaunchable(stanza types.LaunchableStanza) (*url.URL, auth.VerificationData, error)
+}
+
+type registry struct{}
+
+func NewRegistry() Registry {
+	return &registry{}
+}
+
+// Given a launchable stanza, returns the URL from which the artifact may be downloaded, as
+// well as an auth.VerificationData which can be used to verify the artifact.
+// There are two schemes for specifying this information in a launchable stanza:
+// 1) using the "location" field. In this case, the artifact location is simply the value
+// of the field and the path to the verification files is inferred using magic suffixes
+// 2) the "version" field is provided. In this case, the artifact registry is queried with
+// the information specified under the "version" key and the response contains the URLs
+// from which the extra files may be fetched, and these are returned.
+//
+// When using the first method, the following magical suffixes are assumed:
+// manifest: ".manifest"
+// manifest signature: ".manifest.sig"
+// build signature: ".sig"
+func (a registry) LocationDataForLaunchable(stanza types.LaunchableStanza) (*url.URL, auth.VerificationData, error) {
+	if stanza.Location == "" && stanza.Version.ID == "" {
+		return nil, auth.VerificationData{}, util.Errorf("Launchable must provide either \"location\" or \"version\" fields")
+	}
+
+	if stanza.Location != "" && stanza.Version.ID != "" {
+		return nil, auth.VerificationData{}, util.Errorf("Launchable must not provide both \"location\" and \"version\" fields")
+	}
+
+	// infer the verification data using magical suffixes
+	if stanza.Location != "" {
+		location, err := url.Parse(stanza.Location)
+		if err != nil {
+			return nil, auth.VerificationData{}, util.Errorf("Couldn't parse launchable url '%s': %s", stanza.Location, err)
+		}
+
+		verificationData := VerificationDataForLocation(location)
+		return location, verificationData, nil
+	}
+
+	return nil, auth.VerificationData{}, util.Errorf("Version key in launchable stanza not implemented")
+}
+
+func VerificationDataForLocation(location *url.URL) auth.VerificationData {
+	manifestLocation := &url.URL{}
+	*manifestLocation = *location
+	manifestLocation.Path = location.Path + ".manifest"
+
+	manifestSignatureLocation := &url.URL{}
+	*manifestSignatureLocation = *manifestLocation
+	manifestSignatureLocation.Path = manifestLocation.Path + ".sig"
+
+	buildSignatureLocation := &url.URL{}
+	*buildSignatureLocation = *location
+	buildSignatureLocation.Path = location.Path + ".sig"
+	return auth.VerificationData{
+		ManifestLocation:          manifestLocation,
+		ManifestSignatureLocation: manifestSignatureLocation,
+		BuildSignatureLocation:    buildSignatureLocation,
+	}
+}

--- a/pkg/artifact/registry_test.go
+++ b/pkg/artifact/registry_test.go
@@ -1,0 +1,94 @@
+package artifact
+
+import (
+	"testing"
+
+	"github.com/square/p2/pkg/types"
+)
+
+const testLocation = "https://fileserver.com/artifact.tar.gz"
+
+func locationLaunchable() types.LaunchableStanza {
+	return types.LaunchableStanza{
+		Location: "https://fileserver.com/artifact.tar.gz",
+	}
+}
+
+func TestLocationDataForLaunchableWithLocation(t *testing.T) {
+	registry := NewRegistry()
+	location, artifactData, err := registry.LocationDataForLaunchable(locationLaunchable())
+	if err != nil {
+		t.Fatalf("Unexpected error getting location data: %s", err)
+	}
+
+	if location.String() != testLocation {
+		t.Errorf(
+			"Didn't properly parse artifact location from stanza: wanted '%s' was '%s'",
+			testLocation,
+			location.String(),
+		)
+	}
+
+	expectedManifestLocation := testLocation + ".manifest"
+	if artifactData.ManifestLocation.String() != expectedManifestLocation {
+		t.Errorf(
+			"Didn't properly compute manifest location: wanted '%s' was '%s'",
+			expectedManifestLocation,
+			artifactData.ManifestLocation.String(),
+		)
+	}
+
+	expectedManifestSignatureLocation := testLocation + ".manifest.sig"
+	if artifactData.ManifestSignatureLocation.String() != expectedManifestSignatureLocation {
+		t.Errorf(
+			"Didn't properly compute manifest signature location: wanted '%s' was '%s'",
+			expectedManifestSignatureLocation,
+			artifactData.ManifestSignatureLocation.String(),
+		)
+	}
+
+	expectedBuildSignatureLocation := testLocation + ".sig"
+	if artifactData.BuildSignatureLocation.String() != expectedBuildSignatureLocation {
+		t.Errorf(
+			"Didn't properly compute build signature location: wanted '%s' was '%s'",
+			expectedBuildSignatureLocation,
+			artifactData.BuildSignatureLocation.String(),
+		)
+	}
+}
+
+func TestNeitherVersionNorLocationInvalid(t *testing.T) {
+	launchable := types.LaunchableStanza{}
+	registry := NewRegistry()
+	_, _, err := registry.LocationDataForLaunchable(launchable)
+	if err == nil {
+		t.Errorf("Expected an error when launchable has neither version nor location")
+	}
+}
+
+func TestBothVersionAndLocationInvalid(t *testing.T) {
+	launchable := types.LaunchableStanza{
+		Version: types.LaunchableVersion{
+			ID: "some_version",
+		},
+		Location: testLocation,
+	}
+	registry := NewRegistry()
+	_, _, err := registry.LocationDataForLaunchable(launchable)
+	if err == nil {
+		t.Errorf("Expected an error when launchable has both version and location")
+	}
+}
+
+func TestVersionSchemeNotImplemented(t *testing.T) {
+	launchable := types.LaunchableStanza{
+		Version: types.LaunchableVersion{
+			ID: "some_version",
+		},
+	}
+	registry := NewRegistry()
+	_, _, err := registry.LocationDataForLaunchable(launchable)
+	if err == nil {
+		t.Errorf("Expected a not implemented error when launchable version only")
+	}
+}

--- a/pkg/hoist/hoist_launchable_test.go
+++ b/pkg/hoist/hoist_launchable_test.go
@@ -36,15 +36,17 @@ func TestInstall(t *testing.T) {
 	defer os.RemoveAll(launchableHome)
 
 	launchable := &Launchable{
-		Id:        "hello",
-		Version:   "def456",
-		ServiceId: "hoisted-hello__hello",
-		RunAs:     currentUser.Username,
-		PodEnvDir: launchableHome,
-		RootDir:   launchableHome,
+		Id:               "hello",
+		Version:          "def456",
+		ServiceId:        "hoisted-hello__hello",
+		RunAs:            currentUser.Username,
+		PodEnvDir:        launchableHome,
+		RootDir:          launchableHome,
+		Location:         testLocation,
+		VerificationData: artifact.VerificationDataForLocation(testLocation),
 	}
 
-	downloader := artifact.NewLocationDownloader(testLocation, fetcher, auth.NopVerifier())
+	downloader := artifact.NewLocationDownloader(fetcher, auth.NopVerifier())
 	err = launchable.Install(downloader)
 	Assert(t).IsNil(err, "there should not have been an error when installing")
 

--- a/pkg/pods/manifest.go
+++ b/pkg/pods/manifest.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"path"
 
-	"github.com/square/p2/pkg/cgroups"
 	"github.com/square/p2/pkg/runit"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/uri"
@@ -22,30 +21,6 @@ import (
 	"golang.org/x/crypto/openpgp/clearsign"
 	"gopkg.in/yaml.v2"
 )
-
-type LaunchableVersion struct {
-	ID   string            `yaml:"id"`
-	Tags map[string]string `yaml:"tags"`
-}
-
-type LaunchableStanza struct {
-	LaunchableType          string            `yaml:"launchable_type"`
-	LaunchableId            string            `yaml:"launchable_id"`
-	DigestLocation          string            `yaml:"digest_location,omitempty"`
-	DigestSignatureLocation string            `yaml:"digest_signature_location,omitempty"`
-	RestartTimeout          string            `yaml:"restart_timeout,omitempty"`
-	CgroupConfig            cgroups.Config    `yaml:"cgroup,omitempty"`
-	Env                     map[string]string `yaml:"env,omitempty"`
-
-	// The URL from which the launchable can be downloaded. May not be used
-	// in conjunction with Version
-	Location string `yaml:"location"`
-
-	// An alternative to using Location to inform artifact downloading. Version information
-	// can be used to query a configured artifact registry which will provide the artifact
-	// URL. Version may not be used in conjunction with Location
-	Version LaunchableVersion `yaml:"version,omitempty"`
-}
 
 type StatusStanza struct {
 	HTTP          bool   `yaml:"http,omitempty"`
@@ -62,7 +37,7 @@ type ManifestBuilder interface {
 	SetStatusHTTP(statusHTTP bool)
 	SetStatusPath(statusPath string)
 	SetStatusPort(port int)
-	SetLaunchables(launchableStanzas map[string]LaunchableStanza)
+	SetLaunchables(launchableStanzas map[string]types.LaunchableStanza)
 }
 
 var _ ManifestBuilder = manifestBuilder{}
@@ -89,7 +64,7 @@ type Manifest interface {
 	WriteConfig(out io.Writer) error
 	PlatformConfigFileName() (string, error)
 	WritePlatformConfig(out io.Writer) error
-	GetLaunchableStanzas() map[string]LaunchableStanza
+	GetLaunchableStanzas() map[string]types.LaunchableStanza
 	GetConfig() map[interface{}]interface{}
 	SHA() (string, error)
 	GetStatusHTTP() bool
@@ -107,14 +82,14 @@ type Manifest interface {
 var _ Manifest = &manifest{}
 
 type manifest struct {
-	Id                types.PodID                 `yaml:"id"` // public for yaml marshaling access. Use ID() instead.
-	RunAs             string                      `yaml:"run_as,omitempty"`
-	LaunchableStanzas map[string]LaunchableStanza `yaml:"launchables"`
-	Config            map[interface{}]interface{} `yaml:"config"`
-	StatusPort        int                         `yaml:"status_port,omitempty"`
-	StatusHTTP        bool                        `yaml:"status_http,omitempty"`
-	Status            StatusStanza                `yaml:"status,omitempty"`
-	RestartPolicy     runit.RestartPolicy         `yaml:"restart_policy,omitempty"`
+	Id                types.PodID                       `yaml:"id"` // public for yaml marshaling access. Use ID() instead.
+	RunAs             string                            `yaml:"run_as,omitempty"`
+	LaunchableStanzas map[string]types.LaunchableStanza `yaml:"launchables"`
+	Config            map[interface{}]interface{}       `yaml:"config"`
+	StatusPort        int                               `yaml:"status_port,omitempty"`
+	StatusHTTP        bool                              `yaml:"status_http,omitempty"`
+	Status            StatusStanza                      `yaml:"status,omitempty"`
+	RestartPolicy     runit.RestartPolicy               `yaml:"restart_policy,omitempty"`
 
 	// Used to track the original bytes so that we don't reorder them when
 	// doing a yaml.Unmarshal and a yaml.Marshal in succession
@@ -144,11 +119,11 @@ func (m manifestBuilder) SetID(id types.PodID) {
 	m.manifest.Id = id
 }
 
-func (manifest *manifest) GetLaunchableStanzas() map[string]LaunchableStanza {
+func (manifest *manifest) GetLaunchableStanzas() map[string]types.LaunchableStanza {
 	return manifest.LaunchableStanzas
 }
 
-func (manifest *manifest) SetLaunchables(launchableStanzas map[string]LaunchableStanza) {
+func (manifest *manifest) SetLaunchables(launchableStanzas map[string]types.LaunchableStanza) {
 	manifest.LaunchableStanzas = launchableStanzas
 }
 

--- a/pkg/pods/manifest_test.go
+++ b/pkg/pods/manifest_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/square/p2/pkg/cgroups"
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util/size"
 
 	. "github.com/anthonybishopric/gotcha"
@@ -96,7 +97,7 @@ QyB184dCJQnFbcQslyXDSR4Lal12NPvxbtK/4YYXZZVwf4hKCfVqvmG2zgwINDc=
 func TestPodManifestCanBeWritten(t *testing.T) {
 	builder := NewManifestBuilder()
 	builder.SetID("thepod")
-	launchables := map[string]LaunchableStanza{
+	launchables := map[string]types.LaunchableStanza{
 		"my-app": {
 			LaunchableType: "hoist",
 			LaunchableId:   "web",

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/square/p2/pkg/artifact"
 	"github.com/square/p2/pkg/hoist"
 	"github.com/square/p2/pkg/launch"
 	"github.com/square/p2/pkg/runit"
@@ -40,7 +41,7 @@ func getUpdatedManifest(t *testing.T) Manifest {
 	return pod
 }
 
-func getLaunchableStanzasFromTestManifest(t *testing.T) map[string]LaunchableStanza {
+func getLaunchableStanzasFromTestManifest(t *testing.T) map[string]types.LaunchableStanza {
 	return getTestPodManifest(t).GetLaunchableStanzas()
 }
 
@@ -312,6 +313,7 @@ func TestUninstall(t *testing.T) {
 		Id:             "testPod",
 		path:           testPodDir,
 		ServiceBuilder: serviceBuilder,
+		Registry:       artifact.NewRegistry(),
 	}
 	manifest := getTestPodManifest(t)
 	manifestContent, err := manifest.Marshal()

--- a/pkg/preparer/listener_test.go
+++ b/pkg/preparer/listener_test.go
@@ -65,7 +65,7 @@ func testHookListener(t *testing.T) (HookListener, <-chan struct{}) {
 	builder := pods.NewManifestBuilder()
 	builder.SetID("users")
 	builder.SetRunAsUser(current.Username)
-	builder.SetLaunchables(map[string]pods.LaunchableStanza{
+	builder.SetLaunchables(map[string]types.LaunchableStanza{
 		"create": {
 			Location:       util.From(runtime.Caller(0)).ExpandPath("hoisted-hello_def456.tar.gz"),
 			LaunchableType: "hoist",

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -4,6 +4,8 @@
 package types
 
 import (
+	"github.com/square/p2/pkg/cgroups"
+
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
@@ -66,4 +68,28 @@ func (n NodeSet) Equal(other NodeSet) bool {
 func (n NodeSet) PopAny() (NodeName, bool) {
 	node, ok := n.String.PopAny()
 	return NodeName(node), ok
+}
+
+type LaunchableVersion struct {
+	ID   string            `yaml:"id"`
+	Tags map[string]string `yaml:"tags"`
+}
+
+type LaunchableStanza struct {
+	LaunchableType          string            `yaml:"launchable_type"`
+	LaunchableId            string            `yaml:"launchable_id"`
+	DigestLocation          string            `yaml:"digest_location,omitempty"`
+	DigestSignatureLocation string            `yaml:"digest_signature_location,omitempty"`
+	RestartTimeout          string            `yaml:"restart_timeout,omitempty"`
+	CgroupConfig            cgroups.Config    `yaml:"cgroup,omitempty"`
+	Env                     map[string]string `yaml:"env,omitempty"`
+
+	// The URL from which the launchable can be downloaded. May not be used
+	// in conjunction with Version
+	Location string `yaml:"location"`
+
+	// An alternative to using Location to inform artifact downloading. Version information
+	// can be used to query a configured artifact registry which will provide the artifact
+	// URL. Version may not be used in conjunction with Location
+	Version LaunchableVersion `yaml:"version,omitempty"`
 }


### PR DESCRIPTION
We're planning to support two methods of specifying the location from
which a launchable may be downloaded:

1) using the "location" field in LaunchableStanza
2) using the "version" field in LaunchableStanza. This method is
currently not implemented to keep this commit smaller.

Previously all artifact downloads used the "location" field, and when
artifact verification is desired, the supplementary files needed to
verify the artifact (such as manifest and signatures) were inferred from
the artifact location by adding some special suffixes.

When the "version" scheme is used, an artifact registry will instead be
queried using the artifact metadata under the "version" key (as well as
other data) and the location of the artifact will be returned along with
the locations of the supplementary verification files. As a result, this
commit pulls the suffix-using logic out of artifact verification code.

Now the artifact package has a new function that takes a
LaunchableStanza and returns the location of the launchable and a
VerificationData struct that can be used for artifact verification.
Querying the artifact registry when using a "version" scheme is not yet
implemented.