### PR TITLE
Make version detection from location URL stricter

### DIFF
--- a/pkg/pods/test_manifest.yaml
+++ b/pkg/pods/test_manifest.yaml
@@ -11,7 +11,7 @@ launchables:
   app:
     launchable_type: hoist
     launchable_id: app
-    location: hoisted-hello_def456.tar.gz
+    location: hoisted-hello_3c021aff048ca8117593f9c71e03b87cf72fd440.tar.gz
 
 config:
   # is written to a file and passed as CONFIG_FILE to the process


### PR DESCRIPTION
Prior to this commit, the version detection code would do so incorrectly
on some artifact names. Now the regex enforces that the version is
a 40 character hexadecimal string with an optional hyphenated suffix.

This resulted in some bad install directory names. For example, a
launchable with id "foo_launchable.tar.gz" would be installed in a
directory named "foo_launchable_launchable/" because the launchable ID
was concatenated with the supposed version "launchable". The desired
behavior would have been for versionFromLocation() to return an error
and the ID of "foo_launchable" alone would be used to determine the
directory name.