### PR TITLE
Create nested cgroup names

### DIFF
--- a/bin/p2-cgroup-info/main.go
+++ b/bin/p2-cgroup-info/main.go
@@ -31,8 +31,70 @@ type Output struct {
 	Launchables []Launchable `json:"launchables,omitempty"`
 }
 
+func hasProcs(cgroupPath string) (bool, error) {
+	procs, err := ioutil.ReadFile(filepath.Join(cgroupPath, "cgroup.procs"))
+	if err != nil {
+		return false, err
+	}
+	return len(procs) > 0, nil
+}
+
+// scanNestedCgroup scans through a nested cgroup naming scheme, e.g.:
+// "/cgroup/cpu/p2/mynode/mypod/mylaunchable/cgroup.procs"
+func scanNestedCgroup(p2Root string) ([]Launchable, error) {
+	var ls []Launchable
+
+	nodes, err := ioutil.ReadDir(p2Root) // "./p2"
+	if err != nil {
+		return nil, err
+	}
+	for _, node := range nodes {
+		if !node.IsDir() {
+			continue
+		}
+		nodePath := filepath.Join(p2Root, node.Name()) // "./p2/mynode"
+		pods, err := ioutil.ReadDir(nodePath)
+		if err != nil {
+			return nil, err
+		}
+		for _, pod := range pods {
+			if !pod.IsDir() {
+				continue
+			}
+			podPath := filepath.Join(nodePath, pod.Name()) // "./p2/mynode/mypod"
+			launchables, err := ioutil.ReadDir(podPath)
+			if err != nil {
+				return nil, err
+			}
+			for _, launchable := range launchables {
+				if !launchable.IsDir() {
+					continue
+				}
+				launchablePath := filepath.Join(podPath, launchable.Name()) // "./p2/mynode/mypod/mylaunchable"
+				if ok, err := hasProcs(launchablePath); err != nil {
+					return nil, err
+				} else if !ok {
+					continue
+				}
+				ls = append(ls, Launchable{
+					Node:       node.Name(),
+					Pod:        pod.Name(),
+					Launchable: launchable.Name(),
+					Cgroup:     filepath.Join("p2", node.Name(), pod.Name(), launchable.Name()),
+				})
+			}
+		}
+	}
+
+	return ls, nil
+}
+
 // scanCgroup scans the root hierarchy of a cgroup memory controller and identifies
