### PR TITLE
Improve the "quitting" log messages in p2-preparer

### DIFF
--- a/pkg/health/store/store.go
+++ b/pkg/health/store/store.go
@@ -48,7 +48,7 @@ func (hs *healthStore) StartWatch(quitCh <-chan struct{}) {
 		case updates := <-healthUpdates:
 			hs.cache(updates)
 		case <-quitCh:
-			hs.logger.Errorln("Quitting...")
+			hs.logger.Infoln("p2-preparer quitting, ceasing to publish health")
 			return
 		case err := <-errCh:
 			hs.logger.WithError(err).Errorln("Consul Watch error")

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -129,7 +129,7 @@ func (p *Preparer) WatchForPodManifestsForNode(quitAndAck chan struct{}) {
 			}
 		case <-quitAndAck:
 			for podToQuit, quitCh := range quitChanMap {
-				p.Logger.WithField("pod", podToQuit).Infoln("Quitting...")
+				p.Logger.WithField("pod", podToQuit).Infof("p2-preparer quitting, ceasing to watch for updates to %s", podToQuit)
 				quitCh <- struct{}{}
 			}
 			close(quitChan)


### PR DESCRIPTION
There are two routines that both had identical "Quitting..." log
messages, and it's unclear what they mean. Now the messages are more
specific to the functionality that is stopping.

Furthermore, the routine watching for pod updates would make it look
like the pod being managed itself is quitting, rather than the
p2-preparer quitting (usually for an update). This can cause confusion
as it makes it look like all of the preparer's pods are being shut down
at the same time.