### PR TITLE
Remove buggy check in hookenv.PodFromDisk()

### DIFF
--- a/pkg/hooks/hook_env.go
+++ b/pkg/hooks/hook_env.go
@@ -76,11 +76,6 @@ func (h *HookEnv) PodFromDisk() (*pods.Pod, error) {
 
 	pod := pods.NewPod(id, node, path)
 
-	// Spot check that the pod is actually on the disk by looking for the current manifest
-	if _, err := pod.CurrentManifest(); err != nil {
-		return nil, err
-	}
-
 	return pod, nil
 }
 


### PR DESCRIPTION
The PodFromDisk() function returned an error if there was no
current_manifest.yaml on the disk for that node. This was to protect
agains thooks loadinga pod struct from disk before it is placed.

However, some hooks are knowingly loading the pod after it has been
installed but before the current manifest exists.

This check has been replaced with a check that the hook event is
BEFORE_INSTALL, in which case the pod should not be loaded from disk.