### PR TITLE
logging: Fix data race adding "Counter" to entries

### DIFF
--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -159,6 +159,9 @@ func TestAddUnrecognizedHook(t *testing.T) {
 	Assert(t).IsNotNil(err, "Expected an error for adding an unrecognized hook output type")
 }
 
+// TestConsurrent checks that one logger can be used concurrently without panics (e.g.,
+// from concurrent map accesses) or data races (if the race detector is enabled), which
+// will fail the test instead of explicit t.Error() calls.
 func TestConcurrent(t *testing.T) {
 	logger := NewLogger(nil)
 	const n = 100

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -156,4 +157,19 @@ func TestAddUnrecognizedHook(t *testing.T) {
 
 	err := logger.AddHook("unrecognized_type", "some_destination")
 	Assert(t).IsNotNil(err, "Expected an error for adding an unrecognized hook output type")
+}
+
+func TestConcurrent(t *testing.T) {
+	logger := NewLogger(nil)
+	const n = 100
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			logger.Infoln(i)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 }

--- a/pkg/logging/process_counter.go
+++ b/pkg/logging/process_counter.go
@@ -26,7 +26,12 @@ func (ProcessCounter) Levels() []logrus.Level {
 }
 
 func (p *ProcessCounter) Fire(entry *logrus.Entry) error {
-	entry.Data["Counter"] = atomic.AddUint64(&p.counter, 1) - 1
-	entry.Data["PID"] = os.Getpid()
+	data := make(logrus.Fields, len(entry.Data)+2)
+	for k, v := range entry.Data {
+		data[k] = v
+	}
+	data["Counter"] = atomic.AddUint64(&p.counter, 1) - 1
+	data["PID"] = os.Getpid()
+	entry.Data = data
 	return nil
 }


### PR DESCRIPTION
ProcessCounter.Fire() contained a data race modifying the entry.Data map
to add the "Counter" and "PID" fields. Logrus makes a copy of the Entry
object, but it is shallow, so multiple loggers could share the same map.

The bug is fixed by having Fire() update a copy of Data.