### PR TITLE
Fix unscheduling bug and daemon set update race conditions

### DIFF
--- a/pkg/ds/daemon_set.go
+++ b/pkg/ds/daemon_set.go
@@ -343,7 +343,7 @@ func (ds *daemonSet) removePods() error {
 	}
 
 	ds.logger.Infof("Need to schedule %v nodes", len(currentNodes))
-	if len(currentNodes) > 0 {
+	if len(currentNodes)-len(toUnscheduleSorted) > 0 {
 		return ds.PublishToReplication()
 	}
 

--- a/pkg/ds/daemon_set.go
+++ b/pkg/ds/daemon_set.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/user"
-	"sync"
 	"time"
 
 	"github.com/square/p2/pkg/health"
@@ -79,9 +78,6 @@ type daemonSet struct {
 
 	// This is the current replication enact go routine that is running
 	currentReplication replication.Replication
-
-	// This locks are used to make sure only one replication is going on at the same time
-	replicationLock sync.Mutex
 }
 
 type dsContention struct {
@@ -146,7 +142,7 @@ func (ds *daemonSet) WatchDesires(
 	go func() {
 		var err error
 		defer close(errCh)
-		defer ds.CancelReplication()
+		defer ds.cancelReplication()
 
 		// Try to schedule pods when this begins watching
 		if !ds.Disabled {
@@ -184,10 +180,10 @@ func (ds *daemonSet) WatchDesires(
 				ds.DaemonSet = *newDS
 
 				if ds.Disabled {
-					ds.CancelReplication()
+					ds.cancelReplication()
 					continue
 				}
-				err := ds.removePods()
+				err = ds.removePods()
 				if err != nil {
 					err = util.Errorf("Unable to remove pods from intent tree: %v", err)
 					continue
@@ -333,7 +329,7 @@ func (ds *daemonSet) removePods() error {
 	toUnscheduleSorted := types.NewNodeSet(currentNodes...).Difference(types.NewNodeSet(eligible...)).ListNodes()
 	ds.logger.NoFields().Infof("Need to unschedule %d nodes", len(toUnscheduleSorted))
 
-	ds.CancelReplication()
+	ds.cancelReplication()
 
 	for _, node := range toUnscheduleSorted {
 		err := ds.unschedule(node)
@@ -365,7 +361,7 @@ func (ds *daemonSet) clearPods() error {
 	toUnscheduleSorted := types.NewNodeSet(currentNodes...).ListNodes()
 	ds.logger.NoFields().Infof("Need to unschedule %d nodes", len(toUnscheduleSorted))
 
-	ds.CancelReplication()
+	ds.cancelReplication()
 
 	for _, node := range toUnscheduleSorted {
 		err := ds.unschedule(node)
@@ -419,6 +415,10 @@ func (ds *daemonSet) PublishToReplication() error {
 		ds.logger.Info("Healthchecker is nil")
 		return nil
 	}
+
+	// We must cancel the replication because if we try to call
+	// InitializeReplicationWithCheck, we will get an error
+	ds.cancelReplication()
 
 	podLocations, err := ds.CurrentPods()
 	if err != nil {
@@ -479,27 +479,22 @@ func (ds *daemonSet) PublishToReplication() error {
 		}
 	}()
 
-	ds.replicationLock.Lock()
-	if ds.currentReplication != nil {
-		ds.currentReplication.Cancel()
-	}
 	// Set a new replication
 	ds.currentReplication = replication
 
 	go replication.Enact()
-	ds.replicationLock.Unlock()
 
 	ds.logger.Info("Replication enacted")
 
 	return nil
 }
 
-func (ds *daemonSet) CancelReplication() {
-	ds.replicationLock.Lock()
-	defer ds.replicationLock.Unlock()
-
+// It is also okay to call this multiple times because it keeps track of when
+// it has been cancelled by checking whether ds.currentReplication == nil
+func (ds *daemonSet) cancelReplication() {
 	if ds.currentReplication != nil {
 		ds.currentReplication.Cancel()
+		ds.currentReplication.WaitForReplication()
 		ds.logger.Info("Replication cancelled")
 		ds.currentReplication = nil
 	}

--- a/pkg/ds/daemon_set.go
+++ b/pkg/ds/daemon_set.go
@@ -410,12 +410,6 @@ func (ds *daemonSet) unschedule(node types.NodeName) error {
 }
 
 func (ds *daemonSet) PublishToReplication() error {
-	// TODO: We need to specifically turn this on to work
-	if ds.healthChecker == nil {
-		ds.logger.Info("Healthchecker is nil")
-		return nil
-	}
-
 	// We must cancel the replication because if we try to call
 	// InitializeReplicationWithCheck, we will get an error
 	ds.cancelReplication()

--- a/pkg/health/checker/test/fake_checker.go
+++ b/pkg/health/checker/test/fake_checker.go
@@ -42,3 +42,72 @@ func (s singleServiceChecker) Service(serviceID string) (map[types.NodeName]heal
 	}
 	return s.health, nil
 }
+
+type AlwaysHappyHealthChecker struct {
+	allNodes []types.NodeName
+}
+
+// creates an implementation of checker.ConsulHealthChecker that always reports
+// satisfied health checks for testing purposes
+func HappyHealthChecker(nodes []types.NodeName) checker.ConsulHealthChecker {
+	return AlwaysHappyHealthChecker{nodes}
+}
+
+func (h AlwaysHappyHealthChecker) WatchNodeService(
+	nodeName types.NodeName,
+	serviceID string,
+	resultCh chan<- health.Result,
+	errCh chan<- error,
+	quitCh <-chan struct{},
+) {
+	happyResult := health.Result{
+		ID:     types.PodID(serviceID),
+		Status: health.Passing,
+	}
+	for {
+		select {
+		case <-quitCh:
+			return
+		case resultCh <- happyResult:
+		}
+	}
+}
+
+func (h AlwaysHappyHealthChecker) Service(serviceID string) (map[types.NodeName]health.Result, error) {
+	results := make(map[types.NodeName]health.Result)
+	for _, node := range h.allNodes {
+		results[node] = health.Result{
+			ID:     types.PodID(serviceID),
+			Status: health.Passing,
+		}
+	}
+	return results, nil
+}
+
+func (h AlwaysHappyHealthChecker) WatchService(
+	serviceID string,
+	resultCh chan<- map[types.NodeName]health.Result,
+	errCh chan<- error,
+	quitCh <-chan struct{},
+) {
+	allHappy := make(map[types.NodeName]health.Result)
+	for _, node := range h.allNodes {
+		allHappy[node] = health.Result{
+			ID:     types.PodID(serviceID),
+			Status: health.Passing,
+		}
+	}
+	for {
+		select {
+		case <-quitCh:
+			return
+		case resultCh <- allHappy:
+		}
+	}
+}
+
+func (h AlwaysHappyHealthChecker) WatchHealth(_ chan []*health.Result,
+	errCh chan<- error,
+	quitCh <-chan struct{}) {
+	panic("not implemented")
+}

--- a/pkg/kp/kptest/fake_store.go
+++ b/pkg/kp/kptest/fake_store.go
@@ -167,11 +167,13 @@ func (*FakePodStore) Ping() error {
 }
 
 func (*FakePodStore) LockHolder(key string) (string, string, error) {
-	panic("not implemented")
+	// Not implemented -- for now, this will never produce an error
+	return "Happy name", "Happy ID", nil
 }
 
 func (*FakePodStore) DestroyLockHolder(id string) error {
-	panic("not implemented")
+	// Not implemented -- for now, this will never produce an error
+	return nil
 }
 
 func (*FakePodStore) NewUnmanagedSession(session string, name string) kp.Session {

--- a/pkg/replication/replication.go
+++ b/pkg/replication/replication.go
@@ -48,6 +48,10 @@ type Replication interface {
 
 	// Cancel the prescribed replication
 	Cancel()
+
+	// Will block until the r.quitCh is closed
+	// this is used to synchronize updates which quickly cancel and re-enact the replicaton
+	WaitForReplication()
 }
 
 // A replication contains the information required to do a single replication (deploy).
@@ -241,6 +245,12 @@ func (r replication) Enact() {
 // Cancels all goroutines (e.g. replication and lock renewal)
 func (r replication) Cancel() {
 	close(r.replicationCancelledCh)
+}
+
+func (r replication) WaitForReplication() {
+	select {
+	case <-r.quitCh:
+	}
 }
 
 // Listen for errors in lock renewal. If the lock can't be renewed, we need to


### PR DESCRIPTION
When unscheduling some pods, the replication needs to be cancelled, but
some pods were being scheduled even though they weren't supposed to
because of a counting error due to currentNodes not being updated.

Previously, an update to daemon sets would quickly cancel the
replication and re-enact it, but it does not wait for replication to
gracefully release the session locks, this commit will fix that problem.

The health has also been faked in the daemon set and daemon set farm test. 
The locks in replication have also been faked, but is a lazy implementation. 
Because of this, we can now remove the nil health checker condition for daemon set unit tests.