### PR TITLE
Only store 200 characters from health output

### DIFF
--- a/pkg/kp/healthmanager.go
+++ b/pkg/kp/healthmanager.go
@@ -41,6 +41,10 @@ var (
 	// health status to "unknown" with an error message, and further updates will be
 	// throttled until enough tokens have been accumulated.
 	HealthResumeLimit = param.Int64("health_resume_limit", 4)
+
+	// HealthMaxStatusOutput sets the largest number of stored characters for a status check
+	// for a particular pod.
+	HealthMaxStatusOutput = param.Int("health_max_status_output", 200)
 )
 
 // consulHealthManager maintains a Consul session for all the local node's health checks,
@@ -342,6 +346,9 @@ func healthToKV(wr WatchResult, session string) (*api.KVPair, error) {
 	wr.Time = now
 	// This health check only expires when the key is removed
 	wr.Expires = now.Add(100 * 365 * 24 * time.Hour)
+	if len(wr.Output) > *HealthMaxStatusOutput {
+		wr.Output = wr.Output[:*HealthMaxStatusOutput] // limit the size of data sent to Consul.
+	}
 	data, err := json.Marshal(wr)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Clients may unintentionally send enormous status strings in their status endpoint. While there is nothing inherently wrong with this, we do not want to store this full output in Consul. This sets an arbitrarily limit of 200 characters for status data before being truncated.

I verified that this worked using the integration test environment.