### PR TITLE
Replication bugfixes and logging

### DIFF
--- a/pkg/ds/daemon_set.go
+++ b/pkg/ds/daemon_set.go
@@ -305,7 +305,7 @@ func (ds *daemonSet) addPods() error {
 		}
 	}
 
-	if len(toScheduleSorted) > 0 {
+	if len(currentNodes) > 0 {
 		return ds.PublishToReplication()
 	}
 
@@ -340,7 +340,7 @@ func (ds *daemonSet) removePods() error {
 		}
 	}
 
-	if len(podLocations)-len(toUnscheduleSorted) > 0 {
+	if len(currentNodes) > 0 {
 		return ds.PublishToReplication()
 	}
 
@@ -449,6 +449,7 @@ func (ds *daemonSet) PublishToReplication() error {
 	)
 	if err != nil {
 		ds.logger.Errorf("Could not initialize replicator: %s", err)
+		return err
 	}
 
 	ds.logger.Info("New replicator was made")

--- a/pkg/ds/daemon_set.go
+++ b/pkg/ds/daemon_set.go
@@ -184,6 +184,7 @@ func (ds *daemonSet) WatchDesires(
 				ds.DaemonSet = *newDS
 
 				if ds.Disabled {
+					ds.CancelReplication()
 					continue
 				}
 				err := ds.removePods()

--- a/pkg/ds/daemon_set.go
+++ b/pkg/ds/daemon_set.go
@@ -297,7 +297,7 @@ func (ds *daemonSet) addPods() error {
 	// Get the difference in nodes that we need to schedule on and then sort them
 	// for deterministic ordering
 	toScheduleSorted := types.NewNodeSet(eligible...).Difference(types.NewNodeSet(currentNodes...)).ListNodes()
-	ds.logger.NoFields().Infof("Need to schedule %d nodes", len(toScheduleSorted))
+	ds.logger.NoFields().Infof("Need to label %d nodes", len(toScheduleSorted))
 
 	for _, node := range toScheduleSorted {
 		err := ds.labelPod(node)
@@ -306,6 +306,7 @@ func (ds *daemonSet) addPods() error {
 		}
 	}
 
+	ds.logger.Infof("Need to schedule %v nodes", len(currentNodes))
 	if len(currentNodes) > 0 {
 		return ds.PublishToReplication()
 	}
@@ -341,6 +342,7 @@ func (ds *daemonSet) removePods() error {
 		}
 	}
 
+	ds.logger.Infof("Need to schedule %v nodes", len(currentNodes))
 	if len(currentNodes) > 0 {
 		return ds.PublishToReplication()
 	}
@@ -494,6 +496,7 @@ func (ds *daemonSet) CancelReplication() {
 
 	if ds.currentReplication != nil {
 		ds.currentReplication.Cancel()
+		ds.logger.Info("Replication cancelled")
 		ds.currentReplication = nil
 	}
 }


### PR DESCRIPTION
This is mainly for fixing some bugs with how locks are handled in the farm.
There is also a fix to cancel the replication when a daemon set is disabled.
There are also additional logging and removing an unnecessary check for whether a daemon set is in the map or not.
This also includes a change in the fake dsstore to imitate the real dsstore's locking mechanism.