### PR TITLE
Use byte instead of SHA equivalence to determine if ds manifest changed.

### DIFF
--- a/bin/p2-dsctl/main.go
+++ b/bin/p2-dsctl/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -247,15 +248,15 @@ func main() {
 					return ds, util.Errorf("Manifest ID of %s does not match daemon set's pod ID (%s)", manifest.ID(), ds.PodID)
 				}
 
-				dsSHA, err := ds.Manifest.SHA()
+				dsBytes, err := ds.Manifest.Marshal()
 				if err != nil {
-					return ds, util.Errorf("Unable to get SHA from consul daemon set manifest: %v", err)
+					return ds, util.Errorf("Unable to to marshal daemon set manifest: %v", err)
 				}
-				newSHA, err := manifest.SHA()
+				newBytes, err := manifest.Marshal()
 				if err != nil {
-					return ds, util.Errorf("Unable to get SHA from new manifest: %v", err)
+					return ds, util.Errorf("Unable to marshal proposed daemon set manifest: %v", err)
 				}
-				if dsSHA != newSHA {
+				if !bytes.Equal(dsBytes, newBytes) {
 					changed = true
 					ds.Manifest = manifest
 				}


### PR DESCRIPTION
p2-dsctl will not update a daemon set if it perceives that no changes
have been made. In order to determine manifest equivalence, the SHA
of the existing and proposed manifests were being preparered. However,
manifest signature is not considered in SHA computation and as a result,
p2-dsctl did not allow updates that only change a manifest's signature,
which is sometimes an operational necessity.

Now, normalized byte equivalence of the manifests is used instead, so an
error will only be raised if the two manifests are exactly equivalent
including both contents and signature.