### PR TITLE
Minor updates to session publisher

### DIFF
--- a/bin/p2-ds-farm/main.go
+++ b/bin/p2-ds-farm/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/square/p2/pkg/kp/flags"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
-	"github.com/square/p2/pkg/util/stream"
 
 	ds_farm "github.com/square/p2/pkg/ds"
 )
@@ -49,10 +48,8 @@ func main() {
 		Behavior:  api.SessionBehaviorDelete,
 		TTL:       "15s",
 	}, client, sessions, quitCh, logger)
-	pub := stream.NewStringValuePublisher(sessions, "")
-	dsSub := pub.Subscribe(nil)
 
-	dsf := ds_farm.NewFarm(kpStore, dsStore, applicator, dsSub.Chan(), logger, nil, &healthChecker)
+	dsf := ds_farm.NewFarm(kpStore, dsStore, applicator, sessions, logger, nil, &healthChecker)
 
 	go func() {
 		// clear lock immediately on ctrl-C

--- a/bin/p2-rctl-server/main.go
+++ b/bin/p2-rctl-server/main.go
@@ -104,8 +104,8 @@ func main() {
 		TTL:       "15s",
 	}, client, sessions, nil, logger)
 	pub := stream.NewStringValuePublisher(sessions, "")
-	rcSub := pub.Subscribe(nil)
-	rlSub := pub.Subscribe(nil)
+	rcSub := pub.Subscribe()
+	rlSub := pub.Subscribe()
 
 	alerter := alerting.NewNop()
 	if *pagerdutyServiceKey != "" {

--- a/pkg/kp/healthmanager.go
+++ b/pkg/kp/healthmanager.go
@@ -115,7 +115,7 @@ func (m *consulHealthManager) NewUpdater(pod types.PodID, service string) Health
 		checker: checksStream,
 	}
 	go func() {
-		sub := m.sessionPub.Subscribe(nil)
+		sub := m.sessionPub.Subscribe()
 		defer sub.Unsubscribe()
 		processHealthUpdater(
 			m.client,

--- a/pkg/util/stream/publisher.go
+++ b/pkg/util/stream/publisher.go
@@ -68,16 +68,10 @@ func (p *StringValuePublisher) read() {
 	}
 }
 
-// Subscribe creates a new subscription to the publisher's data stream. If a nil channel
-// argument is passed, one will be created for the caller. If a channel is provided, the
-// subscription takes ownership of the channel and will close it if the publisher's input
-// is closed.
-func (p *StringValuePublisher) Subscribe(values chan string) *StringSubscription {
-	if values == nil {
-		values = make(chan string)
-	}
+// Subscribe creates a new subscription to the publisher's data stream.
+func (p *StringValuePublisher) Subscribe() *StringSubscription {
 	s := &StringSubscription{
-		values:      values,
+		values:      make(chan string),
 		initialized: make(chan struct{}),
 		canceled:    make(chan struct{}),
 		publisher:   p,


### PR DESCRIPTION
* p2-ds-farm: Remove string publisher

  One subscriber doesn't need a publisher

* stream: Remove user-provided channels for subscriptions

  It was never used

* p2-rctl-server: Move Subscribe() call near its use

  Good hygiene