### PR TITLE
Restore the Installed() check before installing a launchable

### DIFF
--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -404,6 +404,10 @@ func (pod *Pod) Install(manifest manifest.Manifest, verifier auth.ArtifactVerifi
 			return err
 		}
 
+		if launchable.Installed() {
+			continue
+		}
+
 		launchableURL, verificationData, err := artifactRegistry.LocationDataForLaunchable(launchableID, stanza)
 		if err != nil {
 			pod.logLaunchableError(launchable.ServiceID(), err, "Unable to install launchable")


### PR DESCRIPTION
Prior to commit f6635afd588c9a3d79e137565166f0cc8a399a66, each
launchable type would check exit the Install() function early if the
launchable was already installed. When this code was moved to the pods
package, the behavior was not preserved, and installation is always
attempted which would result in errors due to files already being
present.

These errors would result in the whole install directory being deleted
and the installation being reattempted, at which point it would succeed.