### PR TITLE
rc, ds: Permit unmarshaling zero values

### DIFF
--- a/pkg/ds/fields/fields.go
+++ b/pkg/ds/fields/fields.go
@@ -100,9 +100,13 @@ func (ds *DaemonSet) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	podManifest, err := manifest.FromBytes([]byte(rawDS.Manifest))
-	if err != nil {
-		return err
+	var podManifest manifest.Manifest
+	if rawDS.Manifest != "" {
+		var err error
+		podManifest, err = manifest.FromBytes([]byte(rawDS.Manifest))
+		if err != nil {
+			return err
+		}
 	}
 
 	nodeSelector, err := labels.Parse(rawDS.NodeSelector)

--- a/pkg/ds/fields/fields_test.go
+++ b/pkg/ds/fields/fields_test.go
@@ -1,0 +1,14 @@
+package fields
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestZeroUnmarshal(t *testing.T) {
+	var ds DaemonSet
+	err := json.Unmarshal([]byte(`{}`), &ds)
+	if err != nil {
+		t.Fatal("error unmarshaling:", err)
+	}
+}

--- a/pkg/kp/dsstore/consul_store.go
+++ b/pkg/kp/dsstore/consul_store.go
@@ -371,6 +371,9 @@ func kvpToDS(kvp *api.KVPair) (fields.DaemonSet, error) {
 	if err != nil {
 		return ds, util.Errorf("Could not unmarshal DS ('%s') as json: %s", string(kvp.Value), err)
 	}
+	if ds.Manifest == nil {
+		return ds, util.Errorf("%s: DS has no manifest", kvp.Key)
+	}
 
 	return ds, nil
 }

--- a/pkg/kp/rcstore/consul_store.go
+++ b/pkg/kp/rcstore/consul_store.go
@@ -409,6 +409,9 @@ func kvpToRC(kvp *api.KVPair) (fields.RC, error) {
 	if err != nil {
 		return rc, util.Errorf("Could not unmarshal RC ('%s') as json: %s", string(kvp.Value), err)
 	}
+	if rc.Manifest == nil {
+		return rc, util.Errorf("%s: RC has no manifest", kvp.Key)
+	}
 
 	return rc, nil
 }

--- a/pkg/rc/fields/fields.go
+++ b/pkg/rc/fields/fields.go
@@ -104,9 +104,13 @@ func (rc *RC) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	m, err := manifest.FromBytes([]byte(rawRC.Manifest))
-	if err != nil {
-		return err
+	var m manifest.Manifest
+	if rawRC.Manifest != "" {
+		var err error
+		m, err = manifest.FromBytes([]byte(rawRC.Manifest))
+		if err != nil {
+			return err
+		}
 	}
 
 	nodeSel, err := labels.Parse(rawRC.NodeSelector)

--- a/pkg/rc/fields/fields_test.go
+++ b/pkg/rc/fields/fields_test.go
@@ -29,3 +29,9 @@ func TestJSONMarshal(t *testing.T) {
 	Assert(t).AreEqual(rc1.ID, rc2.ID, "RC ID changed when serialized")
 	Assert(t).AreEqual(rc1.Manifest.ID(), rc2.Manifest.ID(), "Manifest ID changed when serialized")
 }
+
+func TestZeroUnmarshal(t *testing.T) {
+	var rc fields.RC
+	err := json.Unmarshal([]byte(`{}`), &rc)
+	Assert(t).IsNil(err, "error unmarshaling")
+}


### PR DESCRIPTION
When unmarshaling a JSON-encoded RC or DaemonSet, skip creating a
manifest object if the Manifest field is empty. This allows the zero
value for the RC and DaemonSet types to be decoded without being a parse
error. It was already OK for a zero value to be encoded. This leads to
strange errors where an object that contains an RC/DS can be encoded but
cannot be decoded.

RCs/DSs without a Manifest are still not valid, and their main Store
interfaces will still reject objects that do not contain a Manifest.
This preserves any existing consistency guarantees.