### PR TITLE
Provide functionality to notice changes in node tree

### DIFF
--- a/pkg/ds/daemon_set.go
+++ b/pkg/ds/daemon_set.go
@@ -33,22 +33,7 @@ type DaemonSet interface {
 	) <-chan error
 
 	// CurrentPods() returns all nodes that are scheduled by this daemon set
-	CurrentPods() (PodLocations, error)
-}
-
-type PodLocation struct {
-	Node  types.NodeName
-	PodID types.PodID
-}
-type PodLocations []PodLocation
-
-// Nodes returns a list of just the locations' nodes.
-func (l PodLocations) Nodes() []types.NodeName {
-	nodes := make([]types.NodeName, len(l))
-	for i, pod := range l {
-		nodes[i] = pod.Node
-	}
-	return nodes
+	CurrentPods() (types.PodLocations, error)
 }
 
 // These methods are the same as the methods of the same name in kp.Store.
@@ -321,7 +306,7 @@ func (ds *daemonSet) unschedule(node types.NodeName) error {
 	return nil
 }
 
-func (ds *daemonSet) CurrentPods() (PodLocations, error) {
+func (ds *daemonSet) CurrentPods() (types.PodLocations, error) {
 	// Changing DaemonSet.ID is not permitted, so as long as there is no uuid
 	// collision, this will always get the current pod path that this daemon set
 	// had scheduled on
@@ -332,7 +317,7 @@ func (ds *daemonSet) CurrentPods() (PodLocations, error) {
 		return nil, util.Errorf("Unable to get matches on pod tree: %v", err)
 	}
 
-	result := make(PodLocations, len(podMatches))
+	result := make(types.PodLocations, len(podMatches))
 	for i, podMatch := range podMatches {
 		// ID will be something like <node>/<PodID>
 		node, podID, err := labels.NodeAndPodIDFromPodLabel(podMatch)

--- a/pkg/labels/applicator.go
+++ b/pkg/labels/applicator.go
@@ -53,6 +53,12 @@ type Labeled struct {
 	Labels    labels.Set
 }
 
+type LabeledChanges struct {
+	Created []Labeled
+	Updated []Labeled
+	Deleted []Labeled
+}
+
 func (l Labeled) SameAs(o Labeled) bool {
 	return l.ID == o.ID && l.LabelType == o.LabelType
 }
@@ -86,5 +92,13 @@ type Applicator interface {
 	// the quit channel - this will be indicated by the closing of the result channel. For
 	// this reason, callers should **always** verify that the channel is closed by checking
 	// the "ok" boolean or using `range`.
-	WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan []Labeled
+	WatchMatches(selector labels.Selector, labelType Type, quitCh <-chan struct{}) chan []Labeled
+
+	// WatchMatchDiff does a diff on top of the results form the WatchMatches and
+	// returns a LabeledChanges structure which contain changes
+	WatchMatchDiff(
+		selector labels.Selector,
+		labelType Type,
+		quitCh <-chan struct{},
+	) <-chan *LabeledChanges
 }

--- a/pkg/labels/consul_aggregator.go
+++ b/pkg/labels/consul_aggregator.go
@@ -108,7 +108,7 @@ func NewConsulAggregator(labelType Type, kv consulutil.ConsulLister, logger logg
 
 // Add a new selector to the aggregator. New values on the output channel may not appear
 // right away.
-func (c *consulAggregator) Watch(selector labels.Selector, quitCh chan struct{}) chan []Labeled {
+func (c *consulAggregator) Watch(selector labels.Selector, quitCh <-chan struct{}) chan []Labeled {
 	resCh := make(chan []Labeled, 1) // this buffer is useful in sendMatches(), below
 	select {
 	case <-c.aggregatorQuit:

--- a/pkg/labels/http_applicator.go
+++ b/pkg/labels/http_applicator.go
@@ -95,7 +95,15 @@ func (h *httpApplicator) GetMatches(selector labels.Selector, labelType Type) ([
 	return labeled, nil
 }
 
-func (h *httpApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh chan struct{}) chan []Labeled {
+func (h *httpApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh <-chan struct{}) chan []Labeled {
 	panic("Not implemented")
 	return nil
+}
+
+func (h *httpApplicator) WatchMatchDiff(
+	selector labels.Selector,
+	labelType Type,
+	quitCh <-chan struct{},
+) <-chan *LabeledChanges {
+	panic("Not implemented")
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -18,6 +18,21 @@ func (p PodID) String() string {
 	return string(p)
 }
 
+type PodLocation struct {
+	Node  NodeName
+	PodID PodID
+}
+type PodLocations []PodLocation
+
+// Nodes returns a list of just the locations' nodes.
+func (l PodLocations) Nodes() []NodeName {
+	nodes := make([]NodeName, len(l))
+	for i, pod := range l {
+		nodes[i] = pod.Node
+	}
+	return nodes
+}
+
 // Wraps sets.String to provide the functionality of a set when dealing with
 // the NodeName type (which is a string)
 type NodeSet struct {


### PR DESCRIPTION
Minor changes:
Share the PodLocation structure between RCs and DSs
Ask the caller to WatchDesires to send a daemon set when a change has been made so that you can verify it
Fix tests to for the above change to WatchDesires

Major changes:
Add a WatchMatchDiff function for each daemon set process to detect changes in node tree
Provide and modify tests for the above WatchDiff function