### PR TITLE
Remove IsUUID field from PodUniqueKey struct

### DIFF
--- a/pkg/kp/kv_test.go
+++ b/pkg/kp/kv_test.go
@@ -67,13 +67,11 @@ func TestPodUniqueKeyFromConsulPath(t *testing.T) {
 			path: "intent/example.com/mysql",
 			err:  false,
 			uuid: false,
-			str:  "example.com/mysql",
 		},
 		{
 			path: "reality/example.com/mysql",
 			err:  false,
 			uuid: false,
-			str:  "example.com/mysql",
 		},
 		{
 			path: "labels/example.com/mysql",
@@ -87,7 +85,6 @@ func TestPodUniqueKeyFromConsulPath(t *testing.T) {
 			path: "hooks/all_hooks",
 			err:  false,
 			uuid: false,
-			str:  "hooks/all_hooks",
 		},
 		{
 			path: fmt.Sprintf("intent/example.com/%s", uuid),
@@ -111,11 +108,11 @@ func TestPodUniqueKeyFromConsulPath(t *testing.T) {
 			continue
 		}
 
-		if podUniqueKey.IsUUID != expectation.uuid {
-			t.Errorf("Expected IsUUID() to be %t, was %t", expectation.uuid, podUniqueKey.IsUUID)
+		if (podUniqueKey != nil) != expectation.uuid {
+			t.Errorf("Expected (podUniqueKey != nil) to be %t, was %t", expectation.uuid, podUniqueKey != nil)
 		}
 
-		if podUniqueKey.ID != expectation.str {
+		if expectation.uuid && podUniqueKey.ID != expectation.str {
 			t.Errorf("Expected key string to be %s, was %t", expectation.str, podUniqueKey.ID)
 		}
 	}

--- a/pkg/kp/podstore/consul_store.go
+++ b/pkg/kp/podstore/consul_store.go
@@ -174,8 +174,8 @@ func (c *consulStore) Schedule(manifest manifest.Manifest, node types.NodeName) 
 }
 
 func (c *consulStore) Unschedule(podKey types.PodUniqueKey) error {
-	if !podKey.IsUUID {
-		return util.Errorf("Pod store can only delete pods with uuid keys (key was '%s')", podKey.ID)
+	if podKey.ID == "" {
+		return util.Errorf("Pod store can only delete pods with uuid keys")
 	}
 
 	// Read the pod so we know which node the secondary index will have
@@ -251,8 +251,8 @@ func IsNoPod(err error) bool {
 }
 
 func (c *consulStore) ReadPod(podKey types.PodUniqueKey) (Pod, error) {
-	if !podKey.IsUUID {
-		return Pod{}, util.Errorf("Pod store can only read pods with uuid keys (key was '%s')", podKey.ID)
+	if podKey.ID == "" {
+		return Pod{}, util.Errorf("Pod store can only read pods with uuid keys")
 	}
 
 	if pod, ok := c.fetchFromCache(podKey); ok {

--- a/pkg/kp/statusstore/podstatus/consul_store.go
+++ b/pkg/kp/statusstore/podstatus/consul_store.go
@@ -24,8 +24,8 @@ func NewConsul(statusStore statusstore.Store, namespace statusstore.Namespace) S
 }
 
 func (c *consulStore) Get(key types.PodUniqueKey) (PodStatus, error) {
-	if !key.IsUUID {
-		return PodStatus{}, util.Errorf("Could not get status for pod '%s': pod status is only compatible with pods with uuid keys", key.ID)
+	if key.ID == "" {
+		return PodStatus{}, util.Errorf("Cannot retrieve status for a pod with an empty uuid")
 	}
 
 	status, err := c.statusStore.GetStatus(statusstore.POD, statusstore.ResourceID(key.ID), c.namespace)
@@ -37,8 +37,8 @@ func (c *consulStore) Get(key types.PodUniqueKey) (PodStatus, error) {
 }
 
 func (c *consulStore) Set(key types.PodUniqueKey, status PodStatus) error {
-	if !key.IsUUID {
-		return util.Errorf("Could not set status for pod '%s': pod status is only compatible with pods with uuid keys", key.ID)
+	if key.ID == "" {
+		return util.Errorf("Could not set status for pod with empty uuid")
 	}
 
 	rawStatus, err := podStatusToStatus(status)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -15,29 +15,22 @@ type NodeName string
 // running at a given time
 type PodID string
 
-// A unique identifier for each pod (instance). At the time of defining this
-// type a PodUniqueKey is is the hostname of the node on which the pod is running
-// and the pod id joined with a slash, e.g. "example.com/mysql" if a pod with id
-// "mysql" is running on a node "example.com".
+// A unique identifier for each pod (instance) expressed as a UUID. Supporting
+// UUIDs is a new feature, meaning that this type will typically be used within
+// a pointer. A nil *PodUniqueKey signifies a legacy pod for which there is no
+// uuid.
 //
 // P2 will begin using uuids instead of the previous format to better support
 // running multiple pods with the same pod id on the same node. Certain new
 // functionality will only be supported for pods with UUID unique keys, hence
-// the need for the bool.
+// the need for using pointers and checking for non-nil values.
 type PodUniqueKey struct {
-	// The actual key, e.g. "example.com/mysql" under the old format or a uuid
-	// under the new format
-	ID string `json:"id"`
-
-	// Tracks whether the key is a uuid or the node/pod_id concatenation. Some
-	// features will require isUUID to be true.
-	IsUUID bool `json:"is_uuid"`
+	ID string `json:"id"` // a uuid
 }
 
 func NewPodUUID() PodUniqueKey {
 	return PodUniqueKey{
-		ID:     uuid.New(),
-		IsUUID: true,
+		ID: uuid.New(),
 	}
 }
 


### PR DESCRIPTION
The field was obviously used to differentiate PodUniqueKey structs that
signify a UUID from those that don't. Prior to this commit, the ID field
would be the consul key e.g. /intent/<node>/<pod_id> if IsUUID was
false.

After making use of PodUniqueKey, it's becoming clear that this struct
is ONLY useful in contexts where it's signifying a UUID. As a result,
this commit removes the IsUUID field and uses a nil pointer to a
PodUniqueKey to signify a legacy pod that does not have a UUID.