### PR TITLE
Adds convenience functions for marshaling RC and PC types as JSON

### DIFF
--- a/pkg/pc/fields/fields.go
+++ b/pkg/pc/fields/fields.go
@@ -103,19 +103,24 @@ type RawPodCluster struct {
 // there. Since we don't own labels.Selector, we have to implement the json
 // marshaling here to wrap around the interface value
 func (pc PodCluster) MarshalJSON() ([]byte, error) {
+	return json.Marshal(pc.ToRaw())
+}
+
+// Converts a pod cluster to a type that will marshal cleanly to JSON.
+func (pc PodCluster) ToRaw() RawPodCluster {
 	var podSel string
 	if pc.PodSelector != nil {
 		podSel = pc.PodSelector.String()
 	}
 
-	return json.Marshal(RawPodCluster{
+	return RawPodCluster{
 		ID:               pc.ID,
 		PodID:            pc.PodID,
 		AvailabilityZone: pc.AvailabilityZone,
 		Name:             pc.Name,
 		PodSelector:      podSel,
 		Annotations:      pc.Annotations,
-	})
+	}
 }
 
 var _ json.Marshaler = PodCluster{}

--- a/pkg/rc/fields/fields.go
+++ b/pkg/rc/fields/fields.go
@@ -60,12 +60,22 @@ type RawRC struct {
 // we own manifest.Manifest, but we don't own labels.Selector, so we have to
 // implement the json marshaling here to wrap around the interface values
 func (rc RC) MarshalJSON() ([]byte, error) {
+	rawRC, err := rc.ToRaw()
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(rawRC)
+}
+
+// Converts an RC to a type that will marshal cleanly as JSON
+func (rc RC) ToRaw() (RawRC, error) {
 	var manifest []byte
 	var err error
 	if rc.Manifest != nil {
 		manifest, err = rc.Manifest.Marshal()
 		if err != nil {
-			return nil, err
+			return RawRC{}, err
 		}
 	}
 
@@ -74,14 +84,14 @@ func (rc RC) MarshalJSON() ([]byte, error) {
 		nodeSel = rc.NodeSelector.String()
 	}
 
-	return json.Marshal(RawRC{
+	return RawRC{
 		ID:              rc.ID,
 		Manifest:        string(manifest),
 		NodeSelector:    nodeSel,
 		PodLabels:       rc.PodLabels,
 		ReplicasDesired: rc.ReplicasDesired,
 		Disabled:        rc.Disabled,
-	})
+	}, nil
 }
 
 var _ json.Marshaler = RC{}


### PR DESCRIPTION
Due to the fact that the RC and PC structs contain custom types that do
not marshal to JSON automatically, representing them as JSON involves
going through an intermediary type named RawRC and RawPC, respectively.
This commit adds convenience functions for converting an RC or PC to the
corresponding json-friendly type.