### PR TITLE
Add command to reset reality for a host

### DIFF
--- a/bin/p2-wipe-reality/main.go
+++ b/bin/p2-wipe-reality/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"log"
+
+	"github.com/square/p2/pkg/kp"
+	"github.com/square/p2/pkg/kp/flags"
+	"github.com/square/p2/pkg/types"
+	"github.com/square/p2/pkg/version"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	nodeName = kingpin.Arg("node", "The node to wipe reality for").Required().String()
+	help     = `p2-wipe-reality takes a hostname, a token and recursively deletes all pods
+in the reality tree. This is useful if any pods on a host have
+been manually altered in some way and need to be restored to
+a known state.
+`
+)
+
+func main() {
+	// CLI takes a hostname, a token and recursively deletes all pods
+	// in the reality tree. This is useful if any pods on a host have
+	// been manually altered in some way and need to be restored to
+	// a known state.
+	kingpin.Version(version.VERSION)
+	_, opts := flags.ParseWithConsulOptions()
+
+	client := kp.NewConsulClient(opts)
+	store := kp.NewConsulStore(client)
+
+	pods, _, err := store.ListPods(kp.REALITY_TREE, types.NodeName(*nodeName))
+	if err != nil {
+		log.Fatalf("Could not list pods for node %v: %v", *nodeName, err)
+	}
+	for _, pod := range pods {
+		log.Printf("Deleting %v from reality\n", pod.Manifest.ID())
+		_, err := store.DeletePod(kp.REALITY_TREE, types.NodeName(*nodeName), pod.Manifest.ID())
+		if err != nil {
+			log.Fatalf("Could not remove %v from pod reality tree: %v", err)
+		}
+	}
+}

--- a/pkg/kp/flags/kingpin.go
+++ b/pkg/kp/flags/kingpin.go
@@ -3,6 +3,8 @@
 package flags
 
 import (
+	"io/ioutil"
+	"log"
 	"net/http"
 
 	"github.com/square/p2/pkg/kp"
@@ -13,11 +15,20 @@ import (
 func ParseWithConsulOptions() (string, kp.Options) {
 	url := kingpin.Flag("consul", "The hostname and port of a consul agent in the p2 cluster. Defaults to 0.0.0.0:8500.").String()
 	token := kingpin.Flag("token", "The consul ACL token to use. Empty by default.").String()
+	tokenFile := kingpin.Flag("token-file", "The file containing the Consul ACL token").ExistingFile()
 	headers := kingpin.Flag("header", "An HTTP header to add to requests, in KEY=VALUE form. Can be specified multiple times.").StringMap()
 	https := kingpin.Flag("https", "Use HTTPS").Bool()
 	wait := kingpin.Flag("wait", "Maximum duration for Consul watches, before resetting and starting again.").Default("30s").Duration()
 
 	cmd := kingpin.Parse()
+
+	if *tokenFile != "" {
+		tokenBytes, err := ioutil.ReadFile(*tokenFile)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		*token = string(tokenBytes)
+	}
 	return cmd, kp.Options{
 		Address:  *url,
 		Token:    *token,


### PR DESCRIPTION
This allows a host that has been manipulated by hand to be fully restored to the state set in Consul. For discussion: should we not operate on the preparer itself?