### PR TITLE
Increase WatchPrefix latency where appropriate

### DIFF
--- a/pkg/health/checker/checker.go
+++ b/pkg/health/checker/checker.go
@@ -150,7 +150,7 @@ func (c consulHealthChecker) WatchHealth(
 	// closed by watchPrefix when we close quitWatch
 	inCh := make(chan api.KVPairs)
 	watchErrCh := make(chan error)
-	go consulutil.WatchPrefix("health/", c.kv, inCh, quitCh, watchErrCh, 0)
+	go consulutil.WatchPrefix("health/", c.kv, inCh, quitCh, watchErrCh, 1*time.Second)
 	publishErrCh := publishLatestHealth(inCh, quitCh, resultCh)
 
 	for {

--- a/pkg/kp/dsstore/consul_store.go
+++ b/pkg/kp/dsstore/consul_store.go
@@ -335,7 +335,7 @@ func (s *consulStore) WatchAll(quitCh <-chan struct{}) <-chan WatchedDaemonSetLi
 	errCh := make(chan error, 1)
 
 	// Watch for changes in the dsTree and deletedDSTree
-	go consulutil.WatchPrefix(dsTree, s.kv, inCh, quitCh, errCh, time.Duration(250*time.Millisecond))
+	go consulutil.WatchPrefix(dsTree, s.kv, inCh, quitCh, errCh, 5*time.Second)
 
 	go func() {
 		defer close(outCh)

--- a/pkg/kp/pcstore/consul_store.go
+++ b/pkg/kp/pcstore/consul_store.go
@@ -302,7 +302,7 @@ func (s *consulStore) Watch(quit <-chan struct{}) <-chan WatchedPodClusters {
 	outCh := make(chan WatchedPodClusters)
 	errChan := make(chan error, 1)
 
-	go consulutil.WatchPrefix(podClusterTree, s.kv, inCh, quit, errChan, 0)
+	go consulutil.WatchPrefix(podClusterTree, s.kv, inCh, quit, errChan, 5*time.Second)
 
 	go func() {
 		var kvp api.KVPairs

--- a/pkg/kp/rcstore/consul_store.go
+++ b/pkg/kp/rcstore/consul_store.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/pborman/uuid"
@@ -184,7 +185,7 @@ func (s *consulStore) WatchNew(quit <-chan struct{}) (<-chan []fields.RC, <-chan
 	inCh := make(chan api.KVPairs)
 
 	outCh, errCh := publishLatestRCs(inCh, quit)
-	go consulutil.WatchPrefix(rcTree+"/", s.kv, inCh, quit, errCh, 0)
+	go consulutil.WatchPrefix(rcTree+"/", s.kv, inCh, quit, errCh, 1*time.Second)
 
 	return outCh, errCh
 }
@@ -214,7 +215,7 @@ func (s *consulStore) WatchNewWithRCLockInfo(quit <-chan struct{}) (<-chan []RCL
 	combinedErrCh := make(chan error)
 
 	rcCh, rcErrCh := publishLatestRCs(inCh, quit)
-	go consulutil.WatchPrefix(rcTree+"/", s.kv, inCh, quit, rcErrCh, 0)
+	go consulutil.WatchPrefix(rcTree+"/", s.kv, inCh, quit, rcErrCh, 1*time.Second)
 
 	// Process RC updates and augment them with lock information
 	outCh, lockInfoErrCh := s.publishLatestRCsWithLockInfo(rcCh, quit)


### PR DESCRIPTION
We observe a lot of network and disk read IO and we suspect it's related
to hungry watches on big trees. Presently, our consul trees are large:
/labels = 7 Megabytes
/intent,/reality = 57 Megabytes
/replication_controllers = 2.5 Megabytes

We need to be more cognizant about the costs of this data access pattern as it relates to our current datastore. I note, without comment, that differential watches are not coming soon to consul.