### PR TITLE
Add a LaunchableVersionID typedef backed by a string

### DIFF
--- a/pkg/artifact/registry.go
+++ b/pkg/artifact/registry.go
@@ -109,7 +109,7 @@ func (a registry) fetchRegistryData(launchableID launch.LaunchableID, version la
 
 	query.Add(osTag, os.String())
 	query.Add(osVersionTag, osVersion.String())
-	query.Add(versionTag, version.ID)
+	query.Add(versionTag, version.ID.String())
 
 	requestURL.RawQuery = query.Encode()
 

--- a/pkg/artifact/registry_test.go
+++ b/pkg/artifact/registry_test.go
@@ -239,7 +239,7 @@ func TestVersionScheme(t *testing.T) {
 		t.Errorf("OS version tag wasn't properly passed, wanted os_version=%s included in request URL", osVersion)
 	}
 
-	if query.Get("version") != launchable.Version.ID {
+	if query.Get("version") != launchable.Version.ID.String() {
 		t.Errorf("Version tag wasn't properly passed, wanted version=%s included in the request URL", launchable.Version.ID)
 	}
 }

--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -22,23 +22,23 @@ import (
 
 // A HoistLaunchable represents a particular install of a hoist artifact.
 type Launchable struct {
-	Id               launch.LaunchableID   // A (pod-wise) unique identifier for this launchable, used to distinguish it from other launchables in the pod
-	Version          string                // A version identifier
-	ServiceId        string                // A (host-wise) unique identifier for this launchable, used when creating runit services
-	RunAs            string                // The user to assume when launching the executable
-	PodEnvDir        string                // The value for chpst -e. See http://smarden.org/runit/chpst.8.html
-	RootDir          string                // The root directory of the launchable, containing N:N>=1 installs.
-	P2Exec           string                // Struct that can be used to build a p2-exec invocation with appropriate flags
-	ExecNoLimit      bool                  // If set, execute with the -n (--no-limit) argument to p2-exec
-	CgroupConfig     cgroups.Config        // Cgroup parameters to use with p2-exec
-	CgroupConfigName string                // The string in PLATFORM_CONFIG to pass to p2-exec
-	CgroupName       string                // The name of the cgroup to run this launchable in
-	RestartTimeout   time.Duration         // How long to wait when restarting the services in this launchable.
-	RestartPolicy    runit.RestartPolicy   // Dictates whether the launchable should be automatically restarted upon exit.
-	SuppliedEnvVars  map[string]string     // A map of user-supplied environment variables to be exported for this launchable
-	Location         *url.URL              // URL to download the artifact from
-	VerificationData auth.VerificationData // Paths to files used to verify the artifact
-	EntryPoints      []string              // paths to entry points to launch under runit
+	Id               launch.LaunchableID        // A (pod-wise) unique identifier for this launchable, used to distinguish it from other launchables in the pod
+	Version          launch.LaunchableVersionID // A version identifier
+	ServiceId        string                     // A (host-wise) unique identifier for this launchable, used when creating runit services
+	RunAs            string                     // The user to assume when launching the executable
+	PodEnvDir        string                     // The value for chpst -e. See http://smarden.org/runit/chpst.8.html
+	RootDir          string                     // The root directory of the launchable, containing N:N>=1 installs.
+	P2Exec           string                     // Struct that can be used to build a p2-exec invocation with appropriate flags
+	ExecNoLimit      bool                       // If set, execute with the -n (--no-limit) argument to p2-exec
+	CgroupConfig     cgroups.Config             // Cgroup parameters to use with p2-exec
+	CgroupConfigName string                     // The string in PLATFORM_CONFIG to pass to p2-exec
+	CgroupName       string                     // The name of the cgroup to run this launchable in
+	RestartTimeout   time.Duration              // How long to wait when restarting the services in this launchable.
+	RestartPolicy    runit.RestartPolicy        // Dictates whether the launchable should be automatically restarted upon exit.
+	SuppliedEnvVars  map[string]string          // A map of user-supplied environment variables to be exported for this launchable
+	Location         *url.URL                   // URL to download the artifact from
+	VerificationData auth.VerificationData      // Paths to files used to verify the artifact
+	EntryPoints      []string                   // paths to entry points to launch under runit
 }
 
 // LaunchAdapter adapts a hoist.Launchable to the launch.Launchable interface.
@@ -305,7 +305,7 @@ func (hl *Launchable) PostInstall() error {
 func (hl *Launchable) Name() string {
 	name := hl.Id.String()
 	if hl.Version != "" {
-		name = name + "_" + hl.Version
+		name = name + "_" + hl.Version.String()
 	}
 	return name
 }

--- a/pkg/launch/launchable.go
+++ b/pkg/launch/launchable.go
@@ -17,9 +17,13 @@ type LaunchableID string
 
 func (l LaunchableID) String() string { return string(l) }
 
+type LaunchableVersionID string
+
+func (l LaunchableVersionID) String() string { return string(l) }
+
 type LaunchableVersion struct {
-	ID   string            `yaml:"id"`
-	Tags map[string]string `yaml:"tags,omitempty"`
+	ID   LaunchableVersionID `yaml:"id"`
+	Tags map[string]string   `yaml:"tags,omitempty"`
 }
 
 type LaunchableStanza struct {
@@ -47,7 +51,7 @@ type LaunchableStanza struct {
 	Version LaunchableVersion `yaml:"version,omitempty"`
 }
 
-func (l LaunchableStanza) LaunchableVersion() (string, error) {
+func (l LaunchableStanza) LaunchableVersion() (LaunchableVersionID, error) {
 	if l.Version.ID != "" {
 		return l.Version.ID, nil
 	}
@@ -63,14 +67,14 @@ func (l LaunchableStanza) LaunchableVersion() (string, error) {
 
 var locationBaseRegex = regexp.MustCompile(`^[a-z0-9-_]+_([a-f0-9]{40}(\-[a-z0-9]+)?)\.tar\.gz$`)
 
-func versionFromLocation(location string) (string, error) {
+func versionFromLocation(location string) (LaunchableVersionID, error) {
 	filename := path.Base(location)
 	parts := locationBaseRegex.FindStringSubmatch(filename)
 	if parts == nil {
 		return "", util.Errorf("Malformed filename in URL: %s", filename)
 	}
 
-	return parts[1], nil
+	return LaunchableVersionID(parts[1]), nil
 }
 
 const DefaultAllowableDiskUsage = 10 * size.Gibibyte

--- a/pkg/launch/launchable_test.go
+++ b/pkg/launch/launchable_test.go
@@ -7,7 +7,7 @@ import (
 func TestVersionFromLocation(t *testing.T) {
 	type testExpectation struct {
 		Location        string
-		ExpectedVersion string
+		ExpectedVersion LaunchableVersionID
 		ExpectError     bool
 	}
 

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -60,7 +60,11 @@ func TestGetLaunchable(t *testing.T) {
 		if launchable.Id != "app" {
 			t.Errorf("Launchable Id did not have expected value: wanted '%s' was '%s'", "app", launchable.Id)
 		}
-		Assert(t).AreEqual("3c021aff048ca8117593f9c71e03b87cf72fd440", launchable.Version, "Launchable version did not have expected value")
+
+		expectedVersion := "3c021aff048ca8117593f9c71e03b87cf72fd440"
+		if launchable.Version.String() != expectedVersion {
+			t.Errorf("Launchable version did not have expected value: wanted '%s' was '%s'", expectedVersion, launchable.Version)
+		}
 		Assert(t).AreEqual("hello__app", launchable.ServiceId, "Launchable ServiceId did not have expected value")
 		Assert(t).AreEqual("foouser", launchable.RunAs, "Launchable run as did not have expected username")
 		Assert(t).IsTrue(launchable.ExecNoLimit, "GetLaunchable() should always set ExecNoLimit to true for hoist launchables")
@@ -82,7 +86,9 @@ func TestGetLaunchableNoVersion(t *testing.T) {
 		t.Errorf("Launchable Id did not have expected value: wanted '%s' was '%s'", "somelaunchable", launchable.Id)
 	}
 
-	Assert(t).AreEqual("", launchable.Version, "Launchable version did not have expected value")
+	if launchable.Version != "" {
+		t.Errorf("Launchable version should have been empty, was '%s'", launchable.Version)
+	}
 	Assert(t).AreEqual("hello__somelaunchable", launchable.ServiceId, "Launchable ServiceId did not have expected value")
 	Assert(t).AreEqual("foouser", launchable.RunAs, "Launchable run as did not have expected username")
 	Assert(t).IsTrue(launchable.ExecNoLimit, "GetLaunchable() should always set ExecNoLimit to true for hoist launchables")


### PR DESCRIPTION
This adds greater type safety when working with launchable version IDs.
This is useful for systems that support upgrading or otherwise modifying
the launchable version ID within a pod manifest.