### PR TITLE
Include response output in remote API call errors

### DIFF
--- a/pkg/artifact/registry.go
+++ b/pkg/artifact/registry.go
@@ -127,7 +127,15 @@ func (a registry) fetchRegistryData(launchableID launch.LaunchableID, version la
 	var registryResponse RegistryResponse
 	err = json.Unmarshal(respBytes, &registryResponse)
 	if err != nil {
-		return nil, auth.VerificationData{}, util.Errorf("Could not unmarshal JSON response from artifact registry: %s", err)
+		l := len(respBytes)
+		if l > 80 {
+			l = 80
+		}
+		return nil, auth.VerificationData{}, util.Errorf(
+			"bad response from artifact registry: %s: %q",
+			err,
+			string(respBytes[:l]),
+		)
 	}
 
 	// Require artifact URL to be present, other fields are optional but returned


### PR DESCRIPTION
It is a hopeless task to debug a JSON decode error without knowing the
input document. Many JSON documents exist in P2 in a durable format
where they can be examined after a failures, e.g., a file on a disk or a
key in Consul. However, the response to a remote API call isn't always
reproducible, so this changes the error messages to include the first 80
characters of the response when querying the artifact registry and an
HTTP label applicator. I am guessing that 80 chars is enough to show
what kind of response was received without overwhelming the logs.