### PR TITLE
Log the cancellation of a replication.

### DIFF
--- a/pkg/replication/replication.go
+++ b/pkg/replication/replication.go
@@ -244,6 +244,7 @@ func (r replication) Enact() {
 
 // Cancels all goroutines (e.g. replication and lock renewal)
 func (r replication) Cancel() {
+	r.logger.Infof("Replication canceled")
 	close(r.replicationCancelledCh)
 }
 


### PR DESCRIPTION
Daemon sets in particular start and cancel replication under a variety
of circumstances, it makes sense to log this event so that it is easier
to observe the behavior of a daemon set.