### PR TITLE
Support launchables with locations that don't match typical format

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -282,7 +282,11 @@ func (hl *Launchable) Install(downloader artifact.Downloader) error {
 // version is derived from the location, using the naming scheme
 // <the-app>_<unique-version-string>.tar.gz
 func (hl *Launchable) Name() string {
-	return fmt.Sprintf("%s_%s", hl.Id, hl.Version)
+	name := hl.Id
+	if hl.Version != "" {
+		name = name + "_" + hl.Version
+	}
+	return name
 }
 
 func (*Launchable) Type() string {

--- a/pkg/hoist/hoist_launchable_test.go
+++ b/pkg/hoist/hoist_launchable_test.go
@@ -84,6 +84,24 @@ func TestInstallDir(t *testing.T) {
 	Assert(t).AreEqual(installDir, expectedDir, "Install dir did not have expected value")
 }
 
+func TestInstallDirNoVersion(t *testing.T) {
+	tempDir := os.TempDir()
+
+	launchable := &Launchable{
+		Id:        "testLaunchable",
+		Version:   "",
+		ServiceId: "testPod__testLaunchable",
+		RunAs:     "testuser",
+		PodEnvDir: tempDir,
+		RootDir:   tempDir,
+	}
+
+	installDir := launchable.InstallDir()
+
+	expectedDir := path.Join(tempDir, "installs", "testLaunchable")
+	Assert(t).AreEqual(installDir, expectedDir, "Install dir did not have expected value")
+}
+
 func TestMultipleExecutables(t *testing.T) {
 	fakeLaunchable, sb := FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
 	defer CleanupFakeLaunchable(fakeLaunchable, sb)

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -663,14 +663,14 @@ func (pod *Pod) getLaunchable(launchableStanza manifest.LaunchableStanza, runAsU
 		return nil, err
 	}
 
-	// The path of a launchable URL is expected to end with
-	// /<launchable_id>_<version>.tar.gz. The launchable needs the
-	// <version> currently, which we parse from the URL. Future work is
-	// planned to implement more explicit versions specified in the
-	// manifest.LaunchableStanza in the pod manifest
+	// The path of a launchable URL is generally expected to end with
+	// <launchable_id>_<version>.tar.gz. The version is useful for
+	// namespacing the install directory of the launchable. For
+	// launchables that do not fit this naming convention, we simply
+	// use the launchable ID as the directory and leave version blank
 	version, err := versionFromLocation(locationURL)
 	if err != nil {
-		return nil, err
+		pod.logger.WithError(err).Warnf("Could not parse version from launchable %s.", launchableStanza.LaunchableId)
 	}
 
 	if launchableStanza.LaunchableType == "hoist" {

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -54,11 +54,29 @@ func TestGetLaunchable(t *testing.T) {
 		l, _ := pod.getLaunchable(stanza, "foouser", runit.RestartPolicyAlways)
 		launchable := l.(hoist.LaunchAdapter).Launchable
 		Assert(t).AreEqual("app", launchable.Id, "Launchable Id did not have expected value")
+		Assert(t).AreEqual("def456", launchable.Version, "Launchable version did not have expected value")
 		Assert(t).AreEqual("hello__app", launchable.ServiceId, "Launchable ServiceId did not have expected value")
 		Assert(t).AreEqual("foouser", launchable.RunAs, "Launchable run as did not have expected username")
 		Assert(t).IsTrue(launchable.ExecNoLimit, "GetLaunchable() should always set ExecNoLimit to true for hoist launchables")
 		Assert(t).AreEqual(launchable.RestartPolicy, runit.RestartPolicyAlways, "Default RestartPolicy for a launchable should be 'always'")
 	}
+}
+
+func TestGetLaunchableNoVersion(t *testing.T) {
+	launchableStanza := manifest.LaunchableStanza{
+		LaunchableId:   "somelaunchable",
+		Location:       "https://server.com/somelaunchable", // note this doesn't have a version identifier
+		LaunchableType: "hoist",
+	}
+	pod := getTestPod()
+	l, _ := pod.getLaunchable(launchableStanza, "foouser", runit.RestartPolicyAlways)
+	launchable := l.(hoist.LaunchAdapter).Launchable
+	Assert(t).AreEqual("somelaunchable", launchable.Id, "Launchable Id did not have expected value")
+	Assert(t).AreEqual("", launchable.Version, "Launchable version did not have expected value")
+	Assert(t).AreEqual("hello__somelaunchable", launchable.ServiceId, "Launchable ServiceId did not have expected value")
+	Assert(t).AreEqual("foouser", launchable.RunAs, "Launchable run as did not have expected username")
+	Assert(t).IsTrue(launchable.ExecNoLimit, "GetLaunchable() should always set ExecNoLimit to true for hoist launchables")
+	Assert(t).AreEqual(launchable.RestartPolicy, runit.RestartPolicyAlways, "Default RestartPolicy for a launchable should be 'always'")
 }
 
 func TestPodCanWriteEnvFile(t *testing.T) {


### PR DESCRIPTION
Normally we expect a launchable to have a location URI whose base is of
the form <launchable_id>_<version>.tar.gz. Prior to this commit, errors
would occur during artifact installation if the location did not match
these scheme, since no version can be parsed out of the location.

This commit simply logs a warning if this occurs, but otherwise will
proceed without the version information for backwards compatibility with
launchables that don't fit the format.

Version is primarily used to determine the name of the directory the
launchable will be installed in, using <launchable_id>_<version>. If
version is blank, the directory will just be <launchable_id>. This means
that launchables that do not have version information in their location
will fail to install new updates as the preparer will think it is
already installed.