### PR TITLE
Move the Manifest type from pkg/pods to pkg/manifest

### DIFF
--- a/bin/p2-bin2pod/main.go
+++ b/bin/p2-bin2pod/main.go
@@ -75,7 +75,7 @@ func main() {
 	kingpin.MustParse(bin2pod.Parse(os.Args[1:]))
 
 	res := result{}
-	manifestBuilder := manifest.NewManifestBuilder()
+	manifestBuilder := manifest.NewBuilder()
 	manifestBuilder.SetID(podID())
 
 	stanza := manifest.LaunchableStanza{}
@@ -157,7 +157,7 @@ func makeTar(workingDir string) (string, error) {
 	return tarPath, nil
 }
 
-func addManifestConfig(manifestBuilder manifest.ManifestBuilder) error {
+func addManifestConfig(manifestBuilder manifest.Builder) error {
 	podConfig := make(map[interface{}]interface{})
 	for _, pair := range *config {
 		res := strings.Split(pair, "=")

--- a/bin/p2-bin2pod/main.go
+++ b/bin/p2-bin2pod/main.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/uri"
 	"github.com/square/p2/pkg/version"
@@ -75,10 +75,10 @@ func main() {
 	kingpin.MustParse(bin2pod.Parse(os.Args[1:]))
 
 	res := result{}
-	manifestBuilder := pods.NewManifestBuilder()
+	manifestBuilder := manifest.NewManifestBuilder()
 	manifestBuilder.SetID(podID())
 
-	stanza := types.LaunchableStanza{}
+	stanza := manifest.LaunchableStanza{}
 	stanza.LaunchableId = podID().String()
 	stanza.LaunchableType = "hoist"
 
@@ -99,7 +99,7 @@ func main() {
 		res.FinalLocation = tarLocation
 	}
 
-	manifestBuilder.SetLaunchables(map[string]types.LaunchableStanza{
+	manifestBuilder.SetLaunchables(map[string]manifest.LaunchableStanza{
 		podID().String(): stanza,
 	})
 
@@ -157,7 +157,7 @@ func makeTar(workingDir string) (string, error) {
 	return tarPath, nil
 }
 
-func addManifestConfig(manifestBuilder pods.ManifestBuilder) error {
+func addManifestConfig(manifestBuilder manifest.ManifestBuilder) error {
 	podConfig := make(map[interface{}]interface{})
 	for _, pair := range *config {
 		res := strings.Split(pair, "=")
@@ -169,7 +169,7 @@ func addManifestConfig(manifestBuilder pods.ManifestBuilder) error {
 	return manifestBuilder.SetConfig(podConfig)
 }
 
-func writeManifest(workingDir string, manifest pods.Manifest) (string, error) {
+func writeManifest(workingDir string, manifest manifest.Manifest) (string, error) {
 	file, err := os.OpenFile(
 		path.Join(workingDir, fmt.Sprintf("%s.yaml", podID())),
 		os.O_WRONLY|os.O_CREATE|os.O_TRUNC,

--- a/bin/p2-bootstrap/bootstrap.go
+++ b/bin/p2-bootstrap/bootstrap.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/square/p2/pkg/auth"
 	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
@@ -28,16 +29,16 @@ func main() {
 	kingpin.Version(version.VERSION)
 	kingpin.Parse()
 	log.Println("Starting bootstrap")
-	agentManifest, err := pods.ManifestFromPath(*agentManifestPath)
+	agentManifest, err := manifest.ManifestFromPath(*agentManifestPath)
 	if err != nil {
 		log.Fatalln("Could not get agent manifest: %s", err)
 	}
 	log.Println("Installing and launching consul")
 
 	var consulPod *pods.Pod
-	var consulManifest pods.Manifest
+	var consulManifest manifest.Manifest
 	if *existingConsul == "" {
-		consulManifest, err = pods.ManifestFromPath(*consulManifestPath)
+		consulManifest, err = manifest.ManifestFromPath(*consulManifestPath)
 		if err != nil {
 			log.Fatalf("Could not get consul manifest: %s", err)
 		}
@@ -86,7 +87,7 @@ func main() {
 	log.Println("Bootstrapping complete")
 }
 
-func installConsul(consulPod *pods.Pod, consulManifest pods.Manifest) error {
+func installConsul(consulPod *pods.Pod, consulManifest manifest.Manifest) error {
 	// Inject servicebuilder?
 	err := consulPod.Install(consulManifest, auth.NopVerifier())
 	if err != nil {
@@ -169,7 +170,7 @@ func verifyReality(waitTime time.Duration, consulID types.PodID, agentID types.P
 	}
 }
 
-func scheduleForThisHost(manifest pods.Manifest, alsoReality bool) error {
+func scheduleForThisHost(manifest manifest.Manifest, alsoReality bool) error {
 	store := kp.NewConsulStore(kp.NewConsulClient(kp.Options{
 		Token: *consulToken,
 	}))
@@ -189,7 +190,7 @@ func scheduleForThisHost(manifest pods.Manifest, alsoReality bool) error {
 	return nil
 }
 
-func installBaseAgent(agentManifest pods.Manifest) error {
+func installBaseAgent(agentManifest manifest.Manifest) error {
 	agentPod := pods.NewPod(agentManifest.ID(), pods.PodPath(*podRoot, agentManifest.ID()))
 	err := agentPod.Install(agentManifest, auth.NopVerifier())
 	if err != nil {

--- a/bin/p2-bootstrap/bootstrap.go
+++ b/bin/p2-bootstrap/bootstrap.go
@@ -29,7 +29,7 @@ func main() {
 	kingpin.Version(version.VERSION)
 	kingpin.Parse()
 	log.Println("Starting bootstrap")
-	agentManifest, err := manifest.ManifestFromPath(*agentManifestPath)
+	agentManifest, err := manifest.FromPath(*agentManifestPath)
 	if err != nil {
 		log.Fatalln("Could not get agent manifest: %s", err)
 	}
@@ -38,7 +38,7 @@ func main() {
 	var consulPod *pods.Pod
 	var consulManifest manifest.Manifest
 	if *existingConsul == "" {
-		consulManifest, err = manifest.ManifestFromPath(*consulManifestPath)
+		consulManifest, err = manifest.FromPath(*consulManifestPath)
 		if err != nil {
 			log.Fatalf("Could not get consul manifest: %s", err)
 		}

--- a/bin/p2-dsctl/main.go
+++ b/bin/p2-dsctl/main.go
@@ -79,7 +79,7 @@ func main() {
 		podID := types.PodID(*createPodID)
 		selector := selectorFrom(az)
 
-		manifest, err := manifest.ManifestFromPath(*createManifest)
+		manifest, err := manifest.FromPath(*createManifest)
 		if err != nil {
 			log.Fatalf("%s", err)
 		}
@@ -195,7 +195,7 @@ func main() {
 				}
 			}
 			if *updateManifest != "" {
-				manifest, err := manifest.ManifestFromPath(*updateManifest)
+				manifest, err := manifest.FromPath(*updateManifest)
 				if err != nil {
 					return ds, util.Errorf("%s", err)
 				}

--- a/bin/p2-dsctl/main.go
+++ b/bin/p2-dsctl/main.go
@@ -14,8 +14,8 @@ import (
 	"github.com/square/p2/pkg/kp/dsstore"
 	"github.com/square/p2/pkg/kp/flags"
 	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/manifest"
 	pc_fields "github.com/square/p2/pkg/pc/fields"
-	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
 	"k8s.io/kubernetes/pkg/labels"
@@ -79,7 +79,7 @@ func main() {
 		podID := types.PodID(*createPodID)
 		selector := selectorFrom(az)
 
-		manifest, err := pods.ManifestFromPath(*createManifest)
+		manifest, err := manifest.ManifestFromPath(*createManifest)
 		if err != nil {
 			log.Fatalf("%s", err)
 		}
@@ -195,7 +195,7 @@ func main() {
 				}
 			}
 			if *updateManifest != "" {
-				manifest, err := pods.ManifestFromPath(*updateManifest)
+				manifest, err := manifest.ManifestFromPath(*updateManifest)
 				if err != nil {
 					return ds, util.Errorf("%s", err)
 				}

--- a/bin/p2-install-hook/main.go
+++ b/bin/p2-install-hook/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/square/p2/pkg/auth"
 	"github.com/square/p2/pkg/hooks"
 	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/version"
 )
@@ -24,7 +25,7 @@ func main() {
 	kingpin.Version(version.VERSION)
 	kingpin.Parse()
 
-	manifest, err := pods.ManifestFromURI(*manifestURI)
+	manifest, err := manifest.ManifestFromURI(*manifestURI)
 	if err != nil {
 		log.Fatalf("%s", err)
 	}

--- a/bin/p2-install-hook/main.go
+++ b/bin/p2-install-hook/main.go
@@ -25,7 +25,7 @@ func main() {
 	kingpin.Version(version.VERSION)
 	kingpin.Parse()
 
-	manifest, err := manifest.ManifestFromURI(*manifestURI)
+	manifest, err := manifest.FromURI(*manifestURI)
 	if err != nil {
 		log.Fatalf("%s", err)
 	}

--- a/bin/p2-launch/main.go
+++ b/bin/p2-launch/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/square/p2/pkg/auth"
 	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/preparer"
 	"github.com/square/p2/pkg/types"
@@ -31,7 +32,7 @@ func main() {
 	kingpin.Version(version.VERSION)
 	kingpin.Parse()
 
-	manifest, err := pods.ManifestFromURI(*manifestURI)
+	manifest, err := manifest.ManifestFromURI(*manifestURI)
 	if err != nil {
 		log.Fatalf("%s", err)
 	}
@@ -56,7 +57,7 @@ func main() {
 	}
 }
 
-func authorize(manifest pods.Manifest) error {
+func authorize(manifest manifest.Manifest) error {
 	var policy auth.Policy
 	var err error
 	switch *authType {

--- a/bin/p2-launch/main.go
+++ b/bin/p2-launch/main.go
@@ -32,7 +32,7 @@ func main() {
 	kingpin.Version(version.VERSION)
 	kingpin.Parse()
 
-	manifest, err := manifest.ManifestFromURI(*manifestURI)
+	manifest, err := manifest.FromURI(*manifestURI)
 	if err != nil {
 		log.Fatalf("%s", err)
 	}

--- a/bin/p2-rctl/main.go
+++ b/bin/p2-rctl/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/square/p2/pkg/kp/rollstore"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	rc_fields "github.com/square/p2/pkg/rc/fields"
 	"github.com/square/p2/pkg/roll"
 	roll_fields "github.com/square/p2/pkg/roll/fields"
@@ -187,7 +187,7 @@ type rctlParams struct {
 }
 
 func (r rctlParams) Create(manifestPath, nodeSelector string, podLabels map[string]string, rcLabels map[string]string) {
-	manifest, err := pods.ManifestFromPath(manifestPath)
+	manifest, err := manifest.ManifestFromPath(manifestPath)
 	if err != nil {
 		r.logger.WithErrorAndFields(err, logrus.Fields{
 			"manifest": manifestPath,

--- a/bin/p2-rctl/main.go
+++ b/bin/p2-rctl/main.go
@@ -187,7 +187,7 @@ type rctlParams struct {
 }
 
 func (r rctlParams) Create(manifestPath, nodeSelector string, podLabels map[string]string, rcLabels map[string]string) {
-	manifest, err := manifest.ManifestFromPath(manifestPath)
+	manifest, err := manifest.FromPath(manifestPath)
 	if err != nil {
 		r.logger.WithErrorAndFields(err, logrus.Fields{
 			"manifest": manifestPath,

--- a/bin/p2-replicate/main.go
+++ b/bin/p2-replicate/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/square/p2/pkg/kp/flags"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/replication"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/version"
@@ -54,7 +54,7 @@ func main() {
 	labeler := labels.NewConsulApplicator(client, 3)
 	healthChecker := checker.NewConsulHealthChecker(client)
 
-	manifest, err := pods.ManifestFromURI(*manifestURI)
+	manifest, err := manifest.ManifestFromURI(*manifestURI)
 	if err != nil {
 		log.Fatalf("%s", err)
 	}

--- a/bin/p2-replicate/main.go
+++ b/bin/p2-replicate/main.go
@@ -54,7 +54,7 @@ func main() {
 	labeler := labels.NewConsulApplicator(client, 3)
 	healthChecker := checker.NewConsulHealthChecker(client)
 
-	manifest, err := manifest.ManifestFromURI(*manifestURI)
+	manifest, err := manifest.FromURI(*manifestURI)
 	if err != nil {
 		log.Fatalf("%s", err)
 	}

--- a/bin/p2-run-hooks/main.go
+++ b/bin/p2-run-hooks/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/square/p2/pkg/hooks"
 	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/version"
@@ -32,21 +33,21 @@ func main() {
 
 	pod := pods.NewPod(types.PodID(path.Base(*podDir)), *podDir)
 
-	var manifest pods.Manifest
+	var podManifest manifest.Manifest
 	if *manifestPath != "" {
-		manifest, err = pods.ManifestFromPath(*manifestPath)
+		podManifest, err = manifest.ManifestFromPath(*manifestPath)
 		if err != nil {
 			log.Fatalln(err)
 		}
 	} else {
-		manifest, err = pod.CurrentManifest()
+		podManifest, err = pod.CurrentManifest()
 		if err != nil {
 			log.Fatalln(err)
 		}
 	}
 
 	log.Printf("About to run %s hooks for pod %s\n", hookType, pod.Path())
-	err = dir.RunHookType(hookType, pod, manifest)
+	err = dir.RunHookType(hookType, pod, podManifest)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/bin/p2-run-hooks/main.go
+++ b/bin/p2-run-hooks/main.go
@@ -35,7 +35,7 @@ func main() {
 
 	var podManifest manifest.Manifest
 	if *manifestPath != "" {
-		podManifest, err = manifest.ManifestFromPath(*manifestPath)
+		podManifest, err = manifest.FromPath(*manifestPath)
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/bin/p2-schedule/main.go
+++ b/bin/p2-schedule/main.go
@@ -38,7 +38,7 @@ func main() {
 	}
 
 	for _, manifestPath := range *manifests {
-		manifest, err := manifest.ManifestFromPath(manifestPath)
+		manifest, err := manifest.FromPath(manifestPath)
 		if err != nil {
 			log.Fatalf("Could not read manifest at %s: %s\n", manifestPath, err)
 		}

--- a/bin/p2-schedule/main.go
+++ b/bin/p2-schedule/main.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/kp/flags"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/version"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -38,7 +38,7 @@ func main() {
 	}
 
 	for _, manifestPath := range *manifests {
-		manifest, err := pods.ManifestFromPath(manifestPath)
+		manifest, err := manifest.ManifestFromPath(manifestPath)
 		if err != nil {
 			log.Fatalf("Could not read manifest at %s: %s\n", manifestPath, err)
 		}

--- a/bin/p2-sum/main.go
+++ b/bin/p2-sum/main.go
@@ -45,7 +45,7 @@ type HashErr struct {
 
 // SumBytes parses the given contents of a manifest file and returns its canonical hash.
 func SumBytes(data []byte) HashErr {
-	m, err := manifest.ManifestFromBytes(data)
+	m, err := manifest.FromBytes(data)
 	if err != nil {
 		return HashErr{"", err}
 	}

--- a/bin/p2-sum/main.go
+++ b/bin/p2-sum/main.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 )
 
 var help = flag.Bool("help", false, "show program usage")
@@ -45,7 +45,7 @@ type HashErr struct {
 
 // SumBytes parses the given contents of a manifest file and returns its canonical hash.
 func SumBytes(data []byte) HashErr {
-	m, err := pods.ManifestFromBytes(data)
+	m, err := manifest.ManifestFromBytes(data)
 	if err != nil {
 		return HashErr{"", err}
 	}

--- a/integration/single-node-slug-deploy/check.go
+++ b/integration/single-node-slug-deploy/check.go
@@ -317,7 +317,7 @@ func getConsulManifest(dir string) (string, error) {
 		"file://%s",
 		util.From(runtime.Caller(0)).ExpandPath("../hoisted-consul_052.tar.gz"),
 	)
-	builder := manifest.NewManifestBuilder()
+	builder := manifest.NewBuilder()
 	builder.SetID("consul")
 	stanzas := map[string]manifest.LaunchableStanza{
 		"consul": {
@@ -393,7 +393,7 @@ func scheduleRCTLServer(dir string) error {
 
 func createHelloReplicationController(dir string) (fields.ID, error) {
 	hello := fmt.Sprintf("file://%s", util.From(runtime.Caller(0)).ExpandPath("../hoisted-hello_def456.tar.gz"))
-	builder := manifest.NewManifestBuilder()
+	builder := manifest.NewBuilder()
 	builder.SetID("hello")
 	builder.SetStatusPort(43770)
 	stanzas := map[string]manifest.LaunchableStanza{

--- a/integration/single-node-slug-deploy/check.go
+++ b/integration/single-node-slug-deploy/check.go
@@ -156,7 +156,7 @@ func generatePreparerPod(workdir string) (string, error) {
 		return "", err
 	}
 
-	manifest, err := manifest.ManifestFromPath(prepBin2Pod.ManifestPath)
+	manifest, err := manifest.FromPath(prepBin2Pod.ManifestPath)
 	if err != nil {
 		return "", err
 	}
@@ -267,7 +267,7 @@ mkdir -p $HOOKED_POD_HOME
 	}
 	manifestPath := createUserBin2Pod.ManifestPath
 
-	userHookManifest, err := manifest.ManifestFromPath(manifestPath)
+	userHookManifest, err := manifest.FromPath(manifestPath)
 	if err != nil {
 		return err
 	}

--- a/integration/single-node-slug-deploy/check.go
+++ b/integration/single-node-slug-deploy/check.go
@@ -20,7 +20,7 @@ import (
 	"github.com/square/p2/pkg/health"
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/labels"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/preparer"
 	"github.com/square/p2/pkg/rc"
 	"github.com/square/p2/pkg/rc/fields"
@@ -156,7 +156,7 @@ func generatePreparerPod(workdir string) (string, error) {
 		return "", err
 	}
 
-	manifest, err := pods.ManifestFromPath(prepBin2Pod.ManifestPath)
+	manifest, err := manifest.ManifestFromPath(prepBin2Pod.ManifestPath)
 	if err != nil {
 		return "", err
 	}
@@ -267,7 +267,7 @@ mkdir -p $HOOKED_POD_HOME
 	}
 	manifestPath := createUserBin2Pod.ManifestPath
 
-	userHookManifest, err := pods.ManifestFromPath(manifestPath)
+	userHookManifest, err := manifest.ManifestFromPath(manifestPath)
 	if err != nil {
 		return err
 	}
@@ -317,9 +317,9 @@ func getConsulManifest(dir string) (string, error) {
 		"file://%s",
 		util.From(runtime.Caller(0)).ExpandPath("../hoisted-consul_052.tar.gz"),
 	)
-	builder := pods.NewManifestBuilder()
+	builder := manifest.NewManifestBuilder()
 	builder.SetID("consul")
-	stanzas := map[string]types.LaunchableStanza{
+	stanzas := map[string]manifest.LaunchableStanza{
 		"consul": {
 			LaunchableId:   "consul",
 			LaunchableType: "hoist",
@@ -393,10 +393,10 @@ func scheduleRCTLServer(dir string) error {
 
 func createHelloReplicationController(dir string) (fields.ID, error) {
 	hello := fmt.Sprintf("file://%s", util.From(runtime.Caller(0)).ExpandPath("../hoisted-hello_def456.tar.gz"))
-	builder := pods.NewManifestBuilder()
+	builder := manifest.NewManifestBuilder()
 	builder.SetID("hello")
 	builder.SetStatusPort(43770)
-	stanzas := map[string]types.LaunchableStanza{
+	stanzas := map[string]manifest.LaunchableStanza{
 		"hello": {
 			LaunchableId:   "hello",
 			LaunchableType: "hoist",

--- a/pkg/artifact/registry.go
+++ b/pkg/artifact/registry.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 
 	"github.com/square/p2/pkg/auth"
-	"github.com/square/p2/pkg/types"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/util"
 )
 
@@ -13,7 +13,7 @@ type Registry interface {
 	// Given a LaunchableStanza from a pod manifest, returns a URL from which the
 	// artifact can be fetched an a struct containing the locations of files that
 	// can be used to verify artifact integrity
-	LocationDataForLaunchable(stanza types.LaunchableStanza) (*url.URL, auth.VerificationData, error)
+	LocationDataForLaunchable(stanza manifest.LaunchableStanza) (*url.URL, auth.VerificationData, error)
 }
 
 type registry struct{}
@@ -35,7 +35,7 @@ func NewRegistry() Registry {
 // manifest: ".manifest"
 // manifest signature: ".manifest.sig"
 // build signature: ".sig"
-func (a registry) LocationDataForLaunchable(stanza types.LaunchableStanza) (*url.URL, auth.VerificationData, error) {
+func (a registry) LocationDataForLaunchable(stanza manifest.LaunchableStanza) (*url.URL, auth.VerificationData, error) {
 	if stanza.Location == "" && stanza.Version.ID == "" {
 		return nil, auth.VerificationData{}, util.Errorf("Launchable must provide either \"location\" or \"version\" fields")
 	}

--- a/pkg/artifact/registry_test.go
+++ b/pkg/artifact/registry_test.go
@@ -3,13 +3,13 @@ package artifact
 import (
 	"testing"
 
-	"github.com/square/p2/pkg/types"
+	"github.com/square/p2/pkg/manifest"
 )
 
 const testLocation = "https://fileserver.com/artifact.tar.gz"
 
-func locationLaunchable() types.LaunchableStanza {
-	return types.LaunchableStanza{
+func locationLaunchable() manifest.LaunchableStanza {
+	return manifest.LaunchableStanza{
 		Location: "https://fileserver.com/artifact.tar.gz",
 	}
 }
@@ -58,7 +58,7 @@ func TestLocationDataForLaunchableWithLocation(t *testing.T) {
 }
 
 func TestNeitherVersionNorLocationInvalid(t *testing.T) {
-	launchable := types.LaunchableStanza{}
+	launchable := manifest.LaunchableStanza{}
 	registry := NewRegistry()
 	_, _, err := registry.LocationDataForLaunchable(launchable)
 	if err == nil {
@@ -67,8 +67,8 @@ func TestNeitherVersionNorLocationInvalid(t *testing.T) {
 }
 
 func TestBothVersionAndLocationInvalid(t *testing.T) {
-	launchable := types.LaunchableStanza{
-		Version: types.LaunchableVersion{
+	launchable := manifest.LaunchableStanza{
+		Version: manifest.LaunchableVersion{
 			ID: "some_version",
 		},
 		Location: testLocation,
@@ -81,8 +81,8 @@ func TestBothVersionAndLocationInvalid(t *testing.T) {
 }
 
 func TestVersionSchemeNotImplemented(t *testing.T) {
-	launchable := types.LaunchableStanza{
-		Version: types.LaunchableVersion{
+	launchable := manifest.LaunchableStanza{
+		Version: manifest.LaunchableVersion{
 			ID: "some_version",
 		},
 	}

--- a/pkg/auth/auth_policy.go
+++ b/pkg/auth/auth_policy.go
@@ -52,7 +52,7 @@ type Policy interface {
 	Close()
 }
 
-// auth.Manifest mirrors pods.Manifest, listing only the data
+// auth.Manifest mirrors manifest.Manifest, listing only the data
 // accessors that auth logic cares about.
 type Manifest interface {
 	ID() types.PodID

--- a/pkg/ds/daemon_set.go
+++ b/pkg/ds/daemon_set.go
@@ -12,7 +12,7 @@ import (
 	"github.com/square/p2/pkg/kp/dsstore"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/scheduler"
 	"github.com/square/p2/pkg/types"
 )
@@ -58,7 +58,7 @@ type kpStore interface {
 	SetPod(
 		podPrefix kp.PodPrefix,
 		nodeName types.NodeName,
-		manifest pods.Manifest,
+		manifest manifest.Manifest,
 	) (time.Duration, error)
 
 	DeletePod(podPrefix kp.PodPrefix,

--- a/pkg/ds/daemon_set_test.go
+++ b/pkg/ds/daemon_set_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/square/p2/pkg/kp/kptest"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/types"
 
 	. "github.com/anthonybishopric/gotcha"
@@ -131,16 +131,16 @@ func TestSchedule(t *testing.T) {
 	minHealth := 0
 	clusterName := ds_fields.ClusterName("some_name")
 
-	manifestBuilder := pods.NewManifestBuilder()
+	manifestBuilder := manifest.NewManifestBuilder()
 	manifestBuilder.SetID(podID)
-	manifest := manifestBuilder.GetManifest()
+	podManifest := manifestBuilder.GetManifest()
 
 	nodeSelector := klabels.Everything().Add("nodeQuality", klabels.EqualsOperator, []string{"good"})
 
-	dsData, err := dsStore.Create(manifest, minHealth, clusterName, nodeSelector, podID)
+	dsData, err := dsStore.Create(podManifest, minHealth, clusterName, nodeSelector, podID)
 	Assert(t).IsNil(err, "expected no error creating request")
 
-	kpStore := kptest.NewFakePodStore(make(map[kptest.FakePodStoreKey]pods.Manifest), make(map[string]kp.WatchResult))
+	kpStore := kptest.NewFakePodStore(make(map[kptest.FakePodStoreKey]manifest.Manifest), make(map[string]kp.WatchResult))
 	applicator := labels.NewFakeApplicator()
 
 	ds := New(

--- a/pkg/ds/daemon_set_test.go
+++ b/pkg/ds/daemon_set_test.go
@@ -131,7 +131,7 @@ func TestSchedule(t *testing.T) {
 	minHealth := 0
 	clusterName := ds_fields.ClusterName("some_name")
 
-	manifestBuilder := manifest.NewManifestBuilder()
+	manifestBuilder := manifest.NewBuilder()
 	manifestBuilder.SetID(podID)
 	podManifest := manifestBuilder.GetManifest()
 

--- a/pkg/ds/fields/fields.go
+++ b/pkg/ds/fields/fields.go
@@ -5,7 +5,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/labels"
 
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/types"
 )
 
@@ -28,7 +28,7 @@ type DaemonSet struct {
 	Disabled bool
 
 	// The pod manifest that should be scheduled on nodes
-	Manifest pods.Manifest
+	Manifest manifest.Manifest
 
 	// Minimum health for nodes when scheduling
 	MinHealth int
@@ -95,7 +95,7 @@ func (ds *DaemonSet) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	podManifest, err := pods.ManifestFromBytes([]byte(rawDS.Manifest))
+	podManifest, err := manifest.ManifestFromBytes([]byte(rawDS.Manifest))
 	if err != nil {
 		return err
 	}

--- a/pkg/ds/fields/fields.go
+++ b/pkg/ds/fields/fields.go
@@ -95,7 +95,7 @@ func (ds *DaemonSet) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	podManifest, err := manifest.ManifestFromBytes([]byte(rawDS.Manifest))
+	podManifest, err := manifest.FromBytes([]byte(rawDS.Manifest))
 	if err != nil {
 		return err
 	}

--- a/pkg/hooks/hook_env.go
+++ b/pkg/hooks/hook_env.go
@@ -24,7 +24,7 @@ func (h *HookEnv) Manifest() (manifest.Manifest, error) {
 	if path == "" {
 		return nil, util.Errorf("No manifest exported")
 	}
-	return manifest.ManifestFromPath(path)
+	return manifest.FromPath(path)
 }
 
 func (h *HookEnv) Pod() (*pods.Pod, error) {

--- a/pkg/hooks/hook_env.go
+++ b/pkg/hooks/hook_env.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/square/p2/pkg/config"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
@@ -18,12 +19,12 @@ func CurrentEnv() *HookEnv {
 // useful access to objects exported by the hooks package.
 type HookEnv struct{}
 
-func (h *HookEnv) Manifest() (pods.Manifest, error) {
+func (h *HookEnv) Manifest() (manifest.Manifest, error) {
 	path := os.Getenv(HOOKED_POD_MANIFEST_ENV_VAR)
 	if path == "" {
 		return nil, util.Errorf("No manifest exported")
 	}
-	return pods.ManifestFromPath(path)
+	return manifest.ManifestFromPath(path)
 }
 
 func (h *HookEnv) Pod() (*pods.Pod, error) {

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/square/p2/pkg/logging"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 )
 
 var DEFAULT_PATH = "/usr/local/p2hooks.d"
@@ -182,7 +182,7 @@ func (h *Hook) Run() {
 	}
 }
 
-func (h *HookDir) runHooks(dirpath string, hType HookType, pod Pod, podManifest pods.Manifest, logger logging.Logger) error {
+func (h *HookDir) runHooks(dirpath string, hType HookType, pod Pod, podManifest manifest.Manifest, logger logging.Logger) error {
 	configFileName, err := podManifest.ConfigFileName()
 	if err != nil {
 		return err
@@ -219,7 +219,7 @@ func (h *HookDir) runHooks(dirpath string, hType HookType, pod Pod, podManifest 
 	return runDirectory(dirpath, hookEnvironment, logger)
 }
 
-func (h *HookDir) RunHookType(hookType HookType, pod Pod, manifest pods.Manifest) error {
+func (h *HookDir) RunHookType(hookType HookType, pod Pod, manifest manifest.Manifest) error {
 	logger := h.logger.SubLogger(logrus.Fields{
 		"pod":      manifest.ID(),
 		"pod_path": pod.Path(),

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -76,7 +76,7 @@ func TestDirectoriesDoNotBreakEverything(t *testing.T) {
 }
 
 func testManifest() manifest.Manifest {
-	builder := manifest.NewManifestBuilder()
+	builder := manifest.NewBuilder()
 	builder.SetID(podId)
 	return builder.GetManifest()
 }

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/anthonybishopric/gotcha"
 	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/pods"
 )
 
@@ -74,8 +75,8 @@ func TestDirectoriesDoNotBreakEverything(t *testing.T) {
 	Assert(t).IsNil(err, "Got an error when running a directory inside the hooks directory")
 }
 
-func testManifest() pods.Manifest {
-	builder := pods.NewManifestBuilder()
+func testManifest() manifest.Manifest {
+	builder := manifest.NewManifestBuilder()
 	builder.SetID(podId)
 	return builder.GetManifest()
 }

--- a/pkg/hooks/install.go
+++ b/pkg/hooks/install.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/runit"
 	"github.com/square/p2/pkg/util"
@@ -15,7 +16,7 @@ import (
 // Populates the given directory with executor scripts for each launch script of
 // the given pod, which must be installed. Any orphaned executor scripts (from a
 // past install, but no longer present in this pod) will be cleaned out.
-func InstallHookScripts(dir string, hookPod *pods.Pod, manifest pods.Manifest, logger logging.Logger) error {
+func InstallHookScripts(dir string, hookPod *pods.Pod, manifest manifest.Manifest, logger logging.Logger) error {
 	err := os.MkdirAll(dir, 0755)
 	if err != nil {
 		return err

--- a/pkg/kp/dsstore/consul_store.go
+++ b/pkg/kp/dsstore/consul_store.go
@@ -14,7 +14,7 @@ import (
 	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
 )
@@ -53,7 +53,7 @@ func NewConsul(client *api.Client, retries int, logger *logging.Logger) Store {
 }
 
 func (s *consulStore) Create(
-	manifest pods.Manifest,
+	manifest manifest.Manifest,
 	minHealth int,
 	name fields.ClusterName,
 	nodeSelector klabels.Selector,
@@ -80,7 +80,7 @@ func (s *consulStore) Create(
 
 // these parts of Create may require a retry
 func (s *consulStore) innerCreate(
-	manifest pods.Manifest,
+	manifest manifest.Manifest,
 	minHealth int,
 	name fields.ClusterName,
 	nodeSelector klabels.Selector,
@@ -303,7 +303,7 @@ func (s *consulStore) Watch(quitCh <-chan struct{}) <-chan WatchedDaemonSets {
 	return outCh
 }
 
-func checkManifestPodID(dsPodID types.PodID, manifest pods.Manifest) error {
+func checkManifestPodID(dsPodID types.PodID, manifest manifest.Manifest) error {
 	if dsPodID == "" {
 		return util.Errorf("Daemon set must have a pod id")
 	}

--- a/pkg/kp/dsstore/consul_store_test.go
+++ b/pkg/kp/dsstore/consul_store_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/square/p2/pkg/kp/kptest"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/manifest"
 	pc_fields "github.com/square/p2/pkg/pc/fields"
-	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/types"
 
 	klabels "k8s.io/kubernetes/pkg/labels"
@@ -31,25 +31,25 @@ func TestCreate(t *testing.T) {
 	selector := klabels.Everything().
 		Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{azLabel.String()})
 
-	manifestBuilder := pods.NewManifestBuilder()
+	manifestBuilder := manifest.NewManifestBuilder()
 	manifestBuilder.SetID("")
 
-	manifest := manifestBuilder.GetManifest()
+	podManifest := manifestBuilder.GetManifest()
 
-	if _, err := store.Create(manifest, minHealth, clusterName, selector, podID); err == nil {
+	if _, err := store.Create(podManifest, minHealth, clusterName, selector, podID); err == nil {
 		t.Error("Expected create to fail on bad pod id")
 	}
 
 	podID = types.PodID("pod_id")
-	if _, err := store.Create(manifest, minHealth, clusterName, selector, podID); err == nil {
+	if _, err := store.Create(podManifest, minHealth, clusterName, selector, podID); err == nil {
 		t.Error("Expected create to fail on bad manifest pod id")
 	}
 
-	manifestBuilder = pods.NewManifestBuilder()
+	manifestBuilder = manifest.NewManifestBuilder()
 	manifestBuilder.SetID("different_pod_id")
 
-	manifest = manifestBuilder.GetManifest()
-	if _, err := store.Create(manifest, minHealth, clusterName, selector, podID); err == nil {
+	podManifest = manifestBuilder.GetManifest()
+	if _, err := store.Create(podManifest, minHealth, clusterName, selector, podID); err == nil {
 		t.Error("Expected create to fail on pod id and manifest pod id mismatch")
 	}
 }
@@ -63,7 +63,7 @@ func createDaemonSet(store *consulStore, t *testing.T) ds_fields.DaemonSet {
 	selector := klabels.Everything().
 		Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{azLabel.String()})
 
-	manifestBuilder := pods.NewManifestBuilder()
+	manifestBuilder := manifest.NewManifestBuilder()
 	manifestBuilder.SetID(podID)
 
 	manifest := manifestBuilder.GetManifest()
@@ -139,7 +139,7 @@ func TestGet(t *testing.T) {
 	selector := klabels.Everything().
 		Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{azLabel.String()})
 
-	manifestBuilder := pods.NewManifestBuilder()
+	manifestBuilder := manifest.NewManifestBuilder()
 	manifestBuilder.SetID(podID)
 
 	manifest := manifestBuilder.GetManifest()
@@ -204,7 +204,7 @@ func TestList(t *testing.T) {
 	selector := klabels.Everything().
 		Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{azLabel.String()})
 
-	manifestBuilder := pods.NewManifestBuilder()
+	manifestBuilder := manifest.NewManifestBuilder()
 	manifestBuilder.SetID(firstPodID)
 
 	firstManifest := manifestBuilder.GetManifest()
@@ -217,7 +217,7 @@ func TestList(t *testing.T) {
 	// Create second DaemonSet
 	secondPodID := types.PodID("different_pod_id")
 
-	manifestBuilder = pods.NewManifestBuilder()
+	manifestBuilder = manifest.NewManifestBuilder()
 	manifestBuilder.SetID(secondPodID)
 
 	secondManifest := manifestBuilder.GetManifest()
@@ -257,11 +257,11 @@ func TestMutate(t *testing.T) {
 	selector := klabels.Everything().
 		Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{azLabel.String()})
 
-	manifestBuilder := pods.NewManifestBuilder()
+	manifestBuilder := manifest.NewManifestBuilder()
 	manifestBuilder.SetID(podID)
-	manifest := manifestBuilder.GetManifest()
+	podManifest := manifestBuilder.GetManifest()
 
-	ds, err := store.Create(manifest, minHealth, clusterName, selector, podID)
+	ds, err := store.Create(podManifest, minHealth, clusterName, selector, podID)
 	if err != nil {
 		t.Fatalf("Unable to create daemon set: %s", err)
 	}
@@ -301,7 +301,7 @@ func TestMutate(t *testing.T) {
 	someOtherName := ds_fields.ClusterName("some_other_name")
 	someOtherPodID := types.PodID("some_other_pod_id")
 
-	manifestBuilder = pods.NewManifestBuilder()
+	manifestBuilder = manifest.NewManifestBuilder()
 	manifestBuilder.SetID(someOtherPodID)
 	someOtherManifest := manifestBuilder.GetManifest()
 
@@ -390,11 +390,11 @@ func TestWatch(t *testing.T) {
 	selector := klabels.Everything().
 		Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{azLabel.String()})
 
-	manifestBuilder := pods.NewManifestBuilder()
+	manifestBuilder := manifest.NewManifestBuilder()
 	manifestBuilder.SetID(podID)
-	manifest := manifestBuilder.GetManifest()
+	podManifest := manifestBuilder.GetManifest()
 
-	ds, err := store.Create(manifest, minHealth, clusterName, selector, podID)
+	ds, err := store.Create(podManifest, minHealth, clusterName, selector, podID)
 	if err != nil {
 		t.Fatalf("Unable to create daemon set: %s", err)
 	}
@@ -403,7 +403,7 @@ func TestWatch(t *testing.T) {
 	//
 	someOtherPodID := types.PodID("some_other_pod_id")
 
-	manifestBuilder = pods.NewManifestBuilder()
+	manifestBuilder = manifest.NewManifestBuilder()
 	manifestBuilder.SetID(someOtherPodID)
 	someOtherManifest := manifestBuilder.GetManifest()
 

--- a/pkg/kp/dsstore/consul_store_test.go
+++ b/pkg/kp/dsstore/consul_store_test.go
@@ -31,7 +31,7 @@ func TestCreate(t *testing.T) {
 	selector := klabels.Everything().
 		Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{azLabel.String()})
 
-	manifestBuilder := manifest.NewManifestBuilder()
+	manifestBuilder := manifest.NewBuilder()
 	manifestBuilder.SetID("")
 
 	podManifest := manifestBuilder.GetManifest()
@@ -45,7 +45,7 @@ func TestCreate(t *testing.T) {
 		t.Error("Expected create to fail on bad manifest pod id")
 	}
 
-	manifestBuilder = manifest.NewManifestBuilder()
+	manifestBuilder = manifest.NewBuilder()
 	manifestBuilder.SetID("different_pod_id")
 
 	podManifest = manifestBuilder.GetManifest()
@@ -63,7 +63,7 @@ func createDaemonSet(store *consulStore, t *testing.T) ds_fields.DaemonSet {
 	selector := klabels.Everything().
 		Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{azLabel.String()})
 
-	manifestBuilder := manifest.NewManifestBuilder()
+	manifestBuilder := manifest.NewBuilder()
 	manifestBuilder.SetID(podID)
 
 	manifest := manifestBuilder.GetManifest()
@@ -139,7 +139,7 @@ func TestGet(t *testing.T) {
 	selector := klabels.Everything().
 		Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{azLabel.String()})
 
-	manifestBuilder := manifest.NewManifestBuilder()
+	manifestBuilder := manifest.NewBuilder()
 	manifestBuilder.SetID(podID)
 
 	manifest := manifestBuilder.GetManifest()
@@ -204,7 +204,7 @@ func TestList(t *testing.T) {
 	selector := klabels.Everything().
 		Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{azLabel.String()})
 
-	manifestBuilder := manifest.NewManifestBuilder()
+	manifestBuilder := manifest.NewBuilder()
 	manifestBuilder.SetID(firstPodID)
 
 	firstManifest := manifestBuilder.GetManifest()
@@ -217,7 +217,7 @@ func TestList(t *testing.T) {
 	// Create second DaemonSet
 	secondPodID := types.PodID("different_pod_id")
 
-	manifestBuilder = manifest.NewManifestBuilder()
+	manifestBuilder = manifest.NewBuilder()
 	manifestBuilder.SetID(secondPodID)
 
 	secondManifest := manifestBuilder.GetManifest()
@@ -257,7 +257,7 @@ func TestMutate(t *testing.T) {
 	selector := klabels.Everything().
 		Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{azLabel.String()})
 
-	manifestBuilder := manifest.NewManifestBuilder()
+	manifestBuilder := manifest.NewBuilder()
 	manifestBuilder.SetID(podID)
 	podManifest := manifestBuilder.GetManifest()
 
@@ -301,7 +301,7 @@ func TestMutate(t *testing.T) {
 	someOtherName := ds_fields.ClusterName("some_other_name")
 	someOtherPodID := types.PodID("some_other_pod_id")
 
-	manifestBuilder = manifest.NewManifestBuilder()
+	manifestBuilder = manifest.NewBuilder()
 	manifestBuilder.SetID(someOtherPodID)
 	someOtherManifest := manifestBuilder.GetManifest()
 
@@ -390,7 +390,7 @@ func TestWatch(t *testing.T) {
 	selector := klabels.Everything().
 		Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{azLabel.String()})
 
-	manifestBuilder := manifest.NewManifestBuilder()
+	manifestBuilder := manifest.NewBuilder()
 	manifestBuilder.SetID(podID)
 	podManifest := manifestBuilder.GetManifest()
 
@@ -403,7 +403,7 @@ func TestWatch(t *testing.T) {
 	//
 	someOtherPodID := types.PodID("some_other_pod_id")
 
-	manifestBuilder = manifest.NewManifestBuilder()
+	manifestBuilder = manifest.NewBuilder()
 	manifestBuilder.SetID(someOtherPodID)
 	someOtherManifest := manifestBuilder.GetManifest()
 

--- a/pkg/kp/dsstore/dsstoretest/fake_dsstore.go
+++ b/pkg/kp/dsstore/dsstoretest/fake_dsstore.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pborman/uuid"
 	"github.com/square/p2/pkg/ds/fields"
 	"github.com/square/p2/pkg/kp/dsstore"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/types"
 	klabels "k8s.io/kubernetes/pkg/labels"
 )
@@ -44,7 +44,7 @@ func NewFake() *FakeDSStore {
 }
 
 func (s *FakeDSStore) Create(
-	manifest pods.Manifest,
+	manifest manifest.Manifest,
 	minHealth int,
 	name fields.ClusterName,
 	nodeSelector klabels.Selector,

--- a/pkg/kp/dsstore/store.go
+++ b/pkg/kp/dsstore/store.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/consul/api"
 	"github.com/square/p2/pkg/ds/fields"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/types"
 )
 
@@ -29,7 +29,7 @@ type Store interface {
 	// The node selector is used to determine what nodes the daemon set may schedule on.
 	// The pod label set is applied to every pod the daemon set schedules.
 	Create(
-		manifest pods.Manifest,
+		manifest manifest.Manifest,
 		minHealth int,
 		name fields.ClusterName,
 		nodeSelector labels.Selector,

--- a/pkg/kp/kptest/fake_store.go
+++ b/pkg/kp/kptest/fake_store.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/types"
 )
@@ -15,7 +16,7 @@ import (
 // In memory kp store useful in tests. Currently does not implement the entire
 // kp.Store interface
 type FakePodStore struct {
-	podResults    map[FakePodStoreKey]pods.Manifest
+	podResults    map[FakePodStoreKey]manifest.Manifest
 	healthResults map[string]kp.WatchResult
 
 	// represents locks that are held. Will be shared between any
@@ -28,9 +29,9 @@ type FakePodStore struct {
 
 var _ kp.Store = &FakePodStore{}
 
-func NewFakePodStore(podResults map[FakePodStoreKey]pods.Manifest, healthResults map[string]kp.WatchResult) *FakePodStore {
+func NewFakePodStore(podResults map[FakePodStoreKey]manifest.Manifest, healthResults map[string]kp.WatchResult) *FakePodStore {
 	if podResults == nil {
-		podResults = make(map[FakePodStoreKey]pods.Manifest)
+		podResults = make(map[FakePodStoreKey]manifest.Manifest)
 	}
 	if healthResults == nil {
 		healthResults = make(map[string]kp.WatchResult)
@@ -56,12 +57,12 @@ func FakePodStoreKeyFor(podPrefix kp.PodPrefix, hostname types.NodeName, podId t
 	}
 }
 
-func (f *FakePodStore) SetPod(podPrefix kp.PodPrefix, hostname types.NodeName, manifest pods.Manifest) (time.Duration, error) {
+func (f *FakePodStore) SetPod(podPrefix kp.PodPrefix, hostname types.NodeName, manifest manifest.Manifest) (time.Duration, error) {
 	f.podResults[FakePodStoreKeyFor(podPrefix, hostname, manifest.ID())] = manifest
 	return 0, nil
 }
 
-func (f *FakePodStore) Pod(podPrefix kp.PodPrefix, hostname types.NodeName, podId types.PodID) (pods.Manifest, time.Duration, error) {
+func (f *FakePodStore) Pod(podPrefix kp.PodPrefix, hostname types.NodeName, podId types.PodID) (manifest.Manifest, time.Duration, error) {
 	if pod, ok := f.podResults[FakePodStoreKeyFor(podPrefix, hostname, podId)]; !ok {
 		return nil, 0, pods.NoCurrentManifest
 	} else {

--- a/pkg/kp/kv.go
+++ b/pkg/kp/kv.go
@@ -232,7 +232,7 @@ func (c consulStore) Pod(podPrefix PodPrefix, nodename types.NodeName, podId typ
 	if kvPair == nil {
 		return nil, writeMeta.RequestTime, pods.NoCurrentManifest
 	}
-	manifest, err := manifest.ManifestFromBytes(kvPair.Value)
+	manifest, err := manifest.FromBytes(kvPair.Value)
 	return manifest, writeMeta.RequestTime, err
 }
 
@@ -264,7 +264,7 @@ func (c consulStore) listPods(keyPrefix string) ([]ManifestResult, time.Duration
 	var ret []ManifestResult
 
 	for _, kvp := range kvPairs {
-		manifest, err := manifest.ManifestFromBytes(kvp.Value)
+		manifest, err := manifest.FromBytes(kvp.Value)
 		if err != nil {
 			return nil, queryMeta.RequestTime, err
 		}
@@ -301,7 +301,7 @@ func (c consulStore) WatchPod(
 	for pair := range kvpChan {
 		out := ManifestResult{Path: key}
 		if pair != nil {
-			manifest, err := manifest.ManifestFromBytes(pair.Value)
+			manifest, err := manifest.FromBytes(pair.Value)
 			if err != nil {
 				select {
 				case <-quitChan:
@@ -352,7 +352,7 @@ func (c consulStore) WatchPods(
 	for kvPairs := range kvPairsChan {
 		manifests := make([]ManifestResult, 0, len(kvPairs))
 		for _, pair := range kvPairs {
-			manifest, err := manifest.ManifestFromBytes(pair.Value)
+			manifest, err := manifest.FromBytes(pair.Value)
 			if err != nil {
 				select {
 				case <-quitChan:

--- a/pkg/kp/kv.go
+++ b/pkg/kp/kv.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
@@ -21,13 +22,13 @@ import (
 const TTL = 60 * time.Second
 
 type ManifestResult struct {
-	Manifest pods.Manifest
+	Manifest manifest.Manifest
 	Path     string
 }
 
 type Store interface {
-	SetPod(podPrefix PodPrefix, nodename types.NodeName, manifest pods.Manifest) (time.Duration, error)
-	Pod(podPrefix PodPrefix, nodename types.NodeName, podId types.PodID) (pods.Manifest, time.Duration, error)
+	SetPod(podPrefix PodPrefix, nodename types.NodeName, manifest manifest.Manifest) (time.Duration, error)
+	Pod(podPrefix PodPrefix, nodename types.NodeName, podId types.PodID) (manifest.Manifest, time.Duration, error)
 	DeletePod(podPrefix PodPrefix, nodename types.NodeName, podId types.PodID) (time.Duration, error)
 	PutHealth(res WatchResult) (time.Time, time.Duration, error)
 	GetHealth(service string, node types.NodeName) (WatchResult, error)
@@ -173,7 +174,7 @@ func (c consulStore) GetServiceHealth(service string) (map[string]WatchResult, e
 }
 
 // SetPod writes a pod manifest into the consul key-value store.
-func (c consulStore) SetPod(podPrefix PodPrefix, nodename types.NodeName, manifest pods.Manifest) (time.Duration, error) {
+func (c consulStore) SetPod(podPrefix PodPrefix, nodename types.NodeName, manifest manifest.Manifest) (time.Duration, error) {
 	buf := bytes.Buffer{}
 	err := manifest.Write(&buf)
 	if err != nil {
@@ -218,7 +219,7 @@ func (c consulStore) DeletePod(podPrefix PodPrefix, nodename types.NodeName, pod
 // Pod reads a pod manifest from the key-value store. If the given key does not
 // exist, a nil *PodManifest will be returned, along with a pods.NoCurrentManifest
 // error.
-func (c consulStore) Pod(podPrefix PodPrefix, nodename types.NodeName, podId types.PodID) (pods.Manifest, time.Duration, error) {
+func (c consulStore) Pod(podPrefix PodPrefix, nodename types.NodeName, podId types.PodID) (manifest.Manifest, time.Duration, error) {
 	key, err := podPath(podPrefix, nodename, podId)
 	if err != nil {
 		return nil, 0, err
@@ -231,7 +232,7 @@ func (c consulStore) Pod(podPrefix PodPrefix, nodename types.NodeName, podId typ
 	if kvPair == nil {
 		return nil, writeMeta.RequestTime, pods.NoCurrentManifest
 	}
-	manifest, err := pods.ManifestFromBytes(kvPair.Value)
+	manifest, err := manifest.ManifestFromBytes(kvPair.Value)
 	return manifest, writeMeta.RequestTime, err
 }
 
@@ -263,7 +264,7 @@ func (c consulStore) listPods(keyPrefix string) ([]ManifestResult, time.Duration
 	var ret []ManifestResult
 
 	for _, kvp := range kvPairs {
-		manifest, err := pods.ManifestFromBytes(kvp.Value)
+		manifest, err := manifest.ManifestFromBytes(kvp.Value)
 		if err != nil {
 			return nil, queryMeta.RequestTime, err
 		}
@@ -300,7 +301,7 @@ func (c consulStore) WatchPod(
 	for pair := range kvpChan {
 		out := ManifestResult{Path: key}
 		if pair != nil {
-			manifest, err := pods.ManifestFromBytes(pair.Value)
+			manifest, err := manifest.ManifestFromBytes(pair.Value)
 			if err != nil {
 				select {
 				case <-quitChan:
@@ -351,7 +352,7 @@ func (c consulStore) WatchPods(
 	for kvPairs := range kvPairsChan {
 		manifests := make([]ManifestResult, 0, len(kvPairs))
 		for _, pair := range kvPairs {
-			manifest, err := pods.ManifestFromBytes(pair.Value)
+			manifest, err := manifest.ManifestFromBytes(pair.Value)
 			if err != nil {
 				select {
 				case <-quitChan:

--- a/pkg/kp/rcstore/consul_store.go
+++ b/pkg/kp/rcstore/consul_store.go
@@ -13,7 +13,7 @@ import (
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/labels"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/rc/fields"
 	"github.com/square/p2/pkg/util"
 )
@@ -83,7 +83,7 @@ func NewConsul(client *api.Client, retries int) *consulStore {
 	}
 }
 
-func (s *consulStore) Create(manifest pods.Manifest, nodeSelector klabels.Selector, podLabels klabels.Set) (fields.RC, error) {
+func (s *consulStore) Create(manifest manifest.Manifest, nodeSelector klabels.Selector, podLabels klabels.Set) (fields.RC, error) {
 	rc, err := s.innerCreate(manifest, nodeSelector, podLabels)
 
 	// TODO: measure whether retries are is important in practice
@@ -110,7 +110,7 @@ func (s *consulStore) Create(manifest pods.Manifest, nodeSelector klabels.Select
 }
 
 // these parts of Create may require a retry
-func (s *consulStore) innerCreate(manifest pods.Manifest, nodeSelector klabels.Selector, podLabels klabels.Set) (fields.RC, error) {
+func (s *consulStore) innerCreate(manifest manifest.Manifest, nodeSelector klabels.Selector, podLabels klabels.Set) (fields.RC, error) {
 	id := fields.ID(uuid.New())
 	rcp, err := s.rcPath(id)
 	if err != nil {

--- a/pkg/kp/rcstore/consul_store_test.go
+++ b/pkg/kp/rcstore/consul_store_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/square/p2/pkg/kp/kptest"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/rc/fields"
 
 	"github.com/hashicorp/consul/api"
@@ -509,7 +509,7 @@ func verifyLockInfoTestCase(t *testing.T, lockInfoTestCase LockInfoTestCase, inC
 
 func rcsWithIDs(t *testing.T, id string, num int) api.KVPairs {
 	var pairs api.KVPairs
-	builder := pods.NewManifestBuilder()
+	builder := manifest.NewManifestBuilder()
 	builder.SetID("slug")
 	manifest := builder.GetManifest()
 	for i := 0; i < num; i++ {

--- a/pkg/kp/rcstore/consul_store_test.go
+++ b/pkg/kp/rcstore/consul_store_test.go
@@ -509,7 +509,7 @@ func verifyLockInfoTestCase(t *testing.T, lockInfoTestCase LockInfoTestCase, inC
 
 func rcsWithIDs(t *testing.T, id string, num int) api.KVPairs {
 	var pairs api.KVPairs
-	builder := manifest.NewManifestBuilder()
+	builder := manifest.NewBuilder()
 	builder.SetID("slug")
 	manifest := builder.GetManifest()
 	for i := 0; i < num; i++ {

--- a/pkg/kp/rcstore/fake_store.go
+++ b/pkg/kp/rcstore/fake_store.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/kp/consulutil"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/rc/fields"
 	"github.com/square/p2/pkg/util"
 )
@@ -35,7 +35,7 @@ func NewFake() *fakeStore {
 	}
 }
 
-func (s *fakeStore) Create(manifest pods.Manifest, nodeSelector labels.Selector, podLabels labels.Set) (fields.RC, error) {
+func (s *fakeStore) Create(manifest manifest.Manifest, nodeSelector labels.Selector, podLabels labels.Set) (fields.RC, error) {
 	// A real replication controller will use a UUID.
 	// We'll just use a monotonically increasing counter for expedience.
 	s.creates += 1

--- a/pkg/kp/rcstore/store.go
+++ b/pkg/kp/rcstore/store.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/kp/consulutil"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/rc/fields"
 )
 
@@ -21,7 +21,7 @@ type Store interface {
 	// Create creates a replication controller with the specified manifest and selectors.
 	// The node selector is used to determine what nodes the replication controller may schedule on.
 	// The pod label set is applied to every pod the replication controller schedules.
-	Create(manifest pods.Manifest, nodeSelector labels.Selector, podLabels labels.Set) (fields.RC, error)
+	Create(manifest manifest.Manifest, nodeSelector labels.Selector, podLabels labels.Set) (fields.RC, error)
 
 	Get(id fields.ID) (fields.RC, error)
 	List() ([]fields.RC, error)

--- a/pkg/kp/rollstore/consul_store.go
+++ b/pkg/kp/rollstore/consul_store.go
@@ -16,7 +16,7 @@ import (
 	"github.com/square/p2/pkg/kp/rcstore"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	rc_fields "github.com/square/p2/pkg/rc/fields"
 	roll_fields "github.com/square/p2/pkg/roll/fields"
 	"github.com/square/p2/pkg/util"
@@ -254,7 +254,7 @@ func (s consulStore) CreateRollingUpdateFromOneExistingRCWithID(
 	minimumReplicas int,
 	leaveOld bool,
 	rollDelay time.Duration,
-	newRCManifest pods.Manifest,
+	newRCManifest manifest.Manifest,
 	newRCNodeSelector klabels.Selector,
 	newRCPodLabels klabels.Set,
 	newRCLabels klabels.Set,
@@ -356,7 +356,7 @@ func (s consulStore) CreateRollingUpdateFromOneMaybeExistingWithLabelSelector(
 	minimumReplicas int,
 	leaveOld bool,
 	rollDelay time.Duration,
-	newRCManifest pods.Manifest,
+	newRCManifest manifest.Manifest,
 	newRCNodeSelector klabels.Selector,
 	newRCPodLabels klabels.Set,
 	newRCLabels klabels.Set,

--- a/pkg/kp/rollstore/consul_store_test.go
+++ b/pkg/kp/rollstore/consul_store_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/square/p2/pkg/kp/kptest"
 	"github.com/square/p2/pkg/kp/rcstore"
 	"github.com/square/p2/pkg/labels"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	rc_fields "github.com/square/p2/pkg/rc/fields"
 	"github.com/square/p2/pkg/roll/fields"
 	"github.com/square/p2/pkg/util"
@@ -1081,8 +1081,8 @@ func testRollValue(id rc_fields.ID) fields.Update {
 	}
 }
 
-func testManifest() pods.Manifest {
-	builder := pods.NewManifestBuilder()
+func testManifest() manifest.Manifest {
+	builder := manifest.NewManifestBuilder()
 	builder.SetID("slug")
 	return builder.GetManifest()
 }

--- a/pkg/kp/rollstore/consul_store_test.go
+++ b/pkg/kp/rollstore/consul_store_test.go
@@ -1082,7 +1082,7 @@ func testRollValue(id rc_fields.ID) fields.Update {
 }
 
 func testManifest() manifest.Manifest {
-	builder := manifest.NewManifestBuilder()
+	builder := manifest.NewBuilder()
 	builder.SetID("slug")
 	return builder.GetManifest()
 }

--- a/pkg/kp/rollstore/store.go
+++ b/pkg/kp/rollstore/store.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	rc_fields "github.com/square/p2/pkg/rc/fields"
 	"github.com/square/p2/pkg/roll/fields"
 
@@ -48,7 +48,7 @@ type Store interface {
 		minimumReplicas int,
 		leaveOld bool,
 		rollDelay time.Duration,
-		newRCManifest pods.Manifest,
+		newRCManifest manifest.Manifest,
 		newRCNodeSelector klabels.Selector,
 		newRCPodLabels klabels.Set,
 		newRCLabels klabels.Set,
@@ -64,7 +64,7 @@ type Store interface {
 		minimumReplicas int,
 		leaveOld bool,
 		rollDelay time.Duration,
-		newRCManifest pods.Manifest,
+		newRCManifest manifest.Manifest,
 		newRCNodeSelector klabels.Selector,
 		newRCPodLabels klabels.Set,
 		newRCLabels klabels.Set,

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -253,43 +253,43 @@ func (mb builder) SetRunAsUser(user string) {
 	mb.manifest.RunAs = user
 }
 
-// ManifestFromPath constructs a Manifest from a local file. This function is a helper for
-// ManifestFromBytes().
-func ManifestFromPath(path string) (Manifest, error) {
+// FromPath constructs a Manifest from a local file. This function is a helper for
+// FromBytes().
+func FromPath(path string) (Manifest, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
-	return ManifestFromReader(f)
+	return FromReader(f)
 }
 
-// ManifestFromURI constructs a Manifest from data located at a URI. This function is a
-// helper for ManifestFromBytes().
-func ManifestFromURI(manifestUri *url.URL) (Manifest, error) {
+// FromURI constructs a Manifest from data located at a URI. This function is a
+// helper for FromBytes().
+func FromURI(manifestUri *url.URL) (Manifest, error) {
 	f, err := uri.DefaultFetcher.Open(manifestUri)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
-	return ManifestFromReader(f)
+	return FromReader(f)
 }
 
-// ManifestFromReader constructs a Manifest from an open Reader. All bytes will be read
+// FromReader constructs a Manifest from an open Reader. All bytes will be read
 // from the Reader. The caller is responsible for closing the Reader, if necessary. This
-// function is a helper for ManifestFromBytes().
-func ManifestFromReader(reader io.Reader) (Manifest, error) {
+// function is a helper for FromBytes().
+func FromReader(reader io.Reader) (Manifest, error) {
 	bytes, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}
-	return ManifestFromBytes(bytes)
+	return FromBytes(bytes)
 }
 
-// ManifestFromBytes constructs a Manifest by parsing its serialized representation. The
+// FromBytes constructs a Manifest by parsing its serialized representation. The
 // manifest can be a raw YAML document or a PGP clearsigned YAML document. If signed, the
 // signature components will be stored inside the Manifest instance.
-func ManifestFromBytes(bytes []byte) (Manifest, error) {
+func FromBytes(bytes []byte) (Manifest, error) {
 	manifest := &manifest{}
 
 	// Preserve the raw manifest so that manifest.Bytes() returns bytes in

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -54,7 +54,7 @@ type StatusStanza struct {
 	LocalhostOnly bool   `yaml:"localhost_only,omitempty"`
 }
 
-type ManifestBuilder interface {
+type Builder interface {
 	GetManifest() Manifest
 	SetID(types.PodID)
 	SetConfig(config map[interface{}]interface{}) error
@@ -66,22 +66,22 @@ type ManifestBuilder interface {
 	SetRestartPolicy(runit.RestartPolicy)
 }
 
-var _ ManifestBuilder = manifestBuilder{}
+var _ Builder = builder{}
 
-func NewManifestBuilder() ManifestBuilder {
-	return manifestBuilder{&manifest{}}
+func NewBuilder() Builder {
+	return builder{&manifest{}}
 }
 
-func (m manifestBuilder) GetManifest() Manifest {
+func (m builder) GetManifest() Manifest {
 	return m.manifest
 }
 
-type manifestBuilder struct {
+type builder struct {
 	*manifest
 }
 
 // Read-only immutable interface for manifests. To programmatically build a
-// manifest, use ManifestBuilder
+// manifest, use Builder
 type Manifest interface {
 	ID() types.PodID
 	RunAsUser() string
@@ -101,7 +101,7 @@ type Manifest interface {
 	SignatureData() (plaintext, signature []byte)
 	GetRestartPolicy() runit.RestartPolicy
 
-	GetBuilder() ManifestBuilder
+	GetBuilder() Builder
 }
 
 // assert manifest implements Manifest and UnsignedManifest
@@ -126,8 +126,8 @@ type manifest struct {
 	signature []byte
 }
 
-func (m *manifest) GetBuilder() ManifestBuilder {
-	builder := manifestBuilder{
+func (m *manifest) GetBuilder() Builder {
+	builder := builder{
 		&manifest{},
 	}
 	*builder.manifest = *m
@@ -141,7 +141,7 @@ func (manifest *manifest) ID() types.PodID {
 	return manifest.Id
 }
 
-func (m manifestBuilder) SetID(id types.PodID) {
+func (m builder) SetID(id types.PodID) {
 	m.manifest.Id = id
 }
 
@@ -182,7 +182,7 @@ func (manifest *manifest) GetConfig() map[interface{}]interface{} {
 	return configCopy
 }
 
-func (m manifestBuilder) SetConfig(config map[interface{}]interface{}) error {
+func (m builder) SetConfig(config map[interface{}]interface{}) error {
 	// Confirm that the data passed in can be successfully serialized as YAML
 	bytes, err := yaml.Marshal(config)
 	if err != nil {
@@ -249,7 +249,7 @@ func (manifest *manifest) RunAsUser() string {
 	return string(manifest.ID())
 }
 
-func (mb manifestBuilder) SetRunAsUser(user string) {
+func (mb builder) SetRunAsUser(user string) {
 	mb.manifest.RunAs = user
 }
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -2,7 +2,7 @@
 // p2 with a convenient way to colocate several related launchable artifacts, as well
 // as basic shared runtime configuration. Pod manifests are written as YAML files
 // that describe what to launch.
-package pods
+package manifest
 
 import (
 	"crypto/sha256"
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/square/p2/pkg/cgroups"
 	"github.com/square/p2/pkg/runit"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/uri"
@@ -21,6 +22,30 @@ import (
 	"golang.org/x/crypto/openpgp/clearsign"
 	"gopkg.in/yaml.v2"
 )
+
+type LaunchableVersion struct {
+	ID   string            `yaml:"id"`
+	Tags map[string]string `yaml:"tags"`
+}
+
+type LaunchableStanza struct {
+	LaunchableType          string            `yaml:"launchable_type"`
+	LaunchableId            string            `yaml:"launchable_id"`
+	DigestLocation          string            `yaml:"digest_location,omitempty"`
+	DigestSignatureLocation string            `yaml:"digest_signature_location,omitempty"`
+	RestartTimeout          string            `yaml:"restart_timeout,omitempty"`
+	CgroupConfig            cgroups.Config    `yaml:"cgroup,omitempty"`
+	Env                     map[string]string `yaml:"env,omitempty"`
+
+	// The URL from which the launchable can be downloaded. May not be used
+	// in conjunction with Version
+	Location string `yaml:"location"`
+
+	// An alternative to using Location to inform artifact downloading. Version information
+	// can be used to query a configured artifact registry which will provide the artifact
+	// URL. Version may not be used in conjunction with Location
+	Version LaunchableVersion `yaml:"version,omitempty"`
+}
 
 type StatusStanza struct {
 	HTTP          bool   `yaml:"http,omitempty"`
@@ -37,7 +62,8 @@ type ManifestBuilder interface {
 	SetStatusHTTP(statusHTTP bool)
 	SetStatusPath(statusPath string)
 	SetStatusPort(port int)
-	SetLaunchables(launchableStanzas map[string]types.LaunchableStanza)
+	SetLaunchables(launchableStanzas map[string]LaunchableStanza)
+	SetRestartPolicy(runit.RestartPolicy)
 }
 
 var _ ManifestBuilder = manifestBuilder{}
@@ -64,7 +90,7 @@ type Manifest interface {
 	WriteConfig(out io.Writer) error
 	PlatformConfigFileName() (string, error)
 	WritePlatformConfig(out io.Writer) error
-	GetLaunchableStanzas() map[string]types.LaunchableStanza
+	GetLaunchableStanzas() map[string]LaunchableStanza
 	GetConfig() map[interface{}]interface{}
 	SHA() (string, error)
 	GetStatusHTTP() bool
@@ -82,14 +108,14 @@ type Manifest interface {
 var _ Manifest = &manifest{}
 
 type manifest struct {
-	Id                types.PodID                       `yaml:"id"` // public for yaml marshaling access. Use ID() instead.
-	RunAs             string                            `yaml:"run_as,omitempty"`
-	LaunchableStanzas map[string]types.LaunchableStanza `yaml:"launchables"`
-	Config            map[interface{}]interface{}       `yaml:"config"`
-	StatusPort        int                               `yaml:"status_port,omitempty"`
-	StatusHTTP        bool                              `yaml:"status_http,omitempty"`
-	Status            StatusStanza                      `yaml:"status,omitempty"`
-	RestartPolicy     runit.RestartPolicy               `yaml:"restart_policy,omitempty"`
+	Id                types.PodID                 `yaml:"id"` // public for yaml marshaling access. Use ID() instead.
+	RunAs             string                      `yaml:"run_as,omitempty"`
+	LaunchableStanzas map[string]LaunchableStanza `yaml:"launchables"`
+	Config            map[interface{}]interface{} `yaml:"config"`
+	StatusPort        int                         `yaml:"status_port,omitempty"`
+	StatusHTTP        bool                        `yaml:"status_http,omitempty"`
+	Status            StatusStanza                `yaml:"status,omitempty"`
+	RestartPolicy     runit.RestartPolicy         `yaml:"restart_policy,omitempty"`
 
 	// Used to track the original bytes so that we don't reorder them when
 	// doing a yaml.Unmarshal and a yaml.Marshal in succession
@@ -119,12 +145,16 @@ func (m manifestBuilder) SetID(id types.PodID) {
 	m.manifest.Id = id
 }
 
-func (manifest *manifest) GetLaunchableStanzas() map[string]types.LaunchableStanza {
+func (manifest *manifest) GetLaunchableStanzas() map[string]LaunchableStanza {
 	return manifest.LaunchableStanzas
 }
 
-func (manifest *manifest) SetLaunchables(launchableStanzas map[string]types.LaunchableStanza) {
+func (manifest *manifest) SetLaunchables(launchableStanzas map[string]LaunchableStanza) {
 	manifest.LaunchableStanzas = launchableStanzas
+}
+
+func (manifest *manifest) SetRestartPolicy(restartPolicy runit.RestartPolicy) {
+	manifest.RestartPolicy = restartPolicy
 }
 
 func (manifest *manifest) GetConfig() map[interface{}]interface{} {

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -94,7 +94,7 @@ QyB184dCJQnFbcQslyXDSR4Lal12NPvxbtK/4YYXZZVwf4hKCfVqvmG2zgwINDc=
 }
 
 func TestPodManifestCanBeWritten(t *testing.T) {
-	builder := NewManifestBuilder()
+	builder := NewBuilder()
 	builder.SetID("thepod")
 	launchables := map[string]LaunchableStanza{
 		"my-app": {
@@ -256,15 +256,15 @@ config:
 	Assert(t).AreEqual(string(outBytes), string(manifestBytes), "Byte order should not have changed when unmarshaling and remarshaling a manifest")
 }
 
-func TestManifestBuilder(t *testing.T) {
-	builder := NewManifestBuilder()
+func TestBuilder(t *testing.T) {
+	builder := NewBuilder()
 	builder.SetID("testpod")
 	manifest := builder.GetManifest()
 
 	Assert(t).AreEqual(string(manifest.ID()), "testpod", "id of built manifest did not match expected")
 }
 
-func TestManifestBuilderStripsFields(t *testing.T) {
+func TestBuilderStripsFields(t *testing.T) {
 	podManifest := manifest{
 		raw:       []byte("foo"),
 		signature: []byte("bar"),
@@ -296,18 +296,18 @@ config:
 
 	builder := manifest.GetBuilder()
 	builtManifest := builder.GetManifest()
-	Assert(t).AreEqual(string(builtManifest.ID()), "thepod", "Expected manifest ID to be preserved when converted to ManifestBuilder and back")
+	Assert(t).AreEqual(string(builtManifest.ID()), "thepod", "Expected manifest ID to be preserved when converted to Builder and back")
 }
 
 func TestGetConfigInitializesIfEmpty(t *testing.T) {
-	builder := NewManifestBuilder()
+	builder := NewBuilder()
 	manifest := builder.GetManifest()
 	config := manifest.GetConfig()
 	Assert(t).IsNotNil(config, "Expected returned config to be instantiated by GetConfig() if not set")
 }
 
 func TestGetConfigReturnsCopy(t *testing.T) {
-	builder := NewManifestBuilder()
+	builder := NewBuilder()
 	manifest := builder.GetManifest()
 	config := manifest.GetConfig()
 	config2 := manifest.GetConfig()
@@ -327,13 +327,13 @@ func TestSetConfigErrsIfBadYAML(t *testing.T) {
 	cantMarshalConfig := make(map[interface{}]interface{})
 	cantMarshalConfig["foo"] = CantMarshal{}
 
-	builder := NewManifestBuilder()
+	builder := NewBuilder()
 	err := builder.SetConfig(cantMarshalConfig)
 	Assert(t).IsNotNil(err, "Should have erred setting config with a type that cannot be marshaled as YAML")
 }
 
 func TestSetConfigCopies(t *testing.T) {
-	builder := NewManifestBuilder()
+	builder := NewBuilder()
 	config := map[interface{}]interface{}{
 		"foo": "bar",
 	}

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -18,7 +18,7 @@ func TestPodManifestCanBeRead(t *testing.T) {
 	_, filename, _, _ := runtime.Caller(0)
 	testPath := filepath.Join(filepath.Dir(filename), "test_manifest.yaml")
 
-	manifest, err := ManifestFromPath(testPath)
+	manifest, err := FromPath(testPath)
 	Assert(t).IsNil(err, "Should not have failed to get pod manifest.")
 	Assert(t).AreEqual("hello", string(manifest.ID()), "Id read from manifest didn't have expected value")
 	Assert(t).AreEqual(manifest.GetLaunchableStanzas()["app"].Location, "hoisted-hello_def456.tar.gz", "Location read from manifest didn't have expected value")
@@ -125,7 +125,7 @@ func TestPodManifestCanBeWritten(t *testing.T) {
 
 func TestPodManifestCanWriteItsConfigStanzaSeparately(t *testing.T) {
 	config := testPod()
-	manifest, err := ManifestFromBytes([]byte(config))
+	manifest, err := FromBytes([]byte(config))
 	Assert(t).IsNil(err, "should not have erred when building manifest")
 
 	buff := bytes.Buffer{}
@@ -137,7 +137,7 @@ func TestPodManifestCanWriteItsConfigStanzaSeparately(t *testing.T) {
 
 func TestPodManifestCanReportItsSHA(t *testing.T) {
 	config := testPodOldStatus()
-	manifest, err := ManifestFromBytes([]byte(config))
+	manifest, err := FromBytes([]byte(config))
 	Assert(t).IsNil(err, "should not have erred when building manifest")
 	val, err := manifest.SHA()
 	Assert(t).IsNil(err, "should not have erred when getting SHA")
@@ -150,7 +150,7 @@ func TestPodManifestCanReportItsSHA(t *testing.T) {
 
 func TestPodManifestLaunchablesCGroups(t *testing.T) {
 	config := testPod()
-	manifest, _ := ManifestFromBytes([]byte(config))
+	manifest, _ := FromBytes([]byte(config))
 	launchables := manifest.GetLaunchableStanzas()
 	Assert(t).AreEqual(len(launchables), 1, "Expected exactly one launchable in the manifest")
 	for _, launchable := range launchables {
@@ -179,7 +179,7 @@ func TestStatusHTTP(t *testing.T) {
 		{`{ id: thepod, status: { http: true } }`, true},
 	}
 	for _, test := range tests {
-		manifest, err := ManifestFromBytes([]byte(test.config))
+		manifest, err := FromBytes([]byte(test.config))
 		Assert(t).IsNil(err, "should not have erred when building manifest")
 
 		Assert(t).AreEqual(test.expected, manifest.GetStatusHTTP(), "uses the correct protocol")
@@ -197,7 +197,7 @@ func TestStatusPath(t *testing.T) {
 		{`{ id: thepod, status: { path: /_foobar } }`, "/_foobar"},
 	}
 	for _, test := range tests {
-		manifest, err := ManifestFromBytes([]byte(test.config))
+		manifest, err := FromBytes([]byte(test.config))
 		Assert(t).IsNil(err, "should not have erred when building manifest")
 
 		Assert(t).AreEqual(test.expected, manifest.GetStatusPath(), "uses the correct path")
@@ -215,7 +215,7 @@ func TestStatusPort(t *testing.T) {
 		{`{ id: thepod, status: { port: 398 } }`, 398},
 	}
 	for _, test := range tests {
-		manifest, err := ManifestFromBytes([]byte(test.config))
+		manifest, err := FromBytes([]byte(test.config))
 		Assert(t).IsNil(err, "should not have erred when building manifest")
 
 		Assert(t).AreEqual(test.expected, manifest.GetStatusPort(), "uses the correct port")
@@ -224,13 +224,13 @@ func TestStatusPort(t *testing.T) {
 
 func TestRunAs(t *testing.T) {
 	config := testPod()
-	manifest, err := ManifestFromBytes([]byte(config))
+	manifest, err := FromBytes([]byte(config))
 	Assert(t).IsNil(err, "should not have erred when building manifest")
 
 	Assert(t).AreEqual(manifest.RunAsUser(), string(manifest.ID()), "RunAsUser() didn't match expectations")
 
 	config += `run_as: specialuser`
-	manifest, err = ManifestFromBytes([]byte(config))
+	manifest, err = FromBytes([]byte(config))
 	Assert(t).IsNil(err, "should not have erred when building manifest")
 	Assert(t).AreEqual(manifest.RunAsUser(), "specialuser", "RunAsUser() didn't match expectations")
 }
@@ -238,7 +238,7 @@ func TestRunAs(t *testing.T) {
 func TestByteOrderPreserved(t *testing.T) {
 	// The yaml keys here are intentionally ordered in a way that without special
 	// care, the bytes returned by manifest.Bytes() would be in a different order
-	// than the bytes passed in to ManifestFromBytes()
+	// than the bytes passed in to FromBytes()
 	manifestBytes := []byte(`id: thepod
 launchables:
   my-app:
@@ -249,7 +249,7 @@ status_port: 8000
 config:
   ENVIRONMENT: staging
 `)
-	manifest, err := ManifestFromBytes(manifestBytes)
+	manifest, err := FromBytes(manifestBytes)
 	Assert(t).IsNil(err, "should not have erred constructing manifest from bytes")
 	outBytes, err := manifest.Marshal()
 	Assert(t).IsNil(err, "should not have erred extracting manifest struct to bytes")
@@ -291,7 +291,7 @@ status_port: 8000
 config:
   ENVIRONMENT: staging
 `)
-	manifest, err := ManifestFromBytes(manifestBytes)
+	manifest, err := FromBytes(manifestBytes)
 	Assert(t).IsNil(err, "should not have erred constructing manifest from bytes")
 
 	builder := manifest.GetBuilder()

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -1,4 +1,4 @@
-package pods
+package manifest
 
 import (
 	"bytes"
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/square/p2/pkg/cgroups"
-	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util/size"
 
 	. "github.com/anthonybishopric/gotcha"
@@ -97,7 +96,7 @@ QyB184dCJQnFbcQslyXDSR4Lal12NPvxbtK/4YYXZZVwf4hKCfVqvmG2zgwINDc=
 func TestPodManifestCanBeWritten(t *testing.T) {
 	builder := NewManifestBuilder()
 	builder.SetID("thepod")
-	launchables := map[string]types.LaunchableStanza{
+	launchables := map[string]LaunchableStanza{
 		"my-app": {
 			LaunchableType: "hoist",
 			LaunchableId:   "web",

--- a/pkg/manifest/test_manifest.yaml
+++ b/pkg/manifest/test_manifest.yaml
@@ -1,0 +1,23 @@
+id: hello
+# any base agent that passes this label expression will
+# attempt to run it. Zones and colo-groups collapse into
+# this labeling mechanism
+# label: "%{PA & EXTERNAL}" # aspirational
+# we could alternatively give each host its own label and
+# manually schedule them this way in an initial phase.
+# label: %{foo.bar.square | bam.biz.square}
+# instances: 3 # aspirational
+launchables:
+  app:
+    launchable_type: hoist
+    launchable_id: app
+    location: hoisted-hello_def456.tar.gz
+
+config:
+  # is written to a file and passed as CONFIG_FILE to the process
+  ENVIRONMENT: staging
+  TMPDIR: /data/app/ocrcard/current/tmp
+  hoptoad:
+    url: https://hoptoad.com/notifier_api/v2/notices/
+    api_key: aabbccddeeffgghhiiijjjkkklll
+    api_key_warn: aabbccddeeffgghhiiijjjkkklll

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -107,7 +107,7 @@ func (pod *Pod) CurrentManifest() (manifest.Manifest, error) {
 	if _, err := os.Stat(currentManPath); os.IsNotExist(err) {
 		return nil, NoCurrentManifest
 	}
-	return manifest.ManifestFromPath(currentManPath)
+	return manifest.FromPath(currentManPath)
 }
 
 func (pod *Pod) Halt(manifest manifest.Manifest) (bool, error) {

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -17,6 +17,7 @@ import (
 	"github.com/square/p2/pkg/hoist"
 	"github.com/square/p2/pkg/launch"
 	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/opencontainer"
 	"github.com/square/p2/pkg/p2exec"
 	"github.com/square/p2/pkg/runit"
@@ -101,15 +102,15 @@ func (pod *Pod) Path() string {
 	return pod.path
 }
 
-func (pod *Pod) CurrentManifest() (Manifest, error) {
+func (pod *Pod) CurrentManifest() (manifest.Manifest, error) {
 	currentManPath := pod.currentPodManifestPath()
 	if _, err := os.Stat(currentManPath); os.IsNotExist(err) {
 		return nil, NoCurrentManifest
 	}
-	return ManifestFromPath(currentManPath)
+	return manifest.ManifestFromPath(currentManPath)
 }
 
-func (pod *Pod) Halt(manifest Manifest) (bool, error) {
+func (pod *Pod) Halt(manifest manifest.Manifest) (bool, error) {
 	launchables, err := pod.Launchables(manifest)
 	if err != nil {
 		return false, err
@@ -142,7 +143,7 @@ func (pod *Pod) Halt(manifest Manifest) (bool, error) {
 // during the launch process will be logged, but will not stop attempts to launch other launchables
 // in the same pod. If any services fail to start, the first return bool will be false. If an error
 // occurs when writing the current manifest to the pod directory, an error will be returned.
-func (pod *Pod) Launch(manifest Manifest) (bool, error) {
+func (pod *Pod) Launch(manifest manifest.Manifest) (bool, error) {
 	launchables, err := pod.Launchables(manifest)
 	if err != nil {
 		return false, err
@@ -201,7 +202,7 @@ func (pod *Pod) Launch(manifest Manifest) (bool, error) {
 	return success, nil
 }
 
-func (pod *Pod) Prune(max size.ByteCount, manifest Manifest) {
+func (pod *Pod) Prune(max size.ByteCount, manifest manifest.Manifest) {
 	launchables, err := pod.Launchables(manifest)
 	if err != nil {
 		return
@@ -215,7 +216,7 @@ func (pod *Pod) Prune(max size.ByteCount, manifest Manifest) {
 	}
 }
 
-func (pod *Pod) Services(manifest Manifest) ([]runit.Service, error) {
+func (pod *Pod) Services(manifest manifest.Manifest) ([]runit.Service, error) {
 	allServices := []runit.Service{}
 	launchables, err := pod.Launchables(manifest)
 	if err != nil {
@@ -237,7 +238,7 @@ func (pod *Pod) Services(manifest Manifest) ([]runit.Service, error) {
 
 // Write servicebuilder *.yaml file and run servicebuilder, which will register runit services for this
 // pod.
-func (pod *Pod) buildRunitServices(launchables []launch.Launchable, newManifest Manifest) error {
+func (pod *Pod) buildRunitServices(launchables []launch.Launchable, newManifest manifest.Manifest) error {
 	// if the service is new, building the runit services also starts them
 	sbTemplate := make(map[string]runit.ServiceTemplate)
 	for _, launchable := range launchables {
@@ -267,7 +268,7 @@ func (pod *Pod) buildRunitServices(launchables []launch.Launchable, newManifest 
 	return pod.ServiceBuilder.Prune()
 }
 
-func (pod *Pod) WriteCurrentManifest(manifest Manifest) (string, error) {
+func (pod *Pod) WriteCurrentManifest(manifest manifest.Manifest) (string, error) {
 	// write the old manifest to a temporary location in case a launch fails.
 	tmpDir, err := ioutil.TempDir("", "manifests")
 	if err != nil {
@@ -379,7 +380,7 @@ func (pod *Pod) Uninstall() error {
 // Install will ensure that executables for all required services are present on the host
 // machine and are set up to run. In the case of Hoist artifacts (which is the only format
 // supported currently, this will set up runit services.).
-func (pod *Pod) Install(manifest Manifest, verifier auth.ArtifactVerifier) error {
+func (pod *Pod) Install(manifest manifest.Manifest, verifier auth.ArtifactVerifier) error {
 	podHome := pod.path
 	uid, gid, err := user.IDs(manifest.RunAsUser())
 	if err != nil {
@@ -418,7 +419,7 @@ func (pod *Pod) Install(manifest Manifest, verifier auth.ArtifactVerifier) error
 	return nil
 }
 
-func (pod *Pod) Verify(manifest Manifest, authPolicy auth.Policy) error {
+func (pod *Pod) Verify(manifest manifest.Manifest, authPolicy auth.Policy) error {
 	for _, stanza := range manifest.GetLaunchableStanzas() {
 		if stanza.DigestLocation == "" {
 			continue
@@ -482,7 +483,7 @@ func (pod *Pod) Verify(manifest Manifest, authPolicy auth.Policy) error {
 //
 // We may wish to provide a "config" directory per launchable at some point as
 // well, so that launchables can have different config namespaces
-func (pod *Pod) setupConfig(manifest Manifest, launchables []launch.Launchable) error {
+func (pod *Pod) setupConfig(manifest manifest.Manifest, launchables []launch.Launchable) error {
 	uid, gid, err := user.IDs(manifest.RunAsUser())
 	if err != nil {
 		return util.Errorf("Could not determine pod UID/GID: %s", err)
@@ -598,7 +599,7 @@ func writeEnvFile(envDir, name, value string, uid, gid int) error {
 	return nil
 }
 
-func (pod *Pod) Launchables(manifest Manifest) ([]launch.Launchable, error) {
+func (pod *Pod) Launchables(manifest manifest.Manifest) ([]launch.Launchable, error) {
 	launchableStanzas := manifest.GetLaunchableStanzas()
 	launchables := make([]launch.Launchable, 0, len(launchableStanzas))
 
@@ -637,7 +638,7 @@ func (pod *Pod) SetLogBridgeExec(logExec []string) {
 	pod.LogExec = append([]string{pod.P2Exec}, p2ExecArgs.CommandLine()...)
 }
 
-func (pod *Pod) getLaunchable(launchableStanza types.LaunchableStanza, runAsUser string, restartPolicy runit.RestartPolicy) (launch.Launchable, error) {
+func (pod *Pod) getLaunchable(launchableStanza manifest.LaunchableStanza, runAsUser string, restartPolicy runit.RestartPolicy) (launch.Launchable, error) {
 	launchableRootDir := filepath.Join(pod.path, launchableStanza.LaunchableId)
 	serviceId := strings.Join(
 		[]string{
@@ -666,7 +667,7 @@ func (pod *Pod) getLaunchable(launchableStanza types.LaunchableStanza, runAsUser
 	// /<launchable_id>_<version>.tar.gz. The launchable needs the
 	// <version> currently, which we parse from the URL. Future work is
 	// planned to implement more explicit versions specified in the
-	// types.LaunchableStanza in the pod manifest
+	// manifest.LaunchableStanza in the pod manifest
 	version, err := versionFromLocation(locationURL)
 	if err != nil {
 		return nil, err

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -268,7 +268,7 @@ func TestBuildRunitServices(t *testing.T) {
 	outFilePath := filepath.Join(serviceBuilder.ConfigRoot, "testPod.yaml")
 
 	Assert(t).IsNil(err, "Got an unexpected error when attempting to start runit services")
-	testManifest := manifest.NewManifestBuilder()
+	testManifest := manifest.NewBuilder()
 	testManifest.SetRestartPolicy(runit.RestartPolicyAlways)
 	testLaunchable := hl.If()
 	pod.buildRunitServices([]launch.Launchable{testLaunchable}, testManifest.GetManifest())

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -30,14 +30,14 @@ func getTestPod() *Pod {
 
 func getTestPodManifest(t *testing.T) manifest.Manifest {
 	testPath := util.From(runtime.Caller(0)).ExpandPath("test_manifest.yaml")
-	pod, err := manifest.ManifestFromPath(testPath)
+	pod, err := manifest.FromPath(testPath)
 	Assert(t).IsNil(err, "couldn't read test manifest")
 	return pod
 }
 
 func getUpdatedManifest(t *testing.T) manifest.Manifest {
 	podPath := util.From(runtime.Caller(0)).ExpandPath("updated_manifest.yaml")
-	pod, err := manifest.ManifestFromPath(podPath)
+	pod, err := manifest.FromPath(podPath)
 	Assert(t).IsNil(err, "couldn't read test manifest")
 	return pod
 }
@@ -103,7 +103,7 @@ config:
 	currUser, err := user.Current()
 	Assert(t).IsNil(err, "Could not get the current user")
 	manifestStr += fmt.Sprintf("run_as: %s", currUser.Username)
-	manifest, err := manifest.ManifestFromBytes(bytes.NewBufferString(manifestStr).Bytes())
+	manifest, err := manifest.FromBytes(bytes.NewBufferString(manifestStr).Bytes())
 	Assert(t).IsNil(err, "should not have erred reading the manifest")
 
 	podTemp, _ := ioutil.TempDir("", "pod")
@@ -239,7 +239,7 @@ func TestWriteManifestWillReturnOldManifestTempPath(t *testing.T) {
 	oldPath, err := pod.WriteCurrentManifest(updated.GetManifest())
 	Assert(t).IsNil(err, "should have written the current manifest and linked the old one")
 
-	writtenOld, err := manifest.ManifestFromPath(oldPath)
+	writtenOld, err := manifest.FromPath(oldPath)
 	Assert(t).IsNil(err, "should have written a manifest to the old path")
 	manifestMustEqual(existing.GetManifest(), writtenOld, t)
 

--- a/pkg/preparer/listener_test.go
+++ b/pkg/preparer/listener_test.go
@@ -62,7 +62,7 @@ func testHookListener(t *testing.T) (HookListener, <-chan struct{}) {
 
 	current, err := user.Current()
 	Assert(t).IsNil(err, "test setup: could not get the current user")
-	builder := manifest.NewManifestBuilder()
+	builder := manifest.NewBuilder()
 	builder.SetID("users")
 	builder.SetRunAsUser(current.Username)
 	builder.SetLaunchables(map[string]manifest.LaunchableStanza{

--- a/pkg/preparer/listener_test.go
+++ b/pkg/preparer/listener_test.go
@@ -86,7 +86,7 @@ func testHookListener(t *testing.T) (HookListener, <-chan struct{}) {
 	sigWriter.Write(manifestBytes)
 	sigWriter.Close()
 
-	podManifest, err = manifest.ManifestFromBytes(buf.Bytes())
+	podManifest, err = manifest.FromBytes(buf.Bytes())
 	Assert(t).IsNil(err, "should have generated manifest from signed bytes")
 
 	fakeIntent := fakeStoreWithManifests(kp.ManifestResult{

--- a/pkg/preparer/orchestrate_test.go
+++ b/pkg/preparer/orchestrate_test.go
@@ -124,7 +124,7 @@ func testManifest(t *testing.T) manifest.Manifest {
 
 var fakeSigner *openpgp.Entity
 
-func testSignedManifest(t *testing.T, modify func(manifest.ManifestBuilder, *openpgp.Entity)) (manifest.Manifest, *openpgp.Entity) {
+func testSignedManifest(t *testing.T, modify func(manifest.Builder, *openpgp.Entity)) (manifest.Manifest, *openpgp.Entity) {
 	testManifest := testManifest(t)
 
 	if fakeSigner == nil {
@@ -134,9 +134,9 @@ func testSignedManifest(t *testing.T, modify func(manifest.ManifestBuilder, *ope
 	}
 
 	if modify != nil {
-		testManifestBuilder := testManifest.GetBuilder()
-		modify(testManifestBuilder, fakeSigner)
-		testManifest = testManifestBuilder.GetManifest()
+		testBuilder := testManifest.GetBuilder()
+		modify(testBuilder, fakeSigner)
+		testManifest = testBuilder.GetManifest()
 	}
 
 	manifestBytes, err := testManifest.Marshal()
@@ -227,7 +227,7 @@ func TestPreparerLaunchesNewPodsThatArentInstalledYet(t *testing.T) {
 }
 
 func TestPreparerLaunchesPodsThatHaveDifferentSHAs(t *testing.T) {
-	builder := manifest.NewManifestBuilder()
+	builder := manifest.NewBuilder()
 	builder.SetID("hello")
 	existing := builder.GetManifest()
 
@@ -279,7 +279,7 @@ func TestPreparerFailsIfInstallFails(t *testing.T) {
 }
 
 func TestPreparerWillLaunchPreparerAsRoot(t *testing.T) {
-	builder := manifest.NewManifestBuilder()
+	builder := manifest.NewBuilder()
 	builder.SetID(POD_ID)
 	builder.SetRunAsUser("root")
 	illegalManifest := builder.GetManifest()
@@ -379,7 +379,7 @@ func TestPreparerWillAcceptSignatureFromKeyring(t *testing.T) {
 }
 
 func TestPreparerWillAcceptSignatureForPreparerWithoutAuthorizedDeployers(t *testing.T) {
-	manifest, fakeSigner := testSignedManifest(t, func(b manifest.ManifestBuilder, _ *openpgp.Entity) {
+	manifest, fakeSigner := testSignedManifest(t, func(b manifest.Builder, _ *openpgp.Entity) {
 		b.SetID(POD_ID)
 	})
 
@@ -395,7 +395,7 @@ func TestPreparerWillAcceptSignatureForPreparerWithoutAuthorizedDeployers(t *tes
 }
 
 func TestPreparerWillRejectUnauthorizedSignatureForPreparer(t *testing.T) {
-	manifest, fakeSigner := testSignedManifest(t, func(b manifest.ManifestBuilder, _ *openpgp.Entity) {
+	manifest, fakeSigner := testSignedManifest(t, func(b manifest.Builder, _ *openpgp.Entity) {
 		b.SetID(POD_ID)
 	})
 
@@ -415,7 +415,7 @@ func TestPreparerWillRejectUnauthorizedSignatureForPreparer(t *testing.T) {
 
 func TestPreparerWillAcceptAuthorizedSignatureForPreparer(t *testing.T) {
 	sig := ""
-	manifest, fakeSigner := testSignedManifest(t, func(b manifest.ManifestBuilder, e *openpgp.Entity) {
+	manifest, fakeSigner := testSignedManifest(t, func(b manifest.Builder, e *openpgp.Entity) {
 		b.SetID(POD_ID)
 		sig = fmt.Sprintf("%X", e.PrimaryKey.Fingerprint)
 	})

--- a/pkg/preparer/orchestrate_test.go
+++ b/pkg/preparer/orchestrate_test.go
@@ -115,7 +115,7 @@ func (f *fakeHooks) RunHookType(hookType hooks.HookType, pod hooks.Pod, manifest
 
 func testManifest(t *testing.T) manifest.Manifest {
 	manifestPath := util.From(runtime.Caller(0)).ExpandPath("test_manifest.yaml")
-	manifest, err := manifest.ManifestFromPath(manifestPath)
+	manifest, err := manifest.FromPath(manifestPath)
 	if err != nil {
 		t.Fatal("No test manifest found, failing\n")
 	}
@@ -149,7 +149,7 @@ func testSignedManifest(t *testing.T, modify func(manifest.Builder, *openpgp.Ent
 	sigWriter.Write(manifestBytes)
 	sigWriter.Close()
 
-	manifest, err := manifest.ManifestFromBytes(buf.Bytes())
+	manifest, err := manifest.FromBytes(buf.Bytes())
 	Assert(t).IsNil(err, "should have generated manifest from signed bytes")
 
 	return manifest, fakeSigner

--- a/pkg/preparer/result_set.go
+++ b/pkg/preparer/result_set.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 
 	"github.com/square/p2/pkg/kp"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/types"
 )
 
@@ -12,8 +12,8 @@ type ManifestPair struct {
 	// save the ID in a separate field, so that the user of this object doesn't
 	// have to check both manifests
 	ID      types.PodID
-	Intent  pods.Manifest
-	Reality pods.Manifest
+	Intent  manifest.Manifest
+	Reality manifest.Manifest
 }
 
 // Given two lists of ManifestResults, group them into pairs based on their

--- a/pkg/preparer/result_set_test.go
+++ b/pkg/preparer/result_set_test.go
@@ -7,12 +7,12 @@ import (
 
 	. "github.com/anthonybishopric/gotcha"
 	"github.com/square/p2/pkg/kp"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/types"
 )
 
-func podWithID(id string) pods.Manifest {
-	builder := pods.NewManifestBuilder()
+func podWithID(id string) manifest.Manifest {
+	builder := manifest.NewManifestBuilder()
 	builder.SetID(types.PodID(id))
 	return builder.GetManifest()
 }

--- a/pkg/preparer/result_set_test.go
+++ b/pkg/preparer/result_set_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func podWithID(id string) manifest.Manifest {
-	builder := manifest.NewManifestBuilder()
+	builder := manifest.NewBuilder()
 	builder.SetID(types.PodID(id))
 	return builder.GetManifest()
 }

--- a/pkg/rc/fields/fields.go
+++ b/pkg/rc/fields/fields.go
@@ -94,7 +94,7 @@ func (rc *RC) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	m, err := manifest.ManifestFromBytes([]byte(rawRC.Manifest))
+	m, err := manifest.FromBytes([]byte(rawRC.Manifest))
 	if err != nil {
 		return err
 	}

--- a/pkg/rc/fields/fields.go
+++ b/pkg/rc/fields/fields.go
@@ -6,7 +6,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/labels"
 
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 )
 
 // ID is a named type alias for Resource Controller IDs. This is preferred to the raw
@@ -24,7 +24,7 @@ type RC struct {
 	ID ID
 
 	// The pod manifest that should be scheduled on nodes
-	Manifest pods.Manifest
+	Manifest manifest.Manifest
 
 	// Defines the set of nodes on which the manifest can be scheduled
 	NodeSelector labels.Selector
@@ -53,11 +53,11 @@ type RawRC struct {
 // MarshalJSON implements the json.Marshaler interface for serializing the RC to JSON
 // format.
 //
-// The RC struct contains interfaces (pods.Manifest, labels.Selector), and
+// The RC struct contains interfaces (manifest.Manifest, labels.Selector), and
 // unmarshaling into a nil, non-empty interface is impossible (unless the value
 // is a JSON null), because the unmarshaler doesn't know what structure to
 // allocate there
-// we own pods.Manifest, but we don't own labels.Selector, so we have to
+// we own manifest.Manifest, but we don't own labels.Selector, so we have to
 // implement the json marshaling here to wrap around the interface values
 func (rc RC) MarshalJSON() ([]byte, error) {
 	var manifest []byte
@@ -94,7 +94,7 @@ func (rc *RC) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	m, err := pods.ManifestFromBytes([]byte(rawRC.Manifest))
+	m, err := manifest.ManifestFromBytes([]byte(rawRC.Manifest))
 	if err != nil {
 		return err
 	}

--- a/pkg/rc/fields/fields_test.go
+++ b/pkg/rc/fields/fields_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestJSONMarshal(t *testing.T) {
-	mb := manifest.NewManifestBuilder()
+	mb := manifest.NewBuilder()
 	mb.SetID("hello")
 	m := mb.GetManifest()
 

--- a/pkg/rc/fields/fields_test.go
+++ b/pkg/rc/fields/fields_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 
 	. "github.com/anthonybishopric/gotcha"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/rc/fields"
 )
 
 func TestJSONMarshal(t *testing.T) {
-	mb := pods.NewManifestBuilder()
+	mb := manifest.NewManifestBuilder()
 	mb.SetID("hello")
 	m := mb.GetManifest()
 

--- a/pkg/rc/replication_controller.go
+++ b/pkg/rc/replication_controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/square/p2/pkg/kp/rcstore"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/rc/fields"
 	"github.com/square/p2/pkg/scheduler"
@@ -62,14 +63,14 @@ type kpStore interface {
 	SetPod(
 		podPrefix kp.PodPrefix,
 		nodeName types.NodeName,
-		manifest pods.Manifest,
+		manifest manifest.Manifest,
 	) (time.Duration, error)
 
 	Pod(
 		podPrefix kp.PodPrefix,
 		nodeName types.NodeName,
 		podId types.PodID,
-	) (pods.Manifest, time.Duration, error)
+	) (manifest.Manifest, time.Duration, error)
 
 	DeletePod(podPrefix kp.PodPrefix,
 		nodeName types.NodeName,

--- a/pkg/rc/replication_controller_test.go
+++ b/pkg/rc/replication_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/square/p2/pkg/kp/rcstore"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/scheduler"
 	"github.com/square/p2/pkg/types"
@@ -20,10 +21,10 @@ import (
 )
 
 type fakeKpStore struct {
-	manifests map[string]pods.Manifest
+	manifests map[string]manifest.Manifest
 }
 
-func (s *fakeKpStore) SetPod(podPrefix kp.PodPrefix, nodeName types.NodeName, manifest pods.Manifest) (time.Duration, error) {
+func (s *fakeKpStore) SetPod(podPrefix kp.PodPrefix, nodeName types.NodeName, manifest manifest.Manifest) (time.Duration, error) {
 	key := path.Join(string(podPrefix), nodeName.String(), string(manifest.ID()))
 	s.manifests[key] = manifest
 	return 0, nil
@@ -36,7 +37,7 @@ func (s *fakeKpStore) DeletePod(podPrefix kp.PodPrefix, nodeName types.NodeName,
 }
 
 func (s *fakeKpStore) Pod(podPrefix kp.PodPrefix, nodeName types.NodeName, podID types.PodID) (
-	pods.Manifest, time.Duration, error) {
+	manifest.Manifest, time.Duration, error) {
 	key := path.Join(string(podPrefix), nodeName.String(), podID.String())
 	if manifest, ok := s.manifests[key]; ok {
 		return manifest, 0, nil
@@ -54,17 +55,17 @@ func setup(t *testing.T) (
 
 	rcStore = rcstore.NewFake()
 
-	manifestBuilder := pods.NewManifestBuilder()
+	manifestBuilder := manifest.NewManifestBuilder()
 	manifestBuilder.SetID("testPod")
-	manifest := manifestBuilder.GetManifest()
+	podManifest := manifestBuilder.GetManifest()
 
 	nodeSelector := klabels.Everything().Add("nodeQuality", klabels.EqualsOperator, []string{"good"})
 	podLabels := map[string]string{"podTest": "successful"}
 
-	rcData, err := rcStore.Create(manifest, nodeSelector, podLabels)
+	rcData, err := rcStore.Create(podManifest, nodeSelector, podLabels)
 	Assert(t).IsNil(err, "expected no error creating request")
 
-	kpStore = fakeKpStore{manifests: make(map[string]pods.Manifest)}
+	kpStore = fakeKpStore{manifests: make(map[string]manifest.Manifest)}
 	applicator = labels.NewFakeApplicator()
 	alerter = alertingtest.NewRecorder()
 

--- a/pkg/rc/replication_controller_test.go
+++ b/pkg/rc/replication_controller_test.go
@@ -55,7 +55,7 @@ func setup(t *testing.T) (
 
 	rcStore = rcstore.NewFake()
 
-	manifestBuilder := manifest.NewManifestBuilder()
+	manifestBuilder := manifest.NewBuilder()
 	manifestBuilder.SetID("testPod")
 	podManifest := manifestBuilder.GetManifest()
 

--- a/pkg/replication/common_setup_test.go
+++ b/pkg/replication/common_setup_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/types"
 
 	"github.com/Sirupsen/logrus"
@@ -212,8 +212,8 @@ func basicLogger() logging.Logger {
 	)
 }
 
-func basicManifest() pods.Manifest {
-	builder := pods.NewManifestBuilder()
+func basicManifest() manifest.Manifest {
+	builder := manifest.NewManifestBuilder()
 	builder.SetID(testPodId)
 	return builder.GetManifest()
 }

--- a/pkg/replication/common_setup_test.go
+++ b/pkg/replication/common_setup_test.go
@@ -213,7 +213,7 @@ func basicLogger() logging.Logger {
 }
 
 func basicManifest() manifest.Manifest {
-	builder := manifest.NewManifestBuilder()
+	builder := manifest.NewBuilder()
 	builder.SetID(testPodId)
 	return builder.GetManifest()
 }

--- a/pkg/replication/replication.go
+++ b/pkg/replication/replication.go
@@ -12,6 +12,7 @@ import (
 	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/rc"
 	"github.com/square/p2/pkg/types"
@@ -54,7 +55,7 @@ type replication struct {
 	nodes     []types.NodeName
 	store     kp.Store
 	labeler   labels.Applicator
-	manifest  pods.Manifest
+	manifest  manifest.Manifest
 	health    checker.ConsulHealthChecker
 	threshold health.HealthState // minimum state to treat as "healthy"
 	logger    logging.Logger
@@ -281,7 +282,7 @@ func (r replication) updateOne(node types.NodeName, done chan<- types.NodeName, 
 	r.ensureHealthy(node, done, quitCh, nodeLogger, aggregateHealth)
 }
 
-func (r *replication) queryReality(node types.NodeName) (pods.Manifest, error) {
+func (r *replication) queryReality(node types.NodeName) (manifest.Manifest, error) {
 	r.concurrentRealityRequests <- struct{}{}
 	defer func() {
 		<-r.concurrentRealityRequests

--- a/pkg/replication/replicator.go
+++ b/pkg/replication/replicator.go
@@ -6,7 +6,7 @@ import (
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/preparer"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
@@ -24,7 +24,7 @@ type Replicator interface {
 
 // Replicator creates replications
 type replicator struct {
-	manifest  pods.Manifest // the manifest to replicate
+	manifest  manifest.Manifest // the manifest to replicate
 	logger    logging.Logger
 	nodes     []types.NodeName
 	active    int // maximum number of nodes to update concurrently
@@ -37,7 +37,7 @@ type replicator struct {
 }
 
 func NewReplicator(
-	manifest pods.Manifest,
+	manifest manifest.Manifest,
 	logger logging.Logger,
 	nodes []types.NodeName,
 	active int,

--- a/pkg/roll/update_test.go
+++ b/pkg/roll/update_test.go
@@ -351,7 +351,7 @@ func SimulateRollingUpgrade(t *testing.T, full, nonew, strictRemove bool) {
 }
 
 func podWithIDAndPort(id string, port int) manifest.Manifest {
-	builder := manifest.NewManifestBuilder()
+	builder := manifest.NewBuilder()
 	builder.SetID(types.PodID(id))
 	builder.SetStatusPort(port)
 	return builder.GetManifest()

--- a/pkg/roll/update_test.go
+++ b/pkg/roll/update_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/square/p2/pkg/kp/rcstore"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/rc"
 	rc_fields "github.com/square/p2/pkg/rc/fields"
 	"github.com/square/p2/pkg/roll/fields"
@@ -350,8 +350,8 @@ func SimulateRollingUpgrade(t *testing.T, full, nonew, strictRemove bool) {
 	}
 }
 
-func podWithIDAndPort(id string, port int) pods.Manifest {
-	builder := pods.NewManifestBuilder()
+func podWithIDAndPort(id string, port int) manifest.Manifest {
+	builder := manifest.NewManifestBuilder()
 	builder.SetID(types.PodID(id))
 	builder.SetStatusPort(port)
 	return builder.GetManifest()
@@ -360,8 +360,8 @@ func podWithIDAndPort(id string, port int) pods.Manifest {
 func assignManifestsToNodes(
 	podID types.PodID,
 	nodes map[types.NodeName]bool,
-	pods map[kptest.FakePodStoreKey]pods.Manifest,
-	ifCurrent, ifNotCurrent pods.Manifest,
+	pods map[kptest.FakePodStoreKey]manifest.Manifest,
+	ifCurrent, ifNotCurrent manifest.Manifest,
 ) {
 	for node, current := range nodes {
 		key := kptest.FakePodStoreKeyFor(kp.REALITY_TREE, node, podID)
@@ -376,7 +376,7 @@ func assignManifestsToNodes(
 func createRC(
 	rcs rcstore.Store,
 	applicator labels.Applicator,
-	manifest pods.Manifest,
+	manifest manifest.Manifest,
 	desired int,
 	nodes map[types.NodeName]bool,
 ) (rc_fields.RC, error) {
@@ -400,13 +400,13 @@ func updateWithHealth(t *testing.T,
 	desiredOld, desiredNew int,
 	oldNodes, newNodes map[types.NodeName]bool,
 	checks map[types.NodeName]health.Result,
-) (update, pods.Manifest, pods.Manifest) {
+) (update, manifest.Manifest, manifest.Manifest) {
 	podID := "mypod"
 
 	oldManifest := podWithIDAndPort(podID, 9001)
 	newManifest := podWithIDAndPort(podID, 9002)
 
-	podMap := map[kptest.FakePodStoreKey]pods.Manifest{}
+	podMap := map[kptest.FakePodStoreKey]manifest.Manifest{}
 	assignManifestsToNodes(types.PodID(podID), oldNodes, podMap, oldManifest, newManifest)
 	assignManifestsToNodes(types.PodID(podID), newNodes, podMap, newManifest, oldManifest)
 	kps := kptest.NewFakePodStore(podMap, nil)
@@ -784,7 +784,7 @@ func failOnError(t *testing.T, desc string, errs <-chan error) {
 }
 
 // Transfers the named node from the old RC to the new RC
-func transferNode(node types.NodeName, manifest pods.Manifest, upd update) error {
+func transferNode(node types.NodeName, manifest manifest.Manifest, upd update) error {
 	if _, err := upd.kps.SetPod(kp.REALITY_TREE, node, manifest); err != nil {
 		return err
 	}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -4,7 +4,7 @@ import (
 	klabels "k8s.io/kubernetes/pkg/labels"
 
 	"github.com/square/p2/pkg/labels"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/types"
 )
 
@@ -12,7 +12,7 @@ import (
 // It potentially takes into account considerations such as existing load on the nodes,
 // label selectors, and more.
 type Scheduler interface {
-	EligibleNodes(pods.Manifest, klabels.Selector) ([]types.NodeName, error)
+	EligibleNodes(manifest.Manifest, klabels.Selector) ([]types.NodeName, error)
 }
 
 type applicatorScheduler struct {
@@ -25,7 +25,7 @@ func NewApplicatorScheduler(applicator labels.Applicator) *applicatorScheduler {
 	return &applicatorScheduler{applicator: applicator}
 }
 
-func (sel *applicatorScheduler) EligibleNodes(_ pods.Manifest, selector klabels.Selector) ([]types.NodeName, error) {
+func (sel *applicatorScheduler) EligibleNodes(_ manifest.Manifest, selector klabels.Selector) ([]types.NodeName, error) {
 	nodes, err := sel.applicator.GetMatches(selector, labels.NODE)
 	if err != nil {
 		return nil, err

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -4,8 +4,6 @@
 package types
 
 import (
-	"github.com/square/p2/pkg/cgroups"
-
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
@@ -68,28 +66,4 @@ func (n NodeSet) Equal(other NodeSet) bool {
 func (n NodeSet) PopAny() (NodeName, bool) {
 	node, ok := n.String.PopAny()
 	return NodeName(node), ok
-}
-
-type LaunchableVersion struct {
-	ID   string            `yaml:"id"`
-	Tags map[string]string `yaml:"tags"`
-}
-
-type LaunchableStanza struct {
-	LaunchableType          string            `yaml:"launchable_type"`
-	LaunchableId            string            `yaml:"launchable_id"`
-	DigestLocation          string            `yaml:"digest_location,omitempty"`
-	DigestSignatureLocation string            `yaml:"digest_signature_location,omitempty"`
-	RestartTimeout          string            `yaml:"restart_timeout,omitempty"`
-	CgroupConfig            cgroups.Config    `yaml:"cgroup,omitempty"`
-	Env                     map[string]string `yaml:"env,omitempty"`
-
-	// The URL from which the launchable can be downloaded. May not be used
-	// in conjunction with Version
-	Location string `yaml:"location"`
-
-	// An alternative to using Location to inform artifact downloading. Version information
-	// can be used to query a configured artifact registry which will provide the artifact
-	// URL. Version may not be used in conjunction with Location
-	Version LaunchableVersion `yaml:"version,omitempty"`
 }

--- a/pkg/watch/health.go
+++ b/pkg/watch/health.go
@@ -9,7 +9,7 @@ import (
 	"github.com/square/p2/pkg/health"
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/logging"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/preparer"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util/param"
@@ -35,7 +35,7 @@ var HEALTHCHECK_TIMEOUT = param.Int64("healthcheck_timeout", 5)
 // tree, and a bool that indicates whether or not the pod
 // has a running MonitorHealth go routine
 type PodWatch struct {
-	manifest      pods.Manifest
+	manifest      manifest.Manifest
 	updater       kp.HealthUpdater
 	statusChecker StatusChecker
 

--- a/pkg/watch/health_test.go
+++ b/pkg/watch/health_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/square/p2/pkg/health"
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/logging"
-	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/types"
 )
 
@@ -143,7 +143,7 @@ func newWatch(id types.PodID) *PodWatch {
 }
 
 func newManifestResult(id types.PodID) kp.ManifestResult {
-	builder := pods.NewManifestBuilder()
+	builder := manifest.NewManifestBuilder()
 	builder.SetID(id)
 	builder.SetStatusPort(1) // StatusPort must != 0 for updatePods to use it
 	return kp.ManifestResult{

--- a/pkg/watch/health_test.go
+++ b/pkg/watch/health_test.go
@@ -143,7 +143,7 @@ func newWatch(id types.PodID) *PodWatch {
 }
 
 func newManifestResult(id types.PodID) kp.ManifestResult {
-	builder := manifest.NewManifestBuilder()
+	builder := manifest.NewBuilder()
 	builder.SetID(id)
 	builder.SetStatusPort(1) // StatusPort must != 0 for updatePods to use it
 	return kp.ManifestResult{


### PR DESCRIPTION
This change allows the LaunchableStanza type to move out of the
pkg/types package which is a dumping ground for commonly imported types
that result in import cycles when in a more "logical" location.

The immediate motivation was the Pod type (in pkg/pods) having a
reference to the pkg/auth (ArtifactVerifier) type, and the artifact
verifier type having a reference to pkg/pods.LaunchableStanza, resulting
in it moving to the types package.