### PR TITLE
`cachedMatch` flag for `GetMatches`

### DIFF
--- a/bin/p2-ds-farm/main.go
+++ b/bin/p2-ds-farm/main.go
@@ -17,6 +17,12 @@ import (
 	"github.com/square/p2/pkg/logging"
 
 	ds_farm "github.com/square/p2/pkg/ds"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	useCachePodMatches = kingpin.Flag("use-cached-pod-matches", "If enabled, create a local cache of the pod label tree and match against that instead of querying on all pod selector queries").Bool()
 )
 
 // SessionName returns a node identifier for use when creating Consul sessions.
@@ -49,7 +55,7 @@ func main() {
 		TTL:       "15s",
 	}, client, sessions, quitCh, logger)
 
-	dsf := ds_farm.NewFarm(kpStore, dsStore, applicator, sessions, logger, nil, &healthChecker, 1*time.Second)
+	dsf := ds_farm.NewFarm(kpStore, dsStore, applicator, sessions, logger, nil, &healthChecker, 1*time.Second, *useCachePodMatches)
 
 	go func() {
 		// clear lock immediately on ctrl-C

--- a/bin/p2-dsctl/main.go
+++ b/bin/p2-dsctl/main.go
@@ -309,7 +309,7 @@ func main() {
 			log.Fatalf("Error occurred: %v", err)
 		}
 
-		matches, err := applicator.GetMatches(selector, labels.NODE)
+		matches, err := applicator.GetMatches(selector, labels.NODE, false)
 		if err != nil {
 			log.Fatalf("Error getting matching labels: %v", err)
 		}
@@ -333,12 +333,12 @@ func parseNodeSelectorWithPrompt(
 		return newSelector, nil
 	}
 
-	newNodeLabels, err := applicator.GetMatches(newSelector, labels.NODE)
+	newNodeLabels, err := applicator.GetMatches(newSelector, labels.NODE, false)
 	if err != nil {
 		return newSelector, util.Errorf("Error getting matching labels: %v", err)
 	}
 
-	oldNodeLabels, err := applicator.GetMatches(oldSelector, labels.NODE)
+	oldNodeLabels, err := applicator.GetMatches(oldSelector, labels.NODE, false)
 	if err != nil {
 		return newSelector, util.Errorf("Error getting matching labels: %v", err)
 	}
@@ -357,7 +357,7 @@ func parseNodeSelectorWithPrompt(
 }
 
 func confirmMinheathForSelector(minHealth int, selector klabels.Selector, applicator labels.Applicator) error {
-	matches, err := applicator.GetMatches(selector, labels.NODE)
+	matches, err := applicator.GetMatches(selector, labels.NODE, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/ds/daemon_set_test.go
+++ b/pkg/ds/daemon_set_test.go
@@ -29,7 +29,7 @@ const (
 
 func scheduledPods(t *testing.T, ds *daemonSet) []labels.Labeled {
 	selector := klabels.Everything().Add(DSIDLabel, klabels.EqualsOperator, []string{ds.ID().String()})
-	labeled, err := ds.applicator.GetMatches(selector, labels.POD)
+	labeled, err := ds.applicator.GetMatches(selector, labels.POD, false)
 	Assert(t).IsNil(err, "expected no error matching pods")
 	return labeled
 }
@@ -175,6 +175,7 @@ func TestSchedule(t *testing.T) {
 		logging.DefaultLogger,
 		&happyHealthChecker,
 		0,
+		false,
 	).(*daemonSet)
 
 	scheduled := scheduledPods(t, ds)
@@ -359,6 +360,7 @@ func TestPublishToReplication(t *testing.T) {
 		logging.DefaultLogger,
 		&happyHealthChecker,
 		0,
+		false,
 	).(*daemonSet)
 
 	scheduled := scheduledPods(t, ds)

--- a/pkg/kp/pcstore/consul_store.go
+++ b/pkg/kp/pcstore/consul_store.go
@@ -279,7 +279,7 @@ func (s *consulStore) FindWhereLabeled(podID types.PodID,
 		Add(fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{availabilityZone.String()}).
 		Add(fields.ClusterNameLabel, klabels.EqualsOperator, []string{clusterName.String()})
 
-	podClusters, err := s.applicator.GetMatches(sel, labels.PC)
+	podClusters, err := s.applicator.GetMatches(sel, labels.PC, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kp/pcstore/consul_store_test.go
+++ b/pkg/kp/pcstore/consul_store_test.go
@@ -185,7 +185,7 @@ func TestLabelsOnCreate(t *testing.T) {
 		t.Fatalf("Unable to create pod cluster: %s", err)
 	}
 
-	matches, err := store.applicator.GetMatches(selector, labels.PC)
+	matches, err := store.applicator.GetMatches(selector, labels.PC, false)
 	if err != nil {
 		t.Fatalf("Unable to check for label match on new pod cluster: %s", err)
 	}

--- a/pkg/kp/rollstore/consul_store.go
+++ b/pkg/kp/rollstore/consul_store.go
@@ -387,7 +387,7 @@ func (s consulStore) CreateRollingUpdateFromOneMaybeExistingWithLabelSelector(
 	defer session.Destroy()
 
 	// Check if any RCs match the oldRCSelector
-	matches, err := s.labeler.GetMatches(oldRCSelector, labels.RC)
+	matches, err := s.labeler.GetMatches(oldRCSelector, labels.RC, false)
 	if err != nil {
 		return roll_fields.Update{}, err
 	}

--- a/pkg/labels/applicator.go
+++ b/pkg/labels/applicator.go
@@ -81,8 +81,10 @@ type Applicator interface {
 	// Get all Labels assigned to the given object
 	GetLabels(labelType Type, id string) (Labeled, error)
 
-	// Return all objects of the given type that match the given selector
-	GetMatches(selector labels.Selector, labelType Type) ([]Labeled, error)
+	// Return all objects of the given type that match the given selector.
+	// When cachedMatch is enabled, Applicators may choose to use an internal cache of
+	// aggregated results to answer GetMatches queries.
+	GetMatches(selector labels.Selector, labelType Type, cachedMatch bool) ([]Labeled, error)
 
 	// Watch a label selector of a given type and see updates to that set
 	// of Labeled over time. If an error occurs, the Applicator implementation

--- a/pkg/labels/consul_aggregator.go
+++ b/pkg/labels/consul_aggregator.go
@@ -209,6 +209,15 @@ func (c *consulAggregator) Aggregate() {
 	}
 }
 
+func (c *consulAggregator) getCache() ([]Labeled, error) {
+	c.watcherLock.Lock()
+	defer c.watcherLock.Unlock()
+	if len(c.labeledCache) == 0 {
+		return nil, fmt.Errorf("No cache available")
+	}
+	return c.labeledCache, nil
+}
+
 func (c *consulAggregator) fillCache(pairs api.KVPairs) {
 	cache := make([]Labeled, len(pairs))
 	for i, kvp := range pairs {

--- a/pkg/labels/consul_applicator_test.go
+++ b/pkg/labels/consul_applicator_test.go
@@ -134,15 +134,15 @@ func TestBasicMatch(t *testing.T) {
 
 	Assert(t).IsNil(c.SetLabel(POD, "object", "label", "value"), "should have had nil error when setting label")
 
-	matches, err := c.GetMatches(labels.Everything().Add("label", labels.EqualsOperator, []string{"value"}), POD)
+	matches, err := c.GetMatches(labels.Everything().Add("label", labels.EqualsOperator, []string{"value"}), POD, false)
 	Assert(t).IsNil(err, "should have had nil error fetching positive matches")
 	Assert(t).AreEqual(len(matches), 1, "should have had exactly one positive match")
 
-	matches, err = c.GetMatches(labels.Everything().Add("label", labels.EqualsOperator, []string{"value"}), NODE)
+	matches, err = c.GetMatches(labels.Everything().Add("label", labels.EqualsOperator, []string{"value"}), NODE, false)
 	Assert(t).IsNil(err, "should have had nil error fetching positive matches for wrong type")
 	Assert(t).AreEqual(len(matches), 0, "should have had exactly zero mistyped matches")
 
-	matches, err = c.GetMatches(labels.Everything().Add("label", labels.NotInOperator, []string{"value"}), POD)
+	matches, err = c.GetMatches(labels.Everything().Add("label", labels.NotInOperator, []string{"value"}), POD, false)
 	Assert(t).IsNil(err, "should have had nil error fetching negative matches")
 	Assert(t).AreEqual(len(matches), 0, "should have had exactly zero negative matches")
 }
@@ -155,7 +155,7 @@ func TestSetLabels(t *testing.T) {
 
 	Assert(t).IsNil(c.SetLabel(POD, "object", "label", "value"), "should have had nil error when setting label")
 
-	matches, err := c.GetMatches(labels.Everything().Add("label", labels.EqualsOperator, []string{"value"}), POD)
+	matches, err := c.GetMatches(labels.Everything().Add("label", labels.EqualsOperator, []string{"value"}), POD, false)
 	Assert(t).IsNil(err, "should have had nil error fetching positive matches")
 	Assert(t).AreEqual(len(matches), 1, "should have had exactly one positive match")
 
@@ -170,7 +170,7 @@ func TestSetLabels(t *testing.T) {
 		Add("label1", labels.EqualsOperator, []string{"value1"}).
 		Add("label2", labels.EqualsOperator, []string{"value2"})
 
-	matches, err = c.GetMatches(sel, POD)
+	matches, err = c.GetMatches(sel, POD, false)
 	Assert(t).IsNil(err, "should have had nil error fetching positive matches")
 	Assert(t).AreEqual(len(matches), 1, "should have had exactly one positive match")
 }

--- a/pkg/labels/fake_applicator.go
+++ b/pkg/labels/fake_applicator.go
@@ -81,7 +81,7 @@ func (app *fakeApplicator) GetLabels(labelType Type, id string) (Labeled, error)
 	}, nil
 }
 
-func (app *fakeApplicator) GetMatches(selector labels.Selector, labelType Type) ([]Labeled, error) {
+func (app *fakeApplicator) GetMatches(selector labels.Selector, labelType Type, _ bool) ([]Labeled, error) {
 	app.mutex.Lock()
 	defer app.mutex.Unlock()
 	forType, ok := app.data[labelType]
@@ -114,7 +114,7 @@ func (app *fakeApplicator) WatchMatches(selector labels.Selector, labelType Type
 			default:
 			}
 
-			res, _ := app.GetMatches(selector, labelType)
+			res, _ := app.GetMatches(selector, labelType, false)
 
 			select {
 			case <-quitCh:

--- a/pkg/labels/fake_applicator_test.go
+++ b/pkg/labels/fake_applicator_test.go
@@ -60,7 +60,7 @@ func TestMatches(t *testing.T) {
 
 	selector := labels.Everything().Add("foo", labels.EqualsOperator, []string{"bar"})
 
-	labeled, err := app.GetMatches(selector, NODE)
+	labeled, err := app.GetMatches(selector, NODE, false)
 	Assert(t).IsNil(err, "expected no error getting matches")
 
 	Assert(t).AreEqual(len(labeled), 1, "expected one match")

--- a/pkg/labels/http_applicator.go
+++ b/pkg/labels/http_applicator.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	"k8s.io/kubernetes/pkg/labels"
 
@@ -60,10 +61,11 @@ func (h *httpApplicator) GetLabels(labelType Type, id string) (Labeled, error) {
 	return Labeled{}, util.Errorf("GetLabels not implemented for HttpApplicator (type %s, id %s)", labelType, id)
 }
 
-func (h *httpApplicator) GetMatches(selector labels.Selector, labelType Type) ([]Labeled, error) {
+func (h *httpApplicator) GetMatches(selector labels.Selector, labelType Type, cachedMatch bool) ([]Labeled, error) {
 	params := url.Values{}
 	params.Add("selector", selector.String())
 	params.Add("type", labelType.String())
+	params.Add("cachedMatch", strconv.FormatBool(cachedMatch))
 
 	// Make value copy of URL; don't want to mutate the URL in the struct.
 	urlToGet := *h.matchesEndpoint

--- a/pkg/labels/http_applicator_test.go
+++ b/pkg/labels/http_applicator_test.go
@@ -18,6 +18,7 @@ func getMatches(t *testing.T, httpResponse string) ([]Labeled, error) {
 		Assert(t).AreEqual(r.URL.Path, endpointSuffix, "Unexpected path requested")
 		Assert(t).AreEqual(r.URL.Query().Get("selector"), "r1=v1,r2=v2", "Unexpected selector requested")
 		Assert(t).AreEqual(r.URL.Query().Get("type"), NODE.String(), "Unexpected type requested")
+		Assert(t).AreEqual(r.URL.Query().Get("cachedMatch"), "true", "Expected a cachedMatch query to be sent")
 		fmt.Fprintln(w, httpResponse)
 	}))
 	defer server.Close()
@@ -28,7 +29,7 @@ func getMatches(t *testing.T, httpResponse string) ([]Labeled, error) {
 	applicator, err := NewHttpApplicator(nil, url)
 	Assert(t).IsNil(err, "expected no error creating HTTP applicator")
 	selector := labels.Everything().Add("r1", labels.EqualsOperator, []string{"v1"}).Add("r2", labels.EqualsOperator, []string{"v2"})
-	return applicator.GetMatches(selector, NODE)
+	return applicator.GetMatches(selector, NODE, true)
 }
 
 func TestGetMatches(t *testing.T) {

--- a/pkg/rc/replication_controller.go
+++ b/pkg/rc/replication_controller.go
@@ -323,7 +323,9 @@ func (rc *replicationController) eligibleNodes() ([]types.NodeName, error) {
 func (rc *replicationController) CurrentPods() (types.PodLocations, error) {
 	selector := klabels.Everything().Add(RCIDLabel, klabels.EqualsOperator, []string{rc.ID().String()})
 
-	podMatches, err := rc.podApplicator.GetMatches(selector, labels.POD)
+	// replication controllers can only pass cachedMatch = false because their operations for matching
+	// replica counts are not necessarily idempotent.
+	podMatches, err := rc.podApplicator.GetMatches(selector, labels.POD, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rc/replication_controller_test.go
+++ b/pkg/rc/replication_controller_test.go
@@ -84,7 +84,7 @@ func setup(t *testing.T) (
 
 func scheduledPods(t *testing.T, pods labels.Applicator) []labels.Labeled {
 	podSelector := klabels.Everything().Add("podTest", klabels.EqualsOperator, []string{"successful"})
-	labeled, err := pods.GetMatches(podSelector, labels.POD)
+	labeled, err := pods.GetMatches(podSelector, labels.POD, false)
 	Assert(t).IsNil(err, "expected no error matching pods")
 	return labeled
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -26,7 +26,7 @@ func NewApplicatorScheduler(applicator labels.Applicator) *applicatorScheduler {
 }
 
 func (sel *applicatorScheduler) EligibleNodes(_ manifest.Manifest, selector klabels.Selector) ([]types.NodeName, error) {
-	nodes, err := sel.applicator.GetMatches(selector, labels.NODE)
+	nodes, err := sel.applicator.GetMatches(selector, labels.NODE, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change introduces a new parameter to the `Applicator.GetMatches`
function, `staleMatch`. It permits clients to specify whether or not
they tolerate cached results from the applicator or not.

The `ConsulApplicator` has been modified to use this flag to indicate
relying on underlying Consul aggreagator's cached label set, instead of
querying Consul for the full tree on each query.

The `HttpApplicator` has been altered to pass a `staleMatch` query parameter
to the receiving service.

The ds farm implementation has been given a struct field that can
be set to enable stale queries for all daemon sets. All other usages
of `GetMatches` keep `staleMatch` disabled for now.