### PR TITLE
introduce pkg/metrics

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,32 @@
+package metrics
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/rcrowley/go-metrics"
+	"github.com/rcrowley/go-metrics/exp"
+)
+
+// Registry is a global metrics registry
+var Registry metrics.Registry
+
+// ExpHandler is an http handler that will publish the contents of its composed registry as JSON
+var ExpHandler http.Handler
+
+var m sync.Mutex
+
+// Those who import this package get a default metrics.Registry
+func init() {
+	Registry = metrics.NewRegistry()
+	if ExpHandler == nil {
+		ExpHandler = exp.ExpHandler(Registry)
+	}
+}
+
+func SetMetricsRegistry(registry metrics.Registry) {
+	m.Lock()
+	defer m.Unlock()
+	Registry = registry
+	ExpHandler = exp.ExpHandler(Registry)
+}


### PR DESCRIPTION
A metrics package appears! This package will be shared throughout the code to decouple the production of metrics from their publishing to a metrics store.

Both Registry & ExpHandler and exposed for mutation by downstream code that wants to use a custom Registry or bind this handler into their app.