### PR TITLE
labels: Add "Accept" header to HttpApplicator requests

### DIFF
--- a/pkg/labels/http_applicator.go
+++ b/pkg/labels/http_applicator.go
@@ -69,7 +69,13 @@ func (h *httpApplicator) GetMatches(selector labels.Selector, labelType Type) ([
 	urlToGet := *h.matchesEndpoint
 	urlToGet.RawQuery = params.Encode()
 
-	resp, err := h.client.Get(urlToGet.String())
+	req, err := http.NewRequest("GET", urlToGet.String(), nil)
+	if err != nil {
+		return []Labeled{}, err
+	}
+	req.Header.Add("Accept", "application/json")
+
+	resp, err := h.client.Do(req)
 	if err != nil {
 		return []Labeled{}, err
 	}


### PR DESCRIPTION
Add an "Accept: application/json" header to the requests sent by the
httpApplicator type. Only JSON is accepted, and the server is only
allowed to return JSON, but having an explicit Accept header plays
nicely with HTTP middleware.