### PR TITLE
RFC (do not merge): check if our replica increase was preempted

### DIFF
--- a/pkg/kp/rcstore/consul_store.go
+++ b/pkg/kp/rcstore/consul_store.go
@@ -451,8 +451,32 @@ func (s *consulStore) SetDesiredReplicas(id fields.ID, n int) error {
 }
 
 func (s *consulStore) AddDesiredReplicas(id fields.ID, n int) error {
+	rcp, err := s.rcPath(id)
+	if err != nil {
+		return err
+	}
+
+	kvp, _, err := s.kv.Get(rcp, nil)
+	if err != nil {
+		return consulutil.NewKVError("get", rcp, err)
+	}
+
+	if kvp == nil {
+		return NoReplicationController
+	}
+
+	rc, err := kvpToRC(kvp)
+	if err != nil {
+		return err
+	}
+
+	oldValue := rc.ReplicasDesired
+
 	return s.retryMutate(id, func(rc fields.RC) (fields.RC, error) {
-		rc.ReplicasDesired += n
+		if rc.ReplicasDesired != oldValue {
+			return rc, fmt.Errorf("I've been pre-empted because value was %d instead of %d", rc.ReplicasDesired, oldValue)
+		}
+		rc.ReplicasDesired = oldValue + n
 		if rc.ReplicasDesired < 0 {
 			rc.ReplicasDesired = 0
 		}


### PR DESCRIPTION
This code is probably not suitable for merge because the new code added
to AddDesiredReplicas has a lot of duplication with mutateRc, and the
proper behavior when we have been pre-empted is uncertain.

But let's talk about whether the behavior is even desirable first. Then
we can think about the specifics of how to make it happen.

AddDesiredReplicas adds n to the desired replicas. If it fails due to
CAS errors, it retries.

Now I'm wondering: Is it possible at all that two p2-master nodes both
manage to increase the replica counts? mutateRc gets a fresh copy of the
RC each time, so if two nodes were attempting, it is possible they could
both succeed, neither being the wiser.

No, I don't have evidence that this is in fact what is happening.

I'm uncertain of how to test it. Perhaps
https://github.com/square/p2/blob/master/pkg/kp/consulutil/fake_kv.go
can be a start, with concurrent attempts to ioncrease replica counts.

More importantly, if p2-master gets one of these new errors in the
process of running
https://github.com/square/p2/blob/master/pkg/roll/run_update.go#L254-L267
, what should it do?