### PR TITLE
Un-flake daemon set tests and and fix replication bug

### DIFF
--- a/pkg/ds/daemon_set.go
+++ b/pkg/ds/daemon_set.go
@@ -24,8 +24,11 @@ import (
 
 const (
 	// This label is applied to pods owned by an RC.
-	DSIDLabel     = "daemon_set_id"
-	RetryInterval = time.Duration(5 * time.Minute)
+	DSIDLabel = "daemon_set_id"
+)
+
+var (
+	retryInterval = time.Duration(5 * time.Minute)
 )
 
 type DaemonSet interface {
@@ -163,9 +166,9 @@ func (ds *daemonSet) WatchDesires(
 			if err != nil {
 				select {
 				case errCh <- err:
-					ds.logger.Warnf("An error has occurred in the daemon set, retrying if no changes are made in %v", RetryInterval)
+					ds.logger.Warnf("An error has occurred in the daemon set, retrying if no changes are made in %v", retryInterval)
 					// Retry the replication in the RetryInterval's duration
-					timer.Reset(RetryInterval)
+					timer.Reset(retryInterval)
 					// This is required in case the user disables the daemon set
 					// so that the timer would be stopped after
 					err = nil

--- a/pkg/ds/daemon_set.go
+++ b/pkg/ds/daemon_set.go
@@ -251,7 +251,17 @@ func (ds *daemonSet) WatchDesires(
 				}
 
 			case <-timer.C:
-				err = ds.PublishToReplication()
+				// Account for any operations that could have failed and retry the replication
+				err = ds.removePods()
+				if err != nil {
+					err = util.Errorf("Unable to remove pods from intent tree: %v", err)
+					continue
+				}
+				err = ds.addPods()
+				if err != nil {
+					err = util.Errorf("Unable to add pods to intent tree: %v", err)
+					continue
+				}
 
 			case <-quitCh:
 				return

--- a/pkg/ds/daemon_set_test.go
+++ b/pkg/ds/daemon_set_test.go
@@ -23,6 +23,10 @@ import (
 	klabels "k8s.io/kubernetes/pkg/labels"
 )
 
+const (
+	testDSRetryInterval = time.Duration(1000 * time.Millisecond)
+)
+
 func scheduledPods(t *testing.T, ds *daemonSet) []labels.Labeled {
 	selector := klabels.Everything().Add(DSIDLabel, klabels.EqualsOperator, []string{ds.ID().String()})
 	labeled, err := ds.applicator.GetMatches(selector, labels.POD)
@@ -37,7 +41,7 @@ func waitForNodes(
 	desiresErrCh <-chan error,
 	dsChangesErrCh <-chan error,
 ) int {
-	timeout := time.After(2 * time.Second)
+	timeout := time.After(10 * time.Second)
 	podLocations, err := ds.CurrentPods()
 	Assert(t).IsNil(err, "expected no error getting pod locations")
 	timedOut := false
@@ -123,6 +127,8 @@ func watchDSChanges(
 // 	- mutations to a daemon set
 //	- deleting a daemon set
 func TestSchedule(t *testing.T) {
+	retryInterval = testFarmRetryInterval
+
 	//
 	// Setup fixture and schedule a pod
 	//
@@ -168,11 +174,9 @@ func TestSchedule(t *testing.T) {
 
 	scheduled := scheduledPods(t, ds)
 	Assert(t).AreEqual(len(scheduled), 0, "expected no pods to have been labeled")
-	manifestResults, _, err := kpStore.AllPods(kp.INTENT_TREE)
-	if err != nil {
-		t.Fatalf("Unable to get all pods from pod store: %v", err)
-	}
-	Assert(t).AreEqual(len(manifestResults), 0, "expected no manifests to have been scheduled")
+
+	err = waitForPodsInIntent(kpStore, 0)
+	Assert(t).IsNil(err, "Unexpected number of pods scheduled")
 
 	err = applicator.SetLabel(labels.NODE, "node1", "nodeQuality", "bad")
 	Assert(t).IsNil(err, "expected no error labeling node1")
@@ -203,15 +207,8 @@ func TestSchedule(t *testing.T) {
 	Assert(t).AreEqual(scheduled[0].ID, "node2/testPod", "expected node labeled with the daemon set's id")
 
 	// Verify that the scheduled pod is correct
-	manifestResults, _, err = kpStore.AllPods(kp.INTENT_TREE)
-	if err != nil {
-		t.Fatalf("Unable to get all pods from pod store: %v", err)
-	}
-	for _, val := range manifestResults {
-		Assert(t).AreEqual(val.PodLocation.Node, types.NodeName("node2"), "expected manifest scheduled on the right node")
-		Assert(t).AreEqual(val.PodLocation.PodID, types.PodID("testPod"), "expected manifest scheduled with correct pod ID")
-		Assert(t).AreEqual(string(val.Manifest.ID()), "testPod", "expected manifest with correct ID")
-	}
+	err = waitForSpecificPod(kpStore, "node2", types.PodID("testPod"))
+	Assert(t).IsNil(err, "Unexpected pod scheduled")
 
 	//
 	// Add 10 good nodes and 10 bad nodes then verify
@@ -261,15 +258,8 @@ func TestSchedule(t *testing.T) {
 	Assert(t).AreEqual(numNodes, 1, "took too long to schedule")
 
 	// Verify that the scheduled pod is correct
-	manifestResults, _, err = kpStore.AllPods(kp.INTENT_TREE)
-	if err != nil {
-		t.Fatalf("Unable to get all pods from pod store: %v", err)
-	}
-	for _, val := range manifestResults {
-		Assert(t).AreEqual(val.PodLocation.Node, types.NodeName("nodeOk"), "expected manifest scheduled on the right node")
-		Assert(t).AreEqual(val.PodLocation.PodID, types.PodID("testPod"), "expected manifest scheduled with correct pod ID")
-		Assert(t).AreEqual(string(val.Manifest.ID()), "testPod", "expected manifest with correct ID")
-	}
+	err = waitForSpecificPod(kpStore, "nodeOk", types.PodID("testPod"))
+	Assert(t).IsNil(err, "Unexpected pod scheduled")
 
 	//
 	// Disabling the daemon set and making a change should not do anything
@@ -301,6 +291,9 @@ func TestSchedule(t *testing.T) {
 	numNodes = waitForNodes(t, ds, 23, desiresErrCh, dsChangesErrCh)
 	Assert(t).AreEqual(numNodes, 23, "took too long to schedule")
 
+	err = waitForPodsInIntent(kpStore, 23)
+	Assert(t).IsNil(err, "Unexpected number of pods scheduled")
+
 	//
 	// Deleting the daemon set should unschedule all of its nodes
 	//
@@ -314,14 +307,14 @@ func TestSchedule(t *testing.T) {
 
 	scheduled = scheduledPods(t, ds)
 	Assert(t).AreEqual(len(scheduled), 0, "expected all nodes to have been unlabeled")
-	manifestResults, _, err = kpStore.AllPods(kp.INTENT_TREE)
-	if err != nil {
-		t.Fatalf("Unable to get all pods from pod store: %v", err)
-	}
-	Assert(t).AreEqual(len(manifestResults), 0, "expected all manifests to have been unscheduled")
+
+	err = waitForPodsInIntent(kpStore, 0)
+	Assert(t).IsNil(err, "Unexpected number of pods scheduled")
 }
 
 func TestPublishToReplication(t *testing.T) {
+	retryInterval = testFarmRetryInterval
+
 	//
 	// Setup fixture and schedule a pod
 	//
@@ -363,11 +356,8 @@ func TestPublishToReplication(t *testing.T) {
 
 	scheduled := scheduledPods(t, ds)
 	Assert(t).AreEqual(len(scheduled), 0, "expected no pods to have been labeled")
-	manifestResults, _, err := kpStore.AllPods(kp.INTENT_TREE)
-	if err != nil {
-		t.Fatalf("Unable to get all pods from pod store: %v", err)
-	}
-	Assert(t).AreEqual(len(manifestResults), 0, "expected no manifests to have been scheduled")
+	err = waitForPodsInIntent(kpStore, 0)
+	Assert(t).IsNil(err, "Unexpected number of pods scheduled")
 
 	err = applicator.SetLabel(labels.NODE, "node1", "nodeQuality", "good")
 	Assert(t).IsNil(err, "expected no error labeling node1")
@@ -412,4 +402,44 @@ func TestPublishToReplication(t *testing.T) {
 	}
 	numNodes = waitForNodes(t, ds, 0, desiresErrCh, dsChangesErrCh)
 	Assert(t).AreEqual(numNodes, 0, "took too long to unschedule")
+}
+
+// Polls for the store to have the same number of pods as the argument
+func waitForPodsInIntent(kpStore *kptest.FakePodStore, numPodsExpected int) error {
+	condition := func() error {
+		manifestResults, _, err := kpStore.AllPods(kp.INTENT_TREE)
+		if err != nil {
+			return util.Errorf("Unable to get all pods from pod store: %v", err)
+		}
+		if len(manifestResults) != numPodsExpected {
+			return util.Errorf(
+				"Expected no manifests to be scheduled, got '%v' manifests, expected '%v'",
+				len(manifestResults),
+				numPodsExpected,
+			)
+		}
+		return nil
+	}
+	return waitForCondition(condition)
+}
+
+// Polls for the store to have a pod with the same pod id and node name
+func waitForSpecificPod(kpStore *kptest.FakePodStore, nodeName types.NodeName, podID types.PodID) error {
+	condition := func() error {
+		manifestResults, _, err := kpStore.AllPods(kp.INTENT_TREE)
+		if err != nil {
+			return util.Errorf("Unable to get all pods from pod store: %v", err)
+		}
+		if manifestResults[0].PodLocation.Node != nodeName {
+			return util.Errorf("expected manifest scheduled on the right node")
+		}
+		if manifestResults[0].PodLocation.PodID != podID {
+			return util.Errorf("expected manifest scheduled with correct pod ID")
+		}
+		if manifestResults[0].Manifest.ID() != podID {
+			return util.Errorf("expected manifest with correct ID")
+		}
+		return nil
+	}
+	return waitForCondition(condition)
 }

--- a/pkg/ds/daemon_set_test.go
+++ b/pkg/ds/daemon_set_test.go
@@ -151,6 +151,10 @@ func TestSchedule(t *testing.T) {
 	kpStore := kptest.NewFakePodStore(make(map[kptest.FakePodStoreKey]manifest.Manifest), make(map[string]kp.WatchResult))
 	applicator := labels.NewFakeApplicator()
 
+	preparer := kptest.NewFakePreparer(kpStore, logging.DefaultLogger)
+	preparer.Enable()
+	defer preparer.Disable()
+
 	var allNodes []types.NodeName
 	allNodes = append(allNodes, "node1", "node2", "nodeOk")
 	for i := 0; i < 10; i++ {
@@ -291,9 +295,6 @@ func TestSchedule(t *testing.T) {
 	numNodes = waitForNodes(t, ds, 23, desiresErrCh, dsChangesErrCh)
 	Assert(t).AreEqual(numNodes, 23, "took too long to schedule")
 
-	err = waitForPodsInIntent(kpStore, 23)
-	Assert(t).IsNil(err, "Unexpected number of pods scheduled")
-
 	//
 	// Deleting the daemon set should unschedule all of its nodes
 	//
@@ -336,6 +337,10 @@ func TestPublishToReplication(t *testing.T) {
 
 	kpStore := kptest.NewFakePodStore(make(map[kptest.FakePodStoreKey]manifest.Manifest), make(map[string]kp.WatchResult))
 	applicator := labels.NewFakeApplicator()
+
+	preparer := kptest.NewFakePreparer(kpStore, logging.DefaultLogger)
+	preparer.Enable()
+	defer preparer.Disable()
 
 	var allNodes []types.NodeName
 	allNodes = append(allNodes, "node1", "node2")

--- a/pkg/ds/farm_test.go
+++ b/pkg/ds/farm_test.go
@@ -45,6 +45,9 @@ func TestContendNodes(t *testing.T) {
 	logger := logging.DefaultLogger.SubLogger(logrus.Fields{
 		"farm": "contendNodes",
 	})
+	preparer := kptest.NewFakePreparer(kpStore, logging.DefaultLogger)
+	preparer.Enable()
+	defer preparer.Disable()
 
 	var allNodes []types.NodeName
 	allNodes = append(allNodes, "node1")
@@ -153,6 +156,9 @@ func TestContendSelectors(t *testing.T) {
 	logger := logging.DefaultLogger.SubLogger(logrus.Fields{
 		"farm": "contendSelectors",
 	})
+	preparer := kptest.NewFakePreparer(kpStore, logging.DefaultLogger)
+	preparer.Enable()
+	defer preparer.Disable()
 
 	var allNodes []types.NodeName
 	happyHealthChecker := fake_checker.HappyHealthChecker(allNodes)
@@ -295,6 +301,9 @@ func TestFarmSchedule(t *testing.T) {
 	logger := logging.DefaultLogger.SubLogger(logrus.Fields{
 		"farm": "farmSchedule",
 	})
+	preparer := kptest.NewFakePreparer(kpStore, logging.DefaultLogger)
+	preparer.Enable()
+	defer preparer.Disable()
 
 	var allNodes []types.NodeName
 	allNodes = append(allNodes, "node1", "node2", "node3")
@@ -468,6 +477,10 @@ func TestCleanupPods(t *testing.T) {
 	kpStore := kptest.NewFakePodStore(make(map[kptest.FakePodStoreKey]manifest.Manifest), make(map[string]kp.WatchResult))
 	applicator := labels.NewFakeApplicator()
 
+	preparer := kptest.NewFakePreparer(kpStore, logging.DefaultLogger)
+	preparer.Enable()
+	defer preparer.Disable()
+
 	// Make some dangling pod labels and instantiate a farm and expect it clean it up
 	podID := types.PodID("testPod")
 	manifestBuilder := manifest.NewBuilder()
@@ -552,6 +565,11 @@ func TestMultipleFarms(t *testing.T) {
 	dsStore := dsstoretest.NewFake()
 	kpStore := kptest.NewFakePodStore(make(map[kptest.FakePodStoreKey]manifest.Manifest), make(map[string]kp.WatchResult))
 	applicator := labels.NewFakeApplicator()
+
+	preparer := kptest.NewFakePreparer(kpStore, logging.DefaultLogger)
+	preparer.Enable()
+	defer preparer.Disable()
+
 	session := kptest.NewSession()
 	firstLogger := logging.DefaultLogger.SubLogger(logrus.Fields{
 		"farm": "firstMultiple",

--- a/pkg/kp/kptest/fake_preparer.go
+++ b/pkg/kp/kptest/fake_preparer.go
@@ -1,0 +1,97 @@
+package kptest
+
+import (
+	"sync"
+	"time"
+
+	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/logging"
+)
+
+const (
+	checkRate = time.Duration(100 * time.Millisecond)
+)
+
+type FakePreparer struct {
+	podStore *FakePodStore
+
+	enabled        bool
+	enableLock     sync.Mutex
+	preparerQuitCh chan struct{}
+	logger         logging.Logger
+}
+
+func NewFakePreparer(podStore *FakePodStore, logger logging.Logger) *FakePreparer {
+	return &FakePreparer{
+		podStore: podStore,
+		enabled:  false,
+		logger:   logger,
+	}
+}
+
+func (f *FakePreparer) Enable() {
+	f.enableLock.Lock()
+	defer f.enableLock.Unlock()
+
+	if f.enabled {
+		return
+	}
+	f.enabled = true
+	f.preparerQuitCh = make(chan struct{})
+
+	go func() {
+		for {
+			select {
+			case <-f.preparerQuitCh:
+				return
+			case <-time.Tick(checkRate):
+				// Get all pods
+				allPods, _, err := f.podStore.AllPods(kp.INTENT_TREE)
+				if err != nil {
+					f.logger.Errorf("Error getting all pods: %v", err)
+					continue
+				}
+				// Make a copy to know what to delete
+				podsToDelete := make(map[kp.ManifestResult]struct{})
+				for _, manifestResult := range allPods {
+					podsToDelete[manifestResult] = struct{}{}
+				}
+				// Set pods that are in intent
+				for _, manifestResult := range allPods {
+					_, err = f.podStore.SetPod(
+						kp.REALITY_TREE,
+						manifestResult.PodLocation.Node,
+						manifestResult.Manifest,
+					)
+					if err != nil {
+						f.logger.Errorf("Error setting pod: %v", err)
+					}
+					delete(podsToDelete, manifestResult)
+				}
+				// Delete pods that are missing from intent
+				for manifestResult := range podsToDelete {
+					_, err = f.podStore.DeletePod(
+						kp.REALITY_TREE,
+						manifestResult.PodLocation.Node,
+						manifestResult.PodLocation.PodID,
+					)
+					if err != nil {
+						f.logger.Errorf("Error deleting pod: %v", err)
+					}
+				}
+			}
+		}
+	}()
+}
+
+func (f *FakePreparer) Disable() {
+	f.enableLock.Lock()
+	defer f.enableLock.Unlock()
+
+	if !f.enabled {
+		return
+	}
+
+	f.enabled = false
+	close(f.preparerQuitCh)
+}


### PR DESCRIPTION
Added a waiting function that can wait up to a total of 5 seconds for the farm to finish running when waiting for the ds farm to apply its labels.

I am going to test this on travis CI a couple times to make sure it works.