### PR TITLE
Add a Pod() function to HookEnv to initialize hooked pod.

### DIFF
--- a/bin/p2-run-hooks/main.go
+++ b/bin/p2-run-hooks/main.go
@@ -19,6 +19,7 @@ var (
 	hookDir      = kingpin.Flag("hook-dir", "The root of the hooks").Default(hooks.DEFAULT_PATH).String()
 	manifestPath = kingpin.Flag("manifest", "The manifest to use (this is useful when we are in the before_install phase)").ExistingFile()
 	nodeName     = kingpin.Flag("node-name", "The name of this node (default: hostname)").String()
+	podRoot      = kingpin.Flag("pod-root", "The system root for pods").Default(pods.DefaultPath).String()
 )
 
 func main() {
@@ -33,7 +34,7 @@ func main() {
 		*nodeName = hostname
 	}
 
-	dir := hooks.Hooks(*hookDir, &logging.DefaultLogger)
+	dir := hooks.Hooks(*hookDir, *podRoot, &logging.DefaultLogger)
 
 	hookType, err := hooks.AsHookType(*hookType)
 	if err != nil {

--- a/pkg/hooks/hook_env.go
+++ b/pkg/hooks/hook_env.go
@@ -60,6 +60,9 @@ func (h *HookEnv) Node() (types.NodeName, error) {
 	return types.NodeName(node), nil
 }
 
+// Initializes a pod from the current_manifest.yaml file in the pod's home directory. This function
+// will error or return an old manifest if run during an inappropriate hook event, use of this
+// function is discouraged in most cases
 func (h *HookEnv) PodFromDisk() (*pods.Pod, error) {
 	node, err := h.Node()
 	if err != nil {
@@ -71,6 +74,18 @@ func (h *HookEnv) PodFromDisk() (*pods.Pod, error) {
 	}
 
 	return pods.PodFromPodHome(types.NodeName(node), podHome)
+}
+
+// Initializes a pod based on the hooked pod manifest and the system pod root
+func (h *HookEnv) Pod() (*pods.Pod, error) {
+	factory := pods.NewFactory(os.Getenv(HOOKED_SYSTEM_POD_ROOT_ENV_VAR), HOOKED_NODE_ENV_VAR)
+
+	podID, err := h.PodID()
+	if err != nil {
+		return nil, err
+	}
+
+	return factory.NewPod(podID), nil
 }
 
 func (h *HookEnv) Config() (*config.Config, error) {

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -27,6 +27,7 @@ const (
 	HOOKED_CONFIG_PATH_ENV_VAR     = "HOOKED_CONFIG_PATH"
 	HOOKED_ENV_PATH_ENV_VAR        = "HOOKED_ENV_PATH"
 	HOOKED_CONFIG_DIR_PATH_ENV_VAR = "HOOKED_CONFIG_DIR_PATH"
+	HOOKED_SYSTEM_POD_ROOT_ENV_VAR = "HOOKED_SYSTEM_POD_ROOT"
 
 	DefaultTimeout = 120 * time.Second
 )
@@ -40,6 +41,7 @@ type Pod interface {
 
 type HookDir struct {
 	dirpath string
+	podRoot string
 	logger  *logging.Logger
 }
 
@@ -77,8 +79,12 @@ func AsHookType(value string) (HookType, error) {
 	}
 }
 
-func Hooks(dirpath string, logger *logging.Logger) *HookDir {
-	return &HookDir{dirpath, logger}
+func Hooks(dirpath string, podRoot string, logger *logging.Logger) *HookDir {
+	return &HookDir{
+		dirpath: dirpath,
+		podRoot: podRoot,
+		logger:  logger,
+	}
 }
 
 // runDirectory executes all executable files in a given directory path.
@@ -220,6 +226,7 @@ func (h *HookDir) runHooks(dirpath string, hType HookType, pod Pod, podManifest 
 		fmt.Sprintf("%s=%s", HOOKED_CONFIG_PATH_ENV_VAR, path.Join(pod.ConfigDir(), configFileName)),
 		fmt.Sprintf("%s=%s", HOOKED_ENV_PATH_ENV_VAR, pod.EnvDir()),
 		fmt.Sprintf("%s=%s", HOOKED_CONFIG_DIR_PATH_ENV_VAR, pod.ConfigDir()),
+		fmt.Sprintf("%s=%s", HOOKED_SYSTEM_POD_ROOT_ENV_VAR, h.podRoot),
 	}
 
 	return runDirectory(dirpath, hookEnvironment, logger)

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -30,7 +30,7 @@ func TestExecutableHooksAreRun(t *testing.T) {
 	// So PodFromPodHome doesn't bail out, write a minimal current_manifest.yaml
 	ioutil.WriteFile(path.Join(podDir, "current_manifest.yaml"), []byte("id: my_hook"), 0755)
 
-	hooks := Hooks(os.TempDir(), &logging.DefaultLogger)
+	hooks := Hooks(os.TempDir(), pods.DefaultPath, &logging.DefaultLogger)
 	pod, err := pods.PodFromPodHome("testNode", podDir)
 	Assert(t).IsNil(err, "the error should have been nil")
 	hooks.runHooks(tempDir, AFTER_INSTALL, pod, testManifest(), logging.DefaultLogger)
@@ -56,7 +56,7 @@ func TestNonExecutableHooksAreNotRun(t *testing.T) {
 	// So PodFromPodHome doesn't bail out, write a minimal current_manifest.yaml
 	ioutil.WriteFile(path.Join(podDir, "current_manifest.yaml"), []byte("id: my_hook"), 0755)
 
-	hooks := Hooks(os.TempDir(), &logging.DefaultLogger)
+	hooks := Hooks(os.TempDir(), pods.DefaultPath, &logging.DefaultLogger)
 	pod, err := pods.PodFromPodHome("testNode", podDir)
 	Assert(t).IsNil(err, "the error should have been nil")
 	hooks.runHooks(tempDir, AFTER_INSTALL, pod, testManifest(), logging.DefaultLogger)
@@ -83,7 +83,7 @@ func TestDirectoriesDoNotBreakEverything(t *testing.T) {
 	pod, err := pods.PodFromPodHome("testNode", podDir)
 	Assert(t).IsNil(err, "the error should have been nil")
 	logger := logging.TestLogger()
-	hooks := Hooks(os.TempDir(), &logger)
+	hooks := Hooks(os.TempDir(), pods.DefaultPath, &logger)
 	err = hooks.runHooks(tempDir, AFTER_INSTALL, pod, testManifest(), logging.DefaultLogger)
 
 	Assert(t).IsNil(err, "Got an error when running a directory inside the hooks directory")

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -334,7 +334,7 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 	return &Preparer{
 		node:                   preparerConfig.NodeName,
 		store:                  store,
-		hooks:                  hooks.Hooks(preparerConfig.HooksDirectory, &logger),
+		hooks:                  hooks.Hooks(preparerConfig.HooksDirectory, preparerConfig.PodRoot, &logger),
 		hookListener:           listener,
 		Logger:                 logger,
 		podFactory:             pods.NewFactory(preparerConfig.PodRoot, preparerConfig.NodeName),


### PR DESCRIPTION
Sometimes a hook will need to initialize a pod struct based on the
hooked pod manifest. This is useful when the pod's launchables need to
be initialized, for example in order to place a special directory in
each launchable contained in the manifest.

Commit e8d2f903 changed the way pods are initialized such that instead
of initializing a pod by knowing its $POD_HOME (i.e. the concatenation
of the system pod root and the pod id), a caller must first instantiate
a pod factory using the system root (e.g. /data/pods) and then instruct
the pod factory to instantiate a pod of a specified ID. The goal of that
commit was to reduce the number of code sites that compute a pod's home
directory, so that logic can more easily be changed.

A side effect of this change is that a hook can no longer instantiate a
pod using the $HOOKED_POD_HOME var, because there is no longer a pod
constructor that takes the pod home as an argument. The system pod root
must be known.

As a result, this commit adds a $HOOKED_SYSTEM_POD_ROOT var with which a
pod factory may be instantiated, and a Pod() function on the HookEnv
struct conveniently instantiates a pod factory and subsequently a pod
based on $HOOKED_POD_ID.

For systems using a pod root other than "/data/pods", it is important to
update p2-preparer with this commit prior to deploying hooks that depend
on the Pod() function, so that the $HOOKED_SYSTEM_POD_ROOT variable is
exported to hooks prior to hooks depending on it. For systems that use
"/data/pods", the order of deployment does not matter because when the
pod root passed to pods.NewFactory is the empty string, DefaultPath is
used which is "/data/pods".