### PR TITLE
consulutil: Add exponential backoff to SessionManager

### DIFF
--- a/pkg/util/randseed/seed.go
+++ b/pkg/util/randseed/seed.go
@@ -1,0 +1,23 @@
+package randseed
+
+import (
+	crand "crypto/rand"
+	"encoding/binary"
+	mrand "math/rand"
+	"time"
+)
+
+// Get returns a value intended to be used as a seed for the random number generators in
+// the "math/rand" package.
+func Get() int64 {
+	var seed int64
+	if err := binary.Read(crand.Reader, binary.LittleEndian, &seed); err == nil {
+		return seed
+	}
+	return time.Now().Unix()
+}
+
+// NewRand returns a PRNG using a new entropy source.
+func NewRand() *mrand.Rand {
+	return mrand.New(mrand.NewSource(Get()))
+}


### PR DESCRIPTION
Add an exponential backoff strategy to SessionManager to deal with
errors encountered while creating a session. Session loss is a
highly-correlated event, so jitter is added to mitigate a thundering
herd (mostly preparers) attempting to reestablish their sessions after a
loss occurrs.

Errors encountered while renewing a session are probably a symptom of an
overloaded Consul server, but it isn't clear how to use an exponential
backoff to mitigate that problem. This changes uses a heuristic of
sending the next create request after the maximum timeout from the last
successful create.