### PR TITLE
cgroups: Allow hierarchical names

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -90,7 +90,7 @@ func (subsys Subsystems) SetCPU(name string, cpus int) error {
 		quota = -1
 	}
 
-	err := os.Mkdir(filepath.Join(subsys.CPU, name), 0755)
+	err := os.MkdirAll(filepath.Join(subsys.CPU, name), 0755)
 	if err != nil && !os.IsExist(err) {
 		return err
 	}
@@ -134,7 +134,7 @@ func (subsys Subsystems) SetMemory(name string, bytes int) error {
 		hardLimit = -1
 	}
 
-	err := os.Mkdir(filepath.Join(subsys.Memory, name), 0755)
+	err := os.MkdirAll(filepath.Join(subsys.Memory, name), 0755)
 	if err != nil && !os.IsExist(err) {
 		return err
 	}


### PR DESCRIPTION
Add support for hierarchical cgroups to be created by including the "/"
character in a cgroup's name when passed to p2-exec.