### PR TITLE
Fix bugs related to rate limiting replications.

### DIFF
--- a/pkg/replication/replicator.go
+++ b/pkg/replication/replicator.go
@@ -151,10 +151,10 @@ func (r replicator) initializeReplicationWithCheck(
 	}
 
 	// NewTicker() requires the value passed to it to be positive.
-	if rateLimitInterval <= 0 {
-		rateLimitInterval = 1 * time.Nanosecond
+	var ticker *time.Ticker
+	if rateLimitInterval > 0 {
+		ticker = time.NewTicker(rateLimitInterval)
 	}
-	ticker := time.NewTicker(rateLimitInterval)
 
 	errCh := make(chan error)
 	replication := &replication{
@@ -166,7 +166,7 @@ func (r replicator) initializeReplicationWithCheck(
 		health:      r.health,
 		threshold:   r.threshold,
 		logger:      r.logger,
-		rateLimiter: *ticker,
+		rateLimiter: ticker,
 		errCh:       errCh,
 		replicationCancelledCh: make(chan struct{}),
 		replicationDoneCh:      make(chan struct{}),


### PR DESCRIPTION
Bugs fixed:
1) A 1 nanosecond ticker is not a safe default because that causes a lot
of CPU work. Now the ticker used for rate limiting will just be nil if
the specified wait interval is 0, and goroutines will only attempt to
read a value off the ticker's channel if the ticker is not nil.
2) Goroutines pulling values off the ticker's channel also read off of
the quit channel in a select, which will prevent workers from stalling
forever if the ticker is stopped before the workers exit.
3) A check for the ticker's channel being closed was removed because it
will never be closed according to time.Ticker's documentation.