### PR TITLE
improve the information density of dsctl's list command

### DIFF
--- a/bin/p2-dsctl/main.go
+++ b/bin/p2-dsctl/main.go
@@ -150,7 +150,7 @@ func main() {
 			log.Fatalf("err: %v", err)
 		}
 		for _, ds := range dsList {
-			fmt.Println(ds.ID)
+			fmt.Printf("%s/%s:%s\n", ds.PodID, ds.Name, ds.ID)
 		}
 
 	case CmdEnable:


### PR DESCRIPTION
I experimented with including more things here (NodeSelector, manifest SHA, etc) but it got a bit unwieldy. This is enough info to help one use `p2-dsctl get` or `p2-dsctl update` and get the full scoop on the DS you're interested in.