### PR TITLE
Change scheduling to labelling in daemon set

### DIFF
--- a/pkg/ds/daemon_set.go
+++ b/pkg/ds/daemon_set.go
@@ -375,7 +375,7 @@ func (ds *daemonSet) clearPods() error {
 }
 
 func (ds *daemonSet) labelPod(node types.NodeName) error {
-	ds.logger.NoFields().Infof("Scheduling '%v' in node '%v' with daemon set uuid '%v'", ds.Manifest.ID(), node, ds.ID())
+	ds.logger.NoFields().Infof("Labelling '%v' in node '%v' with daemon set uuid '%v'", ds.Manifest.ID(), node, ds.ID())
 
 	// Will apply the following label on the key <labels.POD>/<node>/<ds.Manifest.ID()>:
 	// 	{ DSIDLabel : ds.ID() }


### PR DESCRIPTION
This is because it is not actually scheduling pods yet but rather
labelling them, this will reduce confusion in the log messages.