### PR TITLE
roll: Do not enable old RC on cleanup

### DIFF
--- a/pkg/roll/run_update.go
+++ b/pkg/roll/run_update.go
@@ -164,9 +164,6 @@ func (u *update) Run(quit <-chan struct{}) (ret bool) {
 		if !RetryOrQuit(func() error { return u.rcs.SetDesiredReplicas(u.OldRC, 0) }, quit, u.logger, "Could not zero old replica count") {
 			return
 		}
-		if !RetryOrQuit(func() error { return u.rcs.Enable(u.OldRC) }, quit, u.logger, "Could not enable old RC") {
-			return
-		}
 		if !RetryOrQuit(func() error { return u.rcs.Delete(u.OldRC, false) }, quit, u.logger, "Could not delete old RC") {
 			return
 		}


### PR DESCRIPTION
Recall that the roll algorithm declares a deploy complete when the new
RC **desires** as many nodes as specified in the deploy, and at least
the minimum number of new nodes are healthy.

Imagine this situation:

We are in the middle of a deploy with 2 nodes desired, 1 node min
healthy on a 2 node environment.

* Old RC: 1 desired, 1 healthy, disabled.
* New RC: 1 desired, 1 healthy, enabled.

Roll algorithm decides (rightfully) that it can roll forward:

* Old RC: 0 desired, 1 healthy, disabled.
* New RC: 2 desired, 1 healthy, enabled.

At this point, the termination condition of the roll algorithm is met.
Upon termination, it sets the old RC's count to zero (not materially
useful; it's already at zero), **enables it** (dangerous!), and then
deletes it.

* Old RC: 0 desired, 1 healthy, enabled.
* New RC: 2 desired, 1 healthy, enabled.

Now the two RCs race:

* The old RC is attempting to remove the pod from the node that
  currently has it, since it desires to have zero but has one.
* The new RC is attempting to add the pod to the node that doesn't have
  it.

So in the following sequence of events:

* The old RC decides it needs to act (new RC has not yet relabeled the
  pod)
* The new RC acts and schedules the pod
* The old RC unschedules the pod

We have lost a pod.

If we do not enable the old RC, we avoid this situation.