### PR TITLE
Double the hook timeout

### DIFF
--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -28,7 +28,7 @@ const (
 	HOOKED_ENV_PATH_ENV_VAR        = "HOOKED_ENV_PATH"
 	HOOKED_CONFIG_DIR_PATH_ENV_VAR = "HOOKED_CONFIG_DIR_PATH"
 
-	DefaultTimeout = 60 * time.Second
+	DefaultTimeout = 120 * time.Second
 )
 
 type Pod interface {


### PR DESCRIPTION
some hooks stop services that take as long as 60s to cleanly shutdown.