### PR TITLE
Modify watch labels diff to notice the initial state

### DIFF
--- a/pkg/labels/consul_applicator.go
+++ b/pkg/labels/consul_applicator.go
@@ -273,28 +273,7 @@ func watchDiffLabels(inCh <-chan []Labeled, quitCh <-chan struct{}, logger loggi
 
 	go func() {
 		defer close(outCh)
-
-		var labelsList []Labeled
-
-		select {
-		case <-quitCh:
-			return
-		case val, ok := <-inCh:
-			if !ok {
-				// channel closed
-				return
-			}
-			labelsList = val
-			if labelsList == nil {
-				logger.Errorf("Unexpected nil value received from channel")
-				return
-			}
-		}
-
 		oldLabels := make(map[string]Labeled)
-		for _, labeled := range labelsList {
-			oldLabels[labeled.ID] = labeled
-		}
 
 		for {
 			var results []Labeled
@@ -307,10 +286,6 @@ func watchDiffLabels(inCh <-chan []Labeled, quitCh <-chan struct{}, logger loggi
 					return
 				}
 				results = val
-				if results == nil {
-					logger.Errorf("Unexpected nil value received from watchDiffLabels channel")
-					return
-				}
 			}
 
 			newLabels := make(map[string]Labeled)


### PR DESCRIPTION
Modify labels to notice the initial state of the labels store
    
Also removed an unnecessary nil value check on the values because  a check for the closed channel is already made


How this notices the intial state of the labels store is that by not
taking the initial state, the diff loop will believe that any initial
labels in the store are created and they will be signalled