-// launchables based on P2's naming scheme.
+// launchables based on P2's naming schemes.
+//
+// Flat names ("/cgroup/cpu/mypod__mylaunchable") are handled here in this method. If
+// the scan finds the root of a p2 hierarchy ("/cgroup/cpu/p2/..."), the nested names
+// are offloaded to another method.
 func scanCgroup(dirname string) (*Output, error) {
 	var launchables []Launchable
 
@@ -51,17 +113,23 @@ func scanCgroup(dirname string) (*Output, error) {
 		if !fileInfo.IsDir() {
 			continue
 		}
-		// All of P2's cgroup names follow the naming pattern: "{pod}__{launchable}". See
-		// Pod.getLaunchable().
+		// The nested naming scheme roots all cgroups in one "p2" directory.
+		if fileInfo.Name() == "p2" {
+			ls, err := scanNestedCgroup(filepath.Join(dirname, fileInfo.Name()))
+			if err != nil {
+				return nil, err
+			}
+			launchables = append(launchables, ls...)
+			continue
+		}
+		// The flat naming scheme follows the naming pattern: "{pod}__{launchable}"
 		parts := strings.Split(fileInfo.Name(), "__")
 		if len(parts) != 2 {
 			continue
 		}
-		procs, err := ioutil.ReadFile(filepath.Join(dirname, fileInfo.Name(), "cgroup.procs"))
-		if err != nil {
+		if ok, err := hasProcs(filepath.Join(dirname, fileInfo.Name())); err != nil {
 			return nil, err
-		}
-		if len(procs) == 0 {
+		} else if !ok {
 			continue
 		}
 		launchables = append(launchables, Launchable{
@@ -70,7 +138,6 @@ func scanCgroup(dirname string) (*Output, error) {
 			Launchable: parts[1],
 			Cgroup:     fileInfo.Name(),
 		})
-
 	}
 
 	return &Output{

--- a/bin/p2-install-hook/main.go
+++ b/bin/p2-install-hook/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"os"
 	"path/filepath"
 
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -13,6 +14,7 @@ import (
 	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/osversion"
 	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/uri"
 	"github.com/square/p2/pkg/version"
 )
@@ -20,6 +22,7 @@ import (
 var (
 	manifestURI = kingpin.Arg("manifest", "a path or url to a pod manifest that will be installed and launched immediately.").URL()
 	registryURI = kingpin.Arg("registry", "A URL to the registry to download artifacts from").URL()
+	nodeName    = kingpin.Flag("node-name", "the name of this node (default: hostname)").String()
 	podRoot     = kingpin.Flag("pod-root", "the root of the pods directory").Default(pods.DEFAULT_PATH).String()
 	hookRoot    = kingpin.Flag("hook-root", "the root of the hook scripts directory").Default(hooks.DEFAULT_PATH).String()
 	hookType    = kingpin.Flag("hook-type", "the type of the hook (if unspecified, defaults to global)").String()
@@ -29,6 +32,14 @@ func main() {
 	kingpin.Version(version.VERSION)
 	kingpin.Parse()
 
+	if *nodeName == "" {
+		hostname, err := os.Hostname()
+		if err != nil {
+			log.Fatalf("error getting node name: %v", err)
+		}
+		*nodeName = hostname
+	}
+
 	manifest, err := manifest.FromURI(*manifestURI)
 	if err != nil {
 		log.Fatalf("%s", err)
@@ -37,7 +48,7 @@ func main() {
 	// /data/pods/hooks/<event>/<id>
 	// if the event is the empty string (global hook), then that path segment
 	// will be cleaned out
-	pod := pods.NewPod(manifest.ID(), pods.PodPath(filepath.Join(*podRoot, "hooks", *hookType), manifest.ID()))
+	pod := pods.NewPod(manifest.ID(), types.NodeName(*nodeName), pods.PodPath(filepath.Join(*podRoot, "hooks", *hookType), manifest.ID()))
 
 	// for now use noop verifier in this CLI
 	err = pod.Install(manifest, auth.NopVerifier(), artifact.NewRegistry(*registryURI, uri.DefaultFetcher, osversion.DefaultDetector))

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/manifest"
+	"github.com/square/p2/pkg/types"
 )
 
 var DEFAULT_PATH = "/usr/local/p2hooks.d"
@@ -19,6 +20,7 @@ var DEFAULT_PATH = "/usr/local/p2hooks.d"
 const (
 	HOOK_ENV_VAR                   = "HOOK"
 	HOOK_EVENT_ENV_VAR             = "HOOK_EVENT"
+	HOOKED_NODE_ENV_VAR            = "HOOKED_NODE"
 	HOOKED_POD_ID_ENV_VAR          = "HOOKED_POD_ID"
 	HOOKED_POD_HOME_ENV_VAR        = "HOOKED_POD_HOME"
 	HOOKED_POD_MANIFEST_ENV_VAR    = "HOOKED_POD_MANIFEST"
@@ -32,6 +34,7 @@ const (
 type Pod interface {
 	ConfigDir() string
 	EnvDir() string
+	Node() types.NodeName
 	Path() string
 }
 
@@ -210,6 +213,7 @@ func (h *HookDir) runHooks(dirpath string, hType HookType, pod Pod, podManifest 
 	hookEnvironment := []string{
 		fmt.Sprintf("%s=%s", HOOK_ENV_VAR, path.Base(dirpath)),
 		fmt.Sprintf("%s=%s", HOOK_EVENT_ENV_VAR, hType.String()),
+		fmt.Sprintf("%s=%s", HOOKED_NODE_ENV_VAR, pod.Node()),
 		fmt.Sprintf("%s=%s", HOOKED_POD_ID_ENV_VAR, podManifest.ID()),
 		fmt.Sprintf("%s=%s", HOOKED_POD_HOME_ENV_VAR, pod.Path()),
 		fmt.Sprintf("%s=%s", HOOKED_POD_MANIFEST_ENV_VAR, tmpManifestFile.Name()),

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -28,7 +28,7 @@ func TestExecutableHooksAreRun(t *testing.T) {
 	ioutil.WriteFile(path.Join(tempDir, "test1"), []byte("#!/bin/sh\necho $HOOKED_POD_ID > $(dirname $0)/output"), 0755)
 
 	hooks := Hooks(os.TempDir(), &logging.DefaultLogger)
-	hooks.runHooks(tempDir, AFTER_INSTALL, pods.NewPod(podId, podDir), testManifest(), logging.DefaultLogger)
+	hooks.runHooks(tempDir, AFTER_INSTALL, pods.NewPod(podId, "testNode", podDir), testManifest(), logging.DefaultLogger)
 
 	contents, err := ioutil.ReadFile(path.Join(tempDir, "output"))
 	Assert(t).IsNil(err, "the error should have been nil")
@@ -49,7 +49,7 @@ func TestNonExecutableHooksAreNotRun(t *testing.T) {
 	Assert(t).IsNil(err, "the error should have been nil")
 
 	hooks := Hooks(os.TempDir(), &logging.DefaultLogger)
-	hooks.runHooks(tempDir, AFTER_INSTALL, pods.NewPod(podId, podDir), testManifest(), logging.DefaultLogger)
+	hooks.runHooks(tempDir, AFTER_INSTALL, pods.NewPod(podId, "testNode", podDir), testManifest(), logging.DefaultLogger)
 
 	if _, err := os.Stat(path.Join(tempDir, "failed")); err == nil {
 		t.Fatal("`failed` file exists; non-executable hook ran but should not have run")
@@ -67,7 +67,7 @@ func TestDirectoriesDoNotBreakEverything(t *testing.T) {
 
 	Assert(t).IsNil(os.Mkdir(path.Join(tempDir, "mydir"), 0755), "Should not have erred")
 
-	pod := pods.NewPod(podId, podDir)
+	pod := pods.NewPod(podId, "testNode", podDir)
 	logger := logging.TestLogger()
 	hooks := Hooks(os.TempDir(), &logger)
 	err = hooks.runHooks(tempDir, AFTER_INSTALL, pod, testManifest(), logging.DefaultLogger)

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -53,6 +53,7 @@ func PodPath(root string, manifestId types.PodID) string {
 
 type Pod struct {
 	Id             types.PodID
+	node           types.NodeName
 	path           string
 	logger         logging.Logger
 	SV             runit.SV
@@ -64,9 +65,10 @@ type Pod struct {
 	Fetcher        uri.Fetcher
 }
 
-func NewPod(id types.PodID, path string) *Pod {
+func NewPod(id types.PodID, node types.NodeName, path string) *Pod {
 	return &Pod{
 		Id:             id,
+		node:           node,
 		path:           path,
 		logger:         Log.SubLogger(logrus.Fields{"pod": id}),
 		SV:             runit.DefaultSV,
@@ -79,7 +81,7 @@ func NewPod(id types.PodID, path string) *Pod {
 	}
 }
 
-func ExistingPod(path string) (*Pod, error) {
+func ExistingPod(node types.NodeName, path string) (*Pod, error) {
 	temp := Pod{path: path}
 	manifest, err := temp.CurrentManifest()
 	if err == NoCurrentManifest {
@@ -87,14 +89,18 @@ func ExistingPod(path string) (*Pod, error) {
 	} else if err != nil {
 		return nil, err
 	}
-	return NewPod(manifest.ID(), path), nil
+	return NewPod(manifest.ID(), node, path), nil
 }
 
-func PodFromManifestId(manifestId types.PodID) *Pod {
-	return NewPod(manifestId, PodPath(DEFAULT_PATH, manifestId))
+func PodFromManifestId(manifestId types.PodID, node types.NodeName) *Pod {
+	return NewPod(manifestId, node, PodPath(DEFAULT_PATH, manifestId))
 }
 
 var NoCurrentManifest error = fmt.Errorf("No current manifest for this pod")
+
+func (pod *Pod) Node() types.NodeName {
+	return pod.node
+}
 
 func (pod *Pod) Path() string {
 	return pod.path

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func getTestPod() *Pod {
-	return NewPod(types.PodID("hello"), "/data/pods/test")
+	return NewPod(types.PodID("hello"), "testNode", "/data/pods/test")
 }
 
 func getTestPodManifest(t *testing.T) manifest.Manifest {
@@ -136,7 +136,7 @@ config:
 
 	podTemp, _ := ioutil.TempDir("", "pod")
 
-	pod := NewPod(manifest.ID(), PodPath(podTemp, manifest.ID()))
+	pod := NewPod(manifest.ID(), "testNode", PodPath(podTemp, manifest.ID()))
 
 	launchables := make([]launch.Launchable, 0)
 	for _, stanza := range manifest.GetLaunchableStanzas() {
@@ -203,7 +203,7 @@ func TestLogLaunchableError(t *testing.T) {
 	testManifest := getTestPodManifest(t)
 	testErr := util.Errorf("Unable to do something")
 	message := "Test error occurred"
-	pod := PodFromManifestId(testManifest.ID())
+	pod := PodFromManifestId(testManifest.ID(), "testNode")
 	pod.logLaunchableError(testLaunchable.ServiceId, testErr, message)
 
 	output, err := ioutil.ReadAll(&out)
@@ -221,7 +221,7 @@ func TestLogError(t *testing.T) {
 	testManifest := getTestPodManifest(t)
 	testErr := util.Errorf("Unable to do something")
 	message := "Test error occurred"
-	pod := PodFromManifestId(testManifest.ID())
+	pod := PodFromManifestId(testManifest.ID(), "testNode")
 	pod.logError(testErr, message)
 
 	output, err := ioutil.ReadAll(&out)
@@ -236,7 +236,7 @@ func TestLogInfo(t *testing.T) {
 	Log.SetLogOut(&out)
 
 	testManifest := getTestPodManifest(t)
-	pod := PodFromManifestId(testManifest.ID())
+	pod := PodFromManifestId(testManifest.ID(), "testNode")
 	message := "Pod did something good"
 	pod.logInfo(message)
 
@@ -253,7 +253,7 @@ func TestWriteManifestWillReturnOldManifestTempPath(t *testing.T) {
 
 	poddir, err := ioutil.TempDir("", "poddir")
 	Assert(t).IsNil(err, "couldn't create tempdir")
-	pod := NewPod(types.PodID("testPod"), poddir)
+	pod := NewPod(types.PodID("testPod"), "testNode", poddir)
 
 	// set the RunAs user to the user running the test, because when we
 	// write files we need an owner.

--- a/pkg/preparer/listener.go
+++ b/pkg/preparer/listener.go
@@ -120,6 +120,7 @@ func (l *HookListener) installHook(result kp.ManifestResult) error {
 
 	hookPod := pods.NewPod(
 		result.Manifest.ID(),
+		l.Node,
 		filepath.Join(l.DestinationDir, string(result.Manifest.ID())),
 	)
 

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -186,7 +186,11 @@ func (p *Preparer) handlePods(podChan <-chan ManifestPair, quit <-chan struct{})
 				if !working {
 					p.tryRunHooks(
 						hooks.AFTER_AUTH_FAIL,
-						pods.NewPod(nextLaunch.ID, pods.PodPath(p.podRoot, nextLaunch.ID)),
+						pods.NewPod(
+							nextLaunch.ID,
+							p.node,
+							pods.PodPath(p.podRoot, nextLaunch.ID),
+						),
 						nextLaunch.Intent,
 						manifestLogger,
 					)
@@ -194,7 +198,11 @@ func (p *Preparer) handlePods(podChan <-chan ManifestPair, quit <-chan struct{})
 			}
 		case <-time.After(1 * time.Second):
 			if working {
-				pod := pods.NewPod(nextLaunch.ID, pods.PodPath(p.podRoot, nextLaunch.ID))
+				pod := pods.NewPod(
+					nextLaunch.ID,
+					p.node,
+					pods.PodPath(p.podRoot, nextLaunch.ID),
+				)
 
 				// TODO better solution: force the preparer to have a 0s default timeout, prevent KILLs
 				if pod.Id == POD_ID {

--- a/pkg/preparer/orchestrate_test.go
+++ b/pkg/preparer/orchestrate_test.go
@@ -81,6 +81,10 @@ func (t *TestPod) EnvDir() string {
 	return os.TempDir()
 }
 
+func (t *TestPod) Node() types.NodeName {
+	return "hostname"
+}
+
 func (t *TestPod) Path() string {
 	return os.TempDir()
 }


### PR DESCRIPTION
Add new config option to preparers that changes how they name cgroups.
Instead of creating a singe directory in the cpu and memory resource
controller named "{pod}__{launchable}", the new scheme uses a nested
hierarchy of "p2/{node}/{pod}/{launchable}".

To use the new cgroup name, set the "nested_cgroups" parameter in
the preparer configuration.