### PR TITLE
pods: Write config files robustly

### DIFF
--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -609,7 +609,7 @@ func writeEnvFile(envDir, name, value string, uid, gid int) error {
 	return writeFileChown(filepath.Join(envDir, name), []byte(value), uid, gid)
 }
 
-// writeFileChown writes data to a file and sets the owing user/group of the file.
+// writeFileChown writes data to a file and sets its owner.
 func writeFileChown(filename string, data []byte, uid, gid int) error {
 	file, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {


### PR DESCRIPTION
When writing a pod's config and platform config files, make the
procedure a little more robust to rare errors:
* Fix nil pointer dereference when the open() fails
* close() earlier and detect its errors

An empty platform config file was observed on one host. I don't have any
particular insight into how that could happen, but these changes might
help.