### PR TITLE
Mask *api.Client behind a ConsulClient interface in stores

### DIFF
--- a/bin/p2-rctl/main.go
+++ b/bin/p2-rctl/main.go
@@ -176,7 +176,7 @@ func SessionName() string {
 // and terminates the program on failure
 type rctlParams struct {
 	httpClient *http.Client
-	baseClient *api.Client
+	baseClient consulutil.ConsulClient
 	rcs        rcstore.Store
 	rls        rollstore.Store
 	sched      scheduler.Scheduler

--- a/bin/p2-rm/main.go
+++ b/bin/p2-rm/main.go
@@ -7,10 +7,10 @@ import (
 	"os/user"
 	"path"
 
-	"github.com/hashicorp/consul/api"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/kp/flags"
 	"github.com/square/p2/pkg/kp/rcstore"
 	"github.com/square/p2/pkg/labels"
@@ -31,7 +31,7 @@ var (
 type P2RM struct {
 	Store   kp.Store
 	RCStore rcstore.Store
-	Client  *api.Client
+	Client  consulutil.ConsulClient
 	Labeler labels.Applicator
 
 	LabelID  string
@@ -41,7 +41,7 @@ type P2RM struct {
 
 // NewP2RM is a constructor for the P2RM type. It will generate the necessary
 // storage types based on its api.Client argument
-func NewP2RM(client *api.Client, podName string, nodeName types.NodeName) *P2RM {
+func NewP2RM(client consulutil.ConsulClient, podName string, nodeName types.NodeName) *P2RM {
 	rm := &P2RM{}
 	rm.Client = client
 	rm.Store = kp.NewConsulStore(client)

--- a/bin/p2-watch/main.go
+++ b/bin/p2-watch/main.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/kp/flags"
 	"github.com/square/p2/pkg/kp/pcstore"
 	"github.com/square/p2/pkg/labels"
@@ -16,7 +17,6 @@ import (
 	"github.com/square/p2/pkg/types"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/hashicorp/consul/api"
 	"github.com/square/p2/pkg/version"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
@@ -104,7 +104,7 @@ func (p *printSyncer) Type() pcstore.ConcreteSyncerType {
 	return "print_syncer"
 }
 
-func watchPodClusters(client *api.Client) {
+func watchPodClusters(client consulutil.ConsulClient) {
 	logger := &logging.DefaultLogger
 	logger.Infoln("Beginning pod cluster watch")
 

--- a/pkg/health/checker/checker.go
+++ b/pkg/health/checker/checker.go
@@ -44,7 +44,7 @@ type healthKV interface {
 }
 
 type consulHealthChecker struct {
-	client      *api.Client
+	client      consulutil.ConsulClient
 	kv          healthKV
 	consulStore healthStore
 }
@@ -52,7 +52,7 @@ type consulHealth interface {
 	Node(types.NodeName, *api.QueryOptions) ([]*api.HealthCheck, *api.QueryMeta, error)
 }
 
-func NewConsulHealthChecker(client *api.Client) ConsulHealthChecker {
+func NewConsulHealthChecker(client consulutil.ConsulClient) ConsulHealthChecker {
 	return consulHealthChecker{
 		client:      client,
 		kv:          client.KV(),

--- a/pkg/kp/config.go
+++ b/pkg/kp/config.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/square/p2/pkg/kp/consulutil"
+
 	"github.com/hashicorp/consul/api"
 )
 
@@ -24,7 +26,7 @@ type Options struct {
 	WaitTime time.Duration
 }
 
-func NewConsulClient(opts Options) *api.Client {
+func NewConsulClient(opts Options) consulutil.ConsulClient {
 	conf := api.DefaultConfig()
 	if opts.Address != "" {
 		conf.Address = opts.Address
@@ -41,6 +43,6 @@ func NewConsulClient(opts Options) *api.Client {
 	}
 
 	// error is always nil
-	ret, _ := api.NewClient(conf)
-	return ret
+	client, _ := api.NewClient(conf)
+	return consulutil.ConsulClientFromRaw(client)
 }

--- a/pkg/kp/consulutil/clients.go
+++ b/pkg/kp/consulutil/clients.go
@@ -1,0 +1,58 @@
+package consulutil
+
+import (
+	"github.com/hashicorp/consul/api"
+)
+
+// Wrapper interface that allows retrieval of the underlying interfaces.
+type ConsulClient interface {
+	KV() ConsulKVClient
+	Session() ConsulSessionClient
+}
+
+// Interface representing the functionality of the api.KV struct returned by
+// calling KV() on an *api.Client. This is useful for swapping in KV
+// implementations for tests for example
+type ConsulKVClient interface {
+	Get(key string, q *api.QueryOptions) (*api.KVPair, *api.QueryMeta, error)
+	Delete(key string, w *api.WriteOptions) (*api.WriteMeta, error)
+	Put(pair *api.KVPair, w *api.WriteOptions) (*api.WriteMeta, error)
+	List(prefix string, q *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error)
+	Acquire(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error)
+	CAS(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error)
+	DeleteCAS(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error)
+}
+
+// Specifies the functionality provided by the *api.Session struct for managing
+// consul sessions. This is useful for swapping in session client
+// implementations in tests
+type ConsulSessionClient interface {
+	CreateNoChecks(*api.SessionEntry, *api.WriteOptions) (string, *api.WriteMeta, error)
+	Destroy(string, *api.WriteOptions) (*api.WriteMeta, error)
+	Renew(id string, q *api.WriteOptions) (*api.SessionEntry, *api.WriteMeta, error)
+	RenewPeriodic(initialTTL string, id string, q *api.WriteOptions, doneCh chan struct{}) error
+	Info(id string, q *api.QueryOptions) (*api.SessionEntry, *api.QueryMeta, error)
+}
+
+// Sadly, *api.Client does not implement the ConsulClient interface because the
+// return types of KV() and Session() don't match exactly, e.g. KV() returns an
+// *api.KV not a ConsulKVCLient, even though *api.KV implements ConsulKVClient.
+// This function wraps an *api.Client into something that implements
+// ConsulClient.
+func ConsulClientFromRaw(client *api.Client) ConsulClient {
+	return consulClientWrapper{
+		rawClient: client,
+	}
+}
+
+type consulClientWrapper struct {
+	rawClient *api.Client
+}
+
+func (c consulClientWrapper) KV() ConsulKVClient {
+	return c.rawClient.KV()
+}
+
+func (c consulClientWrapper) Session() ConsulSessionClient {
+	return c.rawClient.Session()
+}

--- a/pkg/kp/consulutil/consultest.go
+++ b/pkg/kp/consulutil/consultest.go
@@ -1,7 +1,9 @@
-// The consultest package contains common routines for setting up a live Consul server for
-// use in unit tests. The server runs within the test process and uses an isolated
-// in-memory data store.
-package consultest
+// package consulutil contains common routines for setting up a live Consul
+// server for use in unit tests. The server runs within the test process and
+// uses an isolated in-memory data store.
+// This functionality is not currently recommended for use due to data
+/// races present in the github.com/hashicorp/consul/testutil package.
+package consulutil
 
 import (
 	"fmt"
@@ -22,7 +24,7 @@ import (
 type Fixture struct {
 	Agent    *agent.Agent
 	Servers  []*agent.HTTPServer
-	Client   *api.Client
+	Client   ConsulClient
 	T        *testing.T
 	HTTPPort int
 }
@@ -90,13 +92,14 @@ func NewFixture(t *testing.T) Fixture {
 		t.Fatal("creating Consul client:", err)
 	}
 
+	consulClient := ConsulClientFromRaw(client)
 	testutil.WaitForLeader(t, a.RPC, config.Datacenter)
 
 	t.Log("starting Consul server with port:", config.Ports.HTTP)
 	return Fixture{
 		Agent:    a,
 		Servers:  servers,
-		Client:   client,
+		Client:   consulClient,
 		T:        t,
 		HTTPPort: config.Ports.HTTP,
 	}

--- a/pkg/kp/consulutil/session.go
+++ b/pkg/kp/consulutil/session.go
@@ -99,7 +99,7 @@ type unlocker struct {
 // Wraps a consul client and consul session, and provides coordination for
 // renewals and errors
 type Session struct {
-	client  *api.Client
+	client  ConsulClient
 	session string
 	name    string
 
@@ -115,7 +115,7 @@ type Session struct {
 	renewalCh <-chan time.Time
 }
 
-func NewManagedSession(client *api.Client, session string, name string, quitCh chan struct{}, renewalErrCh chan error, renewalCh <-chan time.Time) *Session {
+func NewManagedSession(client ConsulClient, session string, name string, quitCh chan struct{}, renewalErrCh chan error, renewalCh <-chan time.Time) *Session {
 	sess := &Session{
 		client:       client,
 		session:      session,
@@ -133,7 +133,7 @@ func NewManagedSession(client *api.Client, session string, name string, quitCh c
 // Creates a Session struct using an existing consul session, and does
 // not set up auto-renewal. Use this constructor when the underlying session
 // already exists and should not be managed here.
-func NewUnmanagedSession(client *api.Client, session, name string) Session {
+func NewUnmanagedSession(client ConsulClient, session, name string) Session {
 	return Session{
 		client:  client,
 		session: session,

--- a/pkg/kp/consulutil/session_controller.go
+++ b/pkg/kp/consulutil/session_controller.go
@@ -29,7 +29,7 @@ var SessionRetrySeconds = param.Int("session_retry_seconds", 5)
 //   logger:  Errors will be logged to this logger.
 func SessionManager(
 	config api.SessionEntry,
-	client *api.Client,
+	client ConsulClient,
 	output chan<- string,
 	done chan struct{},
 	logger logging.Logger,

--- a/pkg/kp/consulutil/session_controller_test.go
+++ b/pkg/kp/consulutil/session_controller_test.go
@@ -7,14 +7,13 @@ import (
 
 	"github.com/hashicorp/consul/api"
 
-	"github.com/square/p2/pkg/consultest"
 	"github.com/square/p2/pkg/logging"
 )
 
 // A basic test of the ConsulSessionManager: create a session, then quit.
 func TestSessionBasics(t *testing.T) {
 	t.Parallel()
-	f := consultest.NewFixture(t)
+	f := NewFixture(t)
 	defer f.Stop()
 
 	sessions := make(chan string)

--- a/pkg/kp/consulutil/watch_test.go
+++ b/pkg/kp/consulutil/watch_test.go
@@ -8,8 +8,6 @@ import (
 
 	. "github.com/anthonybishopric/gotcha"
 	"github.com/hashicorp/consul/api"
-
-	"github.com/square/p2/pkg/consultest"
 )
 
 // PairRecord is a record of a single update to the Consul KV store
@@ -149,7 +147,7 @@ func testLogger(t *testing.T) chan<- error {
 // its prefix.
 func TestWatchPrefix(t *testing.T) {
 	t.Parallel()
-	f := consultest.NewFixture(t)
+	f := NewFixture(t)
 	defer f.Stop()
 
 	done := make(chan struct{})
@@ -211,7 +209,7 @@ func TestWatchPrefix(t *testing.T) {
 
 func TestWatchSingle(t *testing.T) {
 	t.Parallel()
-	f := consultest.NewFixture(t)
+	f := NewFixture(t)
 	defer f.Stop()
 
 	done := make(chan struct{})
@@ -453,7 +451,7 @@ func TestWatchNewKeysExistingData(t *testing.T) {
 
 func TestWatchDiff(t *testing.T) {
 	t.Parallel()
-	f := consultest.NewFixture(t)
+	f := NewFixture(t)
 	defer f.Stop()
 
 	done := make(chan struct{})

--- a/pkg/kp/dsstore/consul_store.go
+++ b/pkg/kp/dsstore/consul_store.go
@@ -44,7 +44,7 @@ func (e CASError) Error() string {
 // Make sure functions declared in the Store interface have the proper contract
 var _ Store = &consulStore{}
 
-func NewConsul(client *api.Client, retries int, logger *logging.Logger) Store {
+func NewConsul(client consulutil.ConsulClient, retries int, logger *logging.Logger) Store {
 	return &consulStore{
 		retries:    retries,
 		applicator: labels.NewConsulApplicator(client, retries),

--- a/pkg/kp/fixtures_test.go
+++ b/pkg/kp/fixtures_test.go
@@ -4,20 +4,20 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/api"
+	"github.com/square/p2/pkg/kp/consulutil"
 
-	"github.com/square/p2/pkg/consultest"
+	"github.com/hashicorp/consul/api"
 )
 
 type ConsulTestFixture struct {
-	consultest.Fixture
+	consulutil.Fixture
 	Store Store
 }
 
 // Create a new test fixture that spins up a local Consul server.
 func NewConsulTestFixture(t *testing.T) *ConsulTestFixture {
 	f := new(ConsulTestFixture)
-	f.Fixture = consultest.NewFixture(t)
+	f.Fixture = consulutil.NewFixture(t)
 	f.Store = NewConsulStore(f.Client)
 	return f
 }

--- a/pkg/kp/healthmanager.go
+++ b/pkg/kp/healthmanager.go
@@ -48,7 +48,7 @@ var (
 type consulHealthManager struct {
 	sessionPub *stream.StringValuePublisher // Publishes the current session
 	done       chan struct{}                // Close this to stop reporting health
-	client     *api.Client                  // Connection to the Consul agent
+	client     consulutil.ConsulClient      // Connection to the Consul agent
 	node       types.NodeName
 	logger     logging.Logger // Logger for health events
 }
@@ -176,7 +176,7 @@ type writeResult struct {
 //   B. Write the recent service state to Consul. At most one outstanding write will be
 //      in-flight at any time.
 func processHealthUpdater(
-	client *api.Client,
+	client consulutil.ConsulClient,
 	checksStream <-chan WatchResult,
 	sessionsStream <-chan string,
 	logger logging.Logger,

--- a/pkg/kp/pcstore/consul_store.go
+++ b/pkg/kp/pcstore/consul_store.go
@@ -42,7 +42,7 @@ var _ Store = &consulStore{}
 // NOTE: The "retries" concept is mimicking what is built in rcstore.
 // TODO: explore transactionality of operations and returning errors instead of
 // using retries
-func NewConsul(client *api.Client, retries int, logger *logging.Logger) Store {
+func NewConsul(client consulutil.ConsulClient, retries int, logger *logging.Logger) Store {
 	return &consulStore{
 		applicator: labels.NewConsulApplicator(client, retries),
 		kv:         client.KV(),

--- a/pkg/kp/rcstore/consul_store.go
+++ b/pkg/kp/rcstore/consul_store.go
@@ -75,7 +75,7 @@ func (e CASError) Error() string {
 
 var _ Store = &consulStore{}
 
-func NewConsul(client *api.Client, retries int) *consulStore {
+func NewConsul(client consulutil.ConsulClient, retries int) *consulStore {
 	return &consulStore{
 		retries:    retries,
 		applicator: labels.NewConsulApplicator(client, retries),

--- a/pkg/kp/rollstore/consul_store.go
+++ b/pkg/kp/rollstore/consul_store.go
@@ -60,7 +60,7 @@ type consulStore struct {
 
 var _ Store = consulStore{}
 
-func NewConsul(c *api.Client, logger *logging.Logger) Store {
+func NewConsul(c consulutil.ConsulClient, logger *logging.Logger) Store {
 	if logger == nil {
 		logger = &logging.DefaultLogger
 	}

--- a/pkg/kp/rollstore/consul_store_test.go
+++ b/pkg/kp/rollstore/consul_store_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/kp/kptest"
 	"github.com/square/p2/pkg/kp/rcstore"
@@ -26,7 +27,7 @@ const (
 )
 
 func TestNewConsul(t *testing.T) {
-	store := NewConsul(&api.Client{}, nil)
+	store := NewConsul(kp.NewConsulClient(kp.Options{}), nil)
 	rollstore := store.(consulStore)
 	if rollstore.kv == nil {
 		t.Fatal("kv should not be nil for constructed rollstore")

--- a/pkg/labels/consul_applicator.go
+++ b/pkg/labels/consul_applicator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rcrowley/go-metrics"
 	"k8s.io/kubernetes/pkg/labels"
 
+	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
@@ -44,7 +45,7 @@ type consulApplicator struct {
 	retryMetric   metrics.Gauge
 }
 
-func NewConsulApplicator(client *api.Client, retries int) *consulApplicator {
+func NewConsulApplicator(client consulutil.ConsulClient, retries int) *consulApplicator {
 	return &consulApplicator{
 		logger:      logging.DefaultLogger,
 		kv:          client.KV(),

--- a/pkg/replication/common_setup_test.go
+++ b/pkg/replication/common_setup_test.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/square/p2/pkg/consultest"
 	"github.com/square/p2/pkg/health"
 	"github.com/square/p2/pkg/health/checker"
 	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/manifest"
@@ -24,7 +24,7 @@ const (
 	testPreparerManifest = `id: p2-preparer`
 )
 
-func testReplicatorAndServer(t *testing.T) (Replicator, kp.Store, consultest.Fixture) {
+func testReplicatorAndServer(t *testing.T) (Replicator, kp.Store, consulutil.Fixture) {
 	active := 1
 	store, f := makeStore(t)
 
@@ -48,15 +48,15 @@ func testReplicatorAndServer(t *testing.T) (Replicator, kp.Store, consultest.Fix
 	return replicator, store, f
 }
 
-func makeStore(t *testing.T) (kp.Store, consultest.Fixture) {
-	f := consultest.NewFixture(t)
+func makeStore(t *testing.T) (kp.Store, consulutil.Fixture) {
+	f := consulutil.NewFixture(t)
 	store := kp.NewConsulStore(f.Client)
 	return store, f
 }
 
 // Adds preparer manifest to reality tree to fool replication library into
 // thinking it is installed on the test nodes
-func setupPreparers(fixture consultest.Fixture) {
+func setupPreparers(fixture consulutil.Fixture) {
 	for _, node := range testNodes {
 		key := fmt.Sprintf("reality/%s/p2-preparer", node)
 		fixture.SetKV(key, []byte(testPreparerManifest))


### PR DESCRIPTION
This will allow providing a fake *api.Client to stores for use in tests
that provides all of the necessary functionality. The main motivation
for this commit is to add more tests to the kp.consulStore struct.

Unfortunately this change required a bit of gymnastics around Go's type
system. *api.Client is a struct with KV() and Session() methods that
return structs providing functionality for interacting with consul keys
and consul sessions, respectively.

The ConsulClient interface captures the KV() and Session() functions
that return sub-interfaces that we use, since tests will ultimately want
to fake out the KV and session portions of consul functionality.

Unfortunately, a raw *api.Client does not implement the ConsulClient
interface because the return types of its KV() and Session() functions
are structs, which is not an exact match to what the ConsulClient
interface requires. As a result, a consulutil.ConsulClientFromRaw()
function was added which returns an implementation of the ConsulClient
interface based on a passed *api.Client.

Since most consul client initialization code goes through
the kp.NewConsulClient function, this function simply calls the wrapper
function, so there shouldn't be much extra burden added to callers
initializing a store.