### PR TITLE
Add a configurable "pause" time duration to consulutil.WatchPrefix

### DIFF
--- a/pkg/health/checker/checker.go
+++ b/pkg/health/checker/checker.go
@@ -150,7 +150,7 @@ func (c consulHealthChecker) WatchHealth(
 	// closed by watchPrefix when we close quitWatch
 	inCh := make(chan api.KVPairs)
 	watchErrCh := make(chan error)
-	go consulutil.WatchPrefix("health/", c.kv, inCh, quitCh, watchErrCh)
+	go consulutil.WatchPrefix("health/", c.kv, inCh, quitCh, watchErrCh, 0)
 	publishErrCh := publishLatestHealth(inCh, quitCh, resultCh)
 
 	for {

--- a/pkg/kp/consulutil/watch_test.go
+++ b/pkg/kp/consulutil/watch_test.go
@@ -166,7 +166,7 @@ func TestWatchPrefix(t *testing.T) {
 
 	// Process existing data
 	f.Client.KV().Put(kv1a, nil)
-	go WatchPrefix("prefix/", f.Client.KV(), pairsChan, done, testLogger(t))
+	go WatchPrefix("prefix/", f.Client.KV(), pairsChan, done, testLogger(t), 0)
 	pairs := kvToMap(<-pairsChan)
 	if !kvMatch(pairs, kv1a) {
 		t.Error("existing data not recognized")

--- a/pkg/kp/kv.go
+++ b/pkg/kp/kv.go
@@ -348,7 +348,7 @@ func (c consulStore) WatchPods(
 	}
 
 	kvPairsChan := make(chan api.KVPairs)
-	go consulutil.WatchPrefix(keyPrefix, c.client.KV(), kvPairsChan, quitChan, errChan)
+	go consulutil.WatchPrefix(keyPrefix, c.client.KV(), kvPairsChan, quitChan, errChan, 0)
 	for kvPairs := range kvPairsChan {
 		manifests := make([]ManifestResult, 0, len(kvPairs))
 		for _, pair := range kvPairs {

--- a/pkg/kp/pcstore/consul_store.go
+++ b/pkg/kp/pcstore/consul_store.go
@@ -302,7 +302,7 @@ func (s *consulStore) Watch(quit <-chan struct{}) <-chan WatchedPodClusters {
 	outCh := make(chan WatchedPodClusters)
 	errChan := make(chan error, 1)
 
-	go consulutil.WatchPrefix(podClusterTree, s.kv, inCh, quit, errChan)
+	go consulutil.WatchPrefix(podClusterTree, s.kv, inCh, quit, errChan, 0)
 
 	go func() {
 		var kvp api.KVPairs

--- a/pkg/kp/rcstore/consul_store.go
+++ b/pkg/kp/rcstore/consul_store.go
@@ -184,7 +184,7 @@ func (s *consulStore) WatchNew(quit <-chan struct{}) (<-chan []fields.RC, <-chan
 	inCh := make(chan api.KVPairs)
 
 	outCh, errCh := publishLatestRCs(inCh, quit)
-	go consulutil.WatchPrefix(rcTree+"/", s.kv, inCh, quit, errCh)
+	go consulutil.WatchPrefix(rcTree+"/", s.kv, inCh, quit, errCh, 0)
 
 	return outCh, errCh
 }
@@ -214,7 +214,7 @@ func (s *consulStore) WatchNewWithRCLockInfo(quit <-chan struct{}) (<-chan []RCL
 	combinedErrCh := make(chan error)
 
 	rcCh, rcErrCh := publishLatestRCs(inCh, quit)
-	go consulutil.WatchPrefix(rcTree+"/", s.kv, inCh, quit, rcErrCh)
+	go consulutil.WatchPrefix(rcTree+"/", s.kv, inCh, quit, rcErrCh, 0)
 
 	// Process RC updates and augment them with lock information
 	outCh, lockInfoErrCh := s.publishLatestRCsWithLockInfo(rcCh, quit)

--- a/pkg/kp/rollstore/consul_store.go
+++ b/pkg/kp/rollstore/consul_store.go
@@ -528,7 +528,7 @@ func (s consulStore) Watch(quit <-chan struct{}) (<-chan []roll_fields.Update, <
 	inCh := make(chan api.KVPairs)
 
 	outCh, errCh := publishLatestRolls(inCh, quit)
-	go consulutil.WatchPrefix(rollTree+"/", s.kv, inCh, quit, errCh)
+	go consulutil.WatchPrefix(rollTree+"/", s.kv, inCh, quit, errCh, 0)
 
 	return outCh, errCh
 }

--- a/pkg/labels/consul_aggregator.go
+++ b/pkg/labels/consul_aggregator.go
@@ -171,7 +171,7 @@ func (c *consulAggregator) Aggregate() {
 	outPairs := make(chan api.KVPairs)
 	done := make(chan struct{})
 	outErrors := make(chan error)
-	go consulutil.WatchPrefix(c.path+"/", c.kv, outPairs, done, outErrors)
+	go consulutil.WatchPrefix(c.path+"/", c.kv, outPairs, done, outErrors, 0)
 	for {
 		missedSends := 0
 		loopTime := time.After(c.aggregationRate)


### PR DESCRIPTION
The pause signifies the amount of time to wait after the consul server
returns a watch result. Clients that can tolerate a high degree of
staleness of returned data can specify a large pause interval to reduce
QPS on the consul store. This is still preferable to polling because the
client can remain responsive when data turnover is slow, but can
significantly reduce QPS if data turnover is high.