### PR TITLE
Fix misleading log message in RU

### DIFF
--- a/pkg/roll/run_update.go
+++ b/pkg/roll/run_update.go
@@ -120,7 +120,7 @@ func (u *update) Run(quit <-chan struct{}) (ret bool) {
 		func() error { return u.lockRCs(quit) },
 		quit,
 		u.logger,
-		"Could not lock update",
+		"Could not lock rcs",
 	) {
 		return
 	}


### PR DESCRIPTION
The message was "could not lock update", when in reality it is the
replication controller lock failure that is causing the message. This
commit changes that to "could not lock rcs"