### PR TITLE
Expand Consul*Client interfaces

### DIFF
--- a/pkg/kp/consulutil/clients.go
+++ b/pkg/kp/consulutil/clients.go
@@ -14,24 +14,29 @@ type ConsulClient interface {
 // calling KV() on an *api.Client. This is useful for swapping in KV
 // implementations for tests for example
 type ConsulKVClient interface {
-	Get(key string, q *api.QueryOptions) (*api.KVPair, *api.QueryMeta, error)
-	Delete(key string, w *api.WriteOptions) (*api.WriteMeta, error)
-	Put(pair *api.KVPair, w *api.WriteOptions) (*api.WriteMeta, error)
-	List(prefix string, q *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error)
 	Acquire(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error)
 	CAS(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error)
+	Delete(key string, w *api.WriteOptions) (*api.WriteMeta, error)
 	DeleteCAS(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error)
+	DeleteTree(prefix string, w *api.WriteOptions) (*api.WriteMeta, error)
+	Get(key string, q *api.QueryOptions) (*api.KVPair, *api.QueryMeta, error)
+	Keys(prefix, separator string, q *api.QueryOptions) ([]string, *api.QueryMeta, error)
+	List(prefix string, q *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error)
+	Put(pair *api.KVPair, w *api.WriteOptions) (*api.WriteMeta, error)
+	Release(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error)
 }
 
 // Specifies the functionality provided by the *api.Session struct for managing
 // consul sessions. This is useful for swapping in session client
 // implementations in tests
 type ConsulSessionClient interface {
+	Create(se *api.SessionEntry, q *api.WriteOptions) (string, *api.WriteMeta, error)
 	CreateNoChecks(*api.SessionEntry, *api.WriteOptions) (string, *api.WriteMeta, error)
 	Destroy(string, *api.WriteOptions) (*api.WriteMeta, error)
+	Info(id string, q *api.QueryOptions) (*api.SessionEntry, *api.QueryMeta, error)
+	List(q *api.QueryOptions) ([]*api.SessionEntry, *api.QueryMeta, error)
 	Renew(id string, q *api.WriteOptions) (*api.SessionEntry, *api.WriteMeta, error)
 	RenewPeriodic(initialTTL string, id string, q *api.WriteOptions, doneCh chan struct{}) error
-	Info(id string, q *api.QueryOptions) (*api.SessionEntry, *api.QueryMeta, error)
 }
 
 // Sadly, *api.Client does not implement the ConsulClient interface because the

--- a/pkg/kp/consulutil/fake_kv.go
+++ b/pkg/kp/consulutil/fake_kv.go
@@ -1,6 +1,8 @@
 package consulutil
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/square/p2/pkg/util"
@@ -45,6 +47,10 @@ func (f FakeKV) Get(key string, q *api.QueryOptions) (*api.KVPair, *api.QueryMet
 	return f.Entries[key], &api.QueryMeta{}, nil
 }
 
+func (f FakeKV) Keys(prefix, separator string, q *api.QueryOptions) ([]string, *api.QueryMeta, error) {
+	return nil, nil, fmt.Errorf("not yet implemented in FakeKV")
+}
+
 func (f FakeKV) Put(pair *api.KVPair, q *api.WriteOptions) (*api.WriteMeta, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -74,10 +80,22 @@ func (f FakeKV) CAS(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, e
 	f.Entries[p.Key] = p
 	return true, &api.WriteMeta{}, nil
 }
+
 func (f FakeKV) Delete(key string, w *api.WriteOptions) (*api.WriteMeta, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	delete(f.Entries, key)
+	return &api.WriteMeta{}, nil
+}
+
+func (f FakeKV) DeleteTree(prefix string, w *api.WriteOptions) (*api.WriteMeta, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for key := range f.Entries {
+		if strings.HasPrefix(key, prefix) {
+			delete(f.Entries, key)
+		}
+	}
 	return &api.WriteMeta{}, nil
 }
 
@@ -105,4 +123,8 @@ func (f FakeKV) DeleteCAS(pair *api.KVPair, opts *api.WriteOptions) (bool, *api.
 
 	delete(f.Entries, pair.Key)
 	return true, &api.WriteMeta{}, nil
+}
+
+func (f FakeKV) Release(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error) {
+	return false, nil, fmt.Errorf("not yet implemented in FakeKV")
 }


### PR DESCRIPTION
Includes additional methods in the ConsulKVClient and
ConsulSessionClient interfaces. This brings these interfaces closer to
the actual method set of api.KV and api.Session structs.