### PR TITLE
roll: CAS desired replicas

### DIFF
--- a/pkg/kp/rcstore/consul_store.go
+++ b/pkg/kp/rcstore/consul_store.go
@@ -460,6 +460,16 @@ func (s *consulStore) AddDesiredReplicas(id fields.ID, n int) error {
 	})
 }
 
+func (s *consulStore) CASDesiredReplicas(id fields.ID, expected int, n int) error {
+	return s.retryMutate(id, func(rc fields.RC) (fields.RC, error) {
+		if rc.ReplicasDesired != expected {
+			return rc, fmt.Errorf("replication controller %s has %d desired replicas instead of %d, not setting to %d", rc.ID, rc.ReplicasDesired, expected, n)
+		}
+		rc.ReplicasDesired = n
+		return rc, nil
+	})
+}
+
 func (s *consulStore) Delete(id fields.ID, force bool) error {
 	return s.retryMutate(id, func(rc fields.RC) (fields.RC, error) {
 		if !force && rc.ReplicasDesired != 0 {

--- a/pkg/kp/rcstore/fake_store.go
+++ b/pkg/kp/rcstore/fake_store.go
@@ -141,6 +141,23 @@ func (s *fakeStore) AddDesiredReplicas(id fields.ID, n int) error {
 	return nil
 }
 
+func (s *fakeStore) CASDesiredReplicas(id fields.ID, expected int, n int) error {
+	entry, ok := s.rcs[id]
+	if !ok {
+		return util.Errorf("Nonexistent RC")
+	}
+
+	if entry.ReplicasDesired != expected {
+		return util.Errorf("pre-empted")
+	}
+
+	entry.ReplicasDesired = n
+	for _, channel := range entry.watchers {
+		channel <- struct{}{}
+	}
+	return nil
+}
+
 func (s *fakeStore) Delete(id fields.ID, force bool) error {
 	entry, ok := s.rcs[id]
 	if !ok {

--- a/pkg/kp/rcstore/store.go
+++ b/pkg/kp/rcstore/store.go
@@ -40,6 +40,9 @@ type Store interface {
 	SetDesiredReplicas(fields.ID, int) error
 	// Add the given integer to the given RC's replica count (bounding at zero).
 	AddDesiredReplicas(fields.ID, int) error
+	// First check that the desired replica count for the given RC is the given integer
+	// (returning an error if it is not), and if it is, set it to the given integer.
+	CASDesiredReplicas(rcID fields.ID, expectedValue int, newValue int) error
 
 	// Set the RC to be enabled. An enabled RC will attempt to meet its desires.
 	Enable(fields.ID) error

--- a/pkg/roll/run_update.go
+++ b/pkg/roll/run_update.go
@@ -252,14 +252,14 @@ func (u *update) rollLoop(podID types.PodID, hChecks <-chan map[types.NodeName]h
 					"nextAdd":    nextAdd,
 				}).Infof("Adding %d new nodes and removing %d old nodes", nextAdd, nextRemove)
 				if nextRemove > 0 {
-					err = u.rcs.AddDesiredReplicas(u.OldRC, -nextRemove)
+					err = u.rcs.CASDesiredReplicas(u.OldRC, oldNodes.Desired, oldNodes.Desired-nextRemove)
 					if err != nil {
 						u.logger.WithError(err).Errorln("Could not decrement old replica count")
 						break
 					}
 				}
 				if nextAdd > 0 {
-					err = u.rcs.AddDesiredReplicas(u.NewRC, nextAdd)
+					err = u.rcs.CASDesiredReplicas(u.NewRC, newNodes.Desired, newNodes.Desired+nextAdd)
 					if err != nil {
 						u.logger.WithError(err).Errorln("Could not increment new replica count")
 						break


### PR DESCRIPTION
Sometimes, AddDesiredReplicas isn't the desired amount of checking that
we would like to have. AddDesiredReplicas retries its mutation so that
it is resistant to *unrelated* changes (such as the changing of the
disable flag), but if someone else changes the desired replica count, we
want to know about it. Thus, a CAS for desired replicas.

---

We are experiencing cases where session losses cause replica count
increases to happen multiple times. This attempts to stop that.