### PR TITLE
Share the mutex in fakeSession

### DIFF
--- a/pkg/kp/kptest/fake_session.go
+++ b/pkg/kp/kptest/fake_session.go
@@ -14,7 +14,7 @@ import (
 // fakeSession
 type fakeSession struct {
 	locks     map[string]bool
-	mu        sync.Mutex
+	mu        *sync.Mutex
 	destroyed bool
 
 	renewalErrCh chan error
@@ -24,10 +24,10 @@ type fakeSession struct {
 }
 
 func NewSession() kp.Session {
-	return newFakeSession(map[string]bool{}, sync.Mutex{}, make(chan error))
+	return newFakeSession(map[string]bool{}, new(sync.Mutex), make(chan error))
 }
 
-func newFakeSession(globalLocks map[string]bool, lockMutex sync.Mutex, renewalErrCh chan error) kp.Session {
+func newFakeSession(globalLocks map[string]bool, lockMutex *sync.Mutex, renewalErrCh chan error) kp.Session {
 	return &fakeSession{
 		locks:        globalLocks,
 		mu:           lockMutex,

--- a/pkg/kp/kptest/fake_store.go
+++ b/pkg/kp/kptest/fake_store.go
@@ -135,7 +135,7 @@ func (f *FakePodStore) GetHealth(service string, node types.NodeName) (kp.WatchR
 
 func (f *FakePodStore) NewSession(name string, renewalCh <-chan time.Time) (kp.Session, chan error, error) {
 	renewalErrCh := make(chan error)
-	return newFakeSession(f.locks, f.locksMu, renewalErrCh), renewalErrCh, nil
+	return newFakeSession(f.locks, &f.locksMu, renewalErrCh), renewalErrCh, nil
 }
 
 func (*FakePodStore) PutHealth(res kp.WatchResult) (time.Time, time.Duration, error) {


### PR DESCRIPTION
It looks like FakePodStore is supposed to hold a single map ("locks")
and mutex to guard access to the map ("locksMu") that are both shared
among many fakeSession values. However, the existing code passed the
mutex by value. sync.Mutex values shouldn't ever be copied, and this
also undermines the intent of the fake stores.

This commit passes the mutex by reference so that fakeSessions can share
one value.