### PR TITLE
Make statusstore use a ConsulClient instead of *api.Client

### DIFF
--- a/pkg/kp/statusstore/consul_store.go
+++ b/pkg/kp/statusstore/consul_store.go
@@ -24,7 +24,7 @@ type consulStore struct {
 
 var _ Store = &consulStore{}
 
-func NewConsul(client *api.Client) Store {
+func NewConsul(client consulutil.ConsulClient) Store {
 	return &consulStore{
 		kv: client.KV(),
 	}


### PR DESCRIPTION
This makes it easier for 3rd party code to use the status store, because
kp.NewConsulClient now returns a ConsulClient interface backed by an
*api.Client instead of the client itself.