### PR TITLE
override locks

### DIFF
--- a/pkg/ds/daemon_set.go
+++ b/pkg/ds/daemon_set.go
@@ -473,12 +473,23 @@ func (ds *daemonSet) PublishToReplication() error {
 
 	ds.logger.Info("New replicator was made")
 
-	// Do not override locks, ignore controllers, and don't check for preparers
+	// Replication locks are designed to make sure that two replications to
+	// the same nodes cannot occur at the same time. The granularity is
+	// pod-wide as an optimization for consul performance (only need to
+	// lock a single key) with limited downside when human operators are
+	// executing deploys, because the likelihood of a lock collision is
+	// low. With daemon sets, locking is not necessary because the node
+	// sets should not overlap when they are managed properly. Even when
+	// there is a node overlap between two daemon sets, a simple mutual
+	// exclusion lock around replication will not prevent the pod manifest
+	// on an overlapped node from thrashing. Therefore, it makes sense for
+	// daemon sets to ignore this locking mechanism and always try to
+	// converge nodes to the specified manifest
 	replication, errCh, err := repl.InitializeReplicationWithCheck(
-		false,
-		true,
+		true, // override locks
+		true, // ignore Replication Controllers
 		replication.DefaultConcurrentReality,
-		false,
+		false, // Ignore missing preparers by writing intent/ anyway
 	)
 	if err != nil {
 		ds.logger.Errorf("Unable to initialize replication: %s", err)


### PR DESCRIPTION
Based on our experience with Daemon Sets in the wild, it is more
valuable to have multiple Daemon Sets executing replications at once
than it is to mutually exclude them to prevent operator error.

Considering the failure cases of overlapping Daemon Set selectors - they
are similar under values of this boolean. If we mutex replications per
pod, then we experience an undefined state of intent/ on any hosts in
the intersection. If we remove the mutex, then this undefined behavior
is more apparent (as it may change multiple times per minute) but it is
no worse or better than in the case using the mutex.