### PR TITLE
daemon_set: skip locking

### DIFF
--- a/pkg/ds/daemon_set.go
+++ b/pkg/ds/daemon_set.go
@@ -503,11 +503,8 @@ func (ds *daemonSet) PublishToReplication() error {
 	// on an overlapped node from thrashing. Therefore, it makes sense for
 	// daemon sets to ignore this locking mechanism and always try to
 	// converge nodes to the specified manifest
-	replication, errCh, err := repl.InitializeReplicationWithCheck(
-		true, // override locks
-		true, // ignore Replication Controllers
+	replication, errCh, err := repl.InitializeDaemonSetReplication(
 		replication.DefaultConcurrentReality,
-		false, // Ignore missing preparers by writing intent/ anyway
 		ds.rateLimitInterval,
 	)
 	if err != nil {

--- a/pkg/replication/replication.go
+++ b/pkg/replication/replication.go
@@ -317,10 +317,13 @@ func (r *replication) WaitForReplication() {
 // * The replication is canceled.
 // * Errors in lock renewal (as signaled on the passed channel).
 //   In this case, the error needs to be communicated up a level.
+//   The passed channel may be nil, in which case this case is not checked,
+//   but the others still are.
 //
 // When replication finishes for any of these reasons, this function is responsible for:
 // * Stopping the replication (if it has not already)
-// * Destroying its session (passed in to this function)
+// * Destroying its session (passed in to this function.
+//   Passing nil is legal, in which case it is not destroyed)
 func (r *replication) handleReplicationEnd(session kp.Session, renewalErrCh chan error) {
 	defer func() {
 		close(r.quitCh)
@@ -328,7 +331,9 @@ func (r *replication) handleReplicationEnd(session kp.Session, renewalErrCh chan
 		if r.rateLimiter != nil {
 			r.rateLimiter.Stop()
 		}
-		_ = session.Destroy()
+		if session != nil {
+			_ = session.Destroy()
+		}
 	}()
 
 	select {

--- a/pkg/replication/replicator.go
+++ b/pkg/replication/replicator.go
@@ -178,10 +178,12 @@ func (r replicator) initializeReplicationWithCheck(
 	// To make a closed channel
 	close(replication.enactedCh)
 
-	err = replication.lockHosts(overrideLock, r.lockMessage)
+	session, renewalErrCh, err := replication.lockHosts(overrideLock, r.lockMessage)
 	if err != nil {
 		return nil, errCh, err
 	}
+	go replication.handleReplicationEnd(session, renewalErrCh)
+
 	if !ignoreControllers {
 		err = replication.checkForManaged()
 		if err != nil {

--- a/pkg/replication/replicator.go
+++ b/pkg/replication/replicator.go
@@ -37,12 +37,13 @@ type Replicator interface {
 		rateLimitInterval time.Duration,
 	) (Replication, chan error, error)
 
-	// Same as InitializeReplication but can skip the checkPreparers
-	InitializeReplicationWithCheck(
-		overrideLock bool,
-		ignoreControllers bool,
+	// InitializeDaemonSetReplication creates a Replication with parameters suitable for a daemon set.
+	// Specifically:
+	// * locks are overridden
+	// * replication controllers are ignored
+	// * and preparers are not checked.
+	InitializeDaemonSetReplication(
 		concurrentRealityRequests int,
-		checkPreparers bool,
 		rateLimitInterval time.Duration,
 	) (Replication, chan error, error)
 }
@@ -116,19 +117,16 @@ func (r replicator) InitializeReplication(
 	)
 }
 
-func (r replicator) InitializeReplicationWithCheck(
-	overrideLock bool,
-	ignoreControllers bool,
+func (r replicator) InitializeDaemonSetReplication(
 	concurrentRealityRequests int,
-	checkPreparers bool,
 	rateLimitInterval time.Duration,
 ) (Replication, chan error, error) {
 	return r.initializeReplicationWithCheck(
-		overrideLock,
-		ignoreControllers,
+		true, // override locks
+		true, // ignore Replication Controllers
 		concurrentRealityRequests,
-		checkPreparers,
-		false,
+		false, // Ignore missing preparers by writing intent/ anyway
+		false, // do not skip locking
 		rateLimitInterval,
 	)
 }

--- a/pkg/replication/replicator.go
+++ b/pkg/replication/replicator.go
@@ -39,7 +39,7 @@ type Replicator interface {
 
 	// InitializeDaemonSetReplication creates a Replication with parameters suitable for a daemon set.
 	// Specifically:
-	// * locks are overridden
+	// * hosts are not locked
 	// * replication controllers are ignored
 	// * and preparers are not checked.
 	InitializeDaemonSetReplication(
@@ -122,11 +122,11 @@ func (r replicator) InitializeDaemonSetReplication(
 	rateLimitInterval time.Duration,
 ) (Replication, chan error, error) {
 	return r.initializeReplicationWithCheck(
-		true, // override locks
+		true, // override locks (irrelevant; they're being skipped)
 		true, // ignore Replication Controllers
 		concurrentRealityRequests,
 		false, // Ignore missing preparers by writing intent/ anyway
-		false, // do not skip locking
+		true,  // skip locking
 		rateLimitInterval,
 	)
 }


### PR DESCRIPTION
InitializeReplicationWithCheck's first argument now controls whether
locks are skipped completely, rather than overridden (now they always
are).

InitializeReplicationWithCheck's first argument now controls whether
locks are skipped completely, rather than overridden (now they always
are).

This is the only place in the code where InitializeReplicationWithCheck
is called.
The behavior change: Now, daemon sets will ignore locks.

This change is desired:
Consider the case where two daemon sets with the same pod ID are
started.
Currently, the second one will override the lock of the first one, and
the first one will stop replicating completely.
That means some nodes do not get the pod installed (if the second one
does not cover all desired nodes)

Since this is undesirable, instead we will skip locking, and trust that
daemon sets will have disjoint node selectors.
The consequence of this assumption being violated is that two daemon
sets would fight over control of any nodes that belong to both of them.

We know that current daemon sets are all disjoint, and currently daemon
set modifications are gated through us so we can maintain this as true.
In addition, we do perform a disjointness check at *creation* time (note
that labels can still change after daemon set creation such that some
node belongs to two daemon sets after they are both created).

The idea is that we will make this change and see if it becomes the case
that we have daemon sets that end up fighting, and take action then.
