### PR TITLE
consulutil: Fix deadlock when SessionManager exits

### DIFF
--- a/pkg/kp/consulutil/session_controller.go
+++ b/pkg/kp/consulutil/session_controller.go
@@ -64,7 +64,10 @@ func SessionManager(
 			} else {
 				sessionLogger.NoFields().Info("session manager: released session")
 			}
-			output <- ""
+			select {
+			case output <- "":
+			case <-done:
+			}
 		case <-done:
 			// Don't bother reporting the new session if exiting
 			_, _ = client.Session().Destroy(id, nil)


### PR DESCRIPTION
In SessionManager, once its "done" channel is closed, there is no
guarantee that any other goroutine will be reading its output channel.
The way to prevent blocking is to send inside a select statement. When a
session is acquired, SessionManager does this; when a session is lost or
released, that send wasn't guarded. As a consequence, the SessionManager
goroutine would never exit.

This problem is fixed by adding select around the second send.