### PR TITLE
Add a missing return statement in replication

### DIFF
--- a/pkg/replication/replication.go
+++ b/pkg/replication/replication.go
@@ -398,6 +398,7 @@ func (r *replication) ensureHealthy(
 				nodeLogger.WithFields(logrus.Fields{"check": id, "health": status}).Infoln("Node is not healthy")
 			} else {
 				r.logger.WithField("node", node).Infoln("Node is current and healthy")
+				return
 			}
 		}
 	}


### PR DESCRIPTION
Replication was taking too long and was always timing out because a
return statement was missing.

https://github.com/KoishiKomeiji/p2/blob/087a0abcbadf77d40302db123637866addba310b/pkg/replication/replication.go
