### PR TITLE
Fix warnings found by analysis tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ script:
   - rake test_all
   - integration/travis.sh
   - rake errcheck
+  - go vet ./bin/... ./pkg/...

--- a/bin/p2-wipe-reality/main.go
+++ b/bin/p2-wipe-reality/main.go
@@ -38,7 +38,7 @@ func main() {
 		log.Printf("Deleting %v from reality\n", pod.Manifest.ID())
 		_, err := store.DeletePod(kp.REALITY_TREE, types.NodeName(*nodeName), pod.Manifest.ID())
 		if err != nil {
-			log.Fatalf("Could not remove %v from pod reality tree: %v", err)
+			log.Fatalf("Could not remove %s/%s from pod reality tree: %v", *nodeName, pod.Manifest.ID(), err)
 		}
 	}
 }

--- a/pkg/auth/artifact_verifier_test.go
+++ b/pkg/auth/artifact_verifier_test.go
@@ -96,7 +96,7 @@ func testNotVerifiedWithFiles(t *testing.T, files []testFile, verifier ArtifactV
 
 	err = verifier.VerifyHoistArtifact(localCopy, verificationData)
 	if err == nil {
-		t.Fatal("Expected files %v to fail verification, but didn't")
+		t.Fatal("Expected files to fail verification, but didn't")
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -70,7 +70,7 @@ func (c *Config) ReadMap(key string) (*Config, error) {
 
 func (c *Config) Keys() []string {
 	keys := []string{}
-	for intf, _ := range c.unpacked {
+	for intf := range c.unpacked {
 		strVal, ok := intf.(string)
 		if ok {
 			keys = append(keys, strVal)

--- a/pkg/ds/farm.go
+++ b/pkg/ds/farm.go
@@ -503,7 +503,7 @@ func (dsf *Farm) raiseContentionAlert(oldDS DaemonSet, newDS ds_fields.DaemonSet
 	}
 
 	if alertErr := dsf.alerter.Alert(alerting.AlertInfo{
-		Description: fmt.Sprintf("New ds '%v', contends with '%v'", oldDS.ID, newDS.ID),
+		Description: fmt.Sprintf("New ds '%v', contends with '%v'", oldDS.ID(), newDS.ID),
 		IncidentKey: "preemptive_ds_contention",
 		Details: struct {
 			OldID           ds_fields.ID          `json:"old_id"`

--- a/pkg/health/store/store_test.go
+++ b/pkg/health/store/store_test.go
@@ -61,8 +61,8 @@ func TestStartWatchBasic(t *testing.T) {
 	}
 
 	checker.Send([]*health.Result{
-		&health.Result{ID: podID1, Node: node},
-		&health.Result{ID: podID2, Node: node},
+		{ID: podID1, Node: node},
+		{ID: podID2, Node: node},
 	})
 
 	result = hs.Fetch(podID1, node)

--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -67,13 +67,13 @@ func (hl *Launchable) Halt(serviceBuilder *runit.ServiceBuilder, sv runit.SV) er
 	// since the output is more useful to the user, that's what we'll preserve
 	out, err := hl.disable()
 	if err != nil {
-		return launch.DisableError{util.Errorf("%s", out)}
+		return launch.DisableError{Inner: util.Errorf("%s", out)}
 	}
 
 	// probably want to do something with output at some point
 	err = hl.stop(serviceBuilder, sv)
 	if err != nil {
-		return launch.StopError{err}
+		return launch.StopError{Inner: err}
 	}
 
 	err = hl.makeLast()
@@ -87,13 +87,13 @@ func (hl *Launchable) Halt(serviceBuilder *runit.ServiceBuilder, sv runit.SV) er
 func (hl *Launchable) Launch(serviceBuilder *runit.ServiceBuilder, sv runit.SV) error {
 	err := hl.start(serviceBuilder, sv)
 	if err != nil {
-		return launch.StartError{err}
+		return launch.StartError{Inner: err}
 	}
 
 	// same as disable
 	out, err := hl.enable()
 	if err != nil {
-		return launch.EnableError{util.Errorf("%s", out)}
+		return launch.EnableError{Inner: util.Errorf("%s", out)}
 	}
 	return nil
 }

--- a/pkg/kp/consulutil/fake_kv.go
+++ b/pkg/kp/consulutil/fake_kv.go
@@ -31,34 +31,34 @@ func NewFakeClient() *FakeConsulClient {
 	}
 }
 
-func NewKVWithEntries(entries map[string]*api.KVPair) FakeKV {
+func NewKVWithEntries(entries map[string]*api.KVPair) *FakeKV {
 	if entries == nil {
 		entries = make(map[string]*api.KVPair)
 	}
 
-	return FakeKV{
+	return &FakeKV{
 		Entries: entries,
 	}
 }
 
-func (f FakeKV) Get(key string, q *api.QueryOptions) (*api.KVPair, *api.QueryMeta, error) {
+func (f *FakeKV) Get(key string, q *api.QueryOptions) (*api.KVPair, *api.QueryMeta, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.Entries[key], &api.QueryMeta{}, nil
 }
 
-func (f FakeKV) Keys(prefix, separator string, q *api.QueryOptions) ([]string, *api.QueryMeta, error) {
+func (f *FakeKV) Keys(prefix, separator string, q *api.QueryOptions) ([]string, *api.QueryMeta, error) {
 	return nil, nil, fmt.Errorf("not yet implemented in FakeKV")
 }
 
-func (f FakeKV) Put(pair *api.KVPair, q *api.WriteOptions) (*api.WriteMeta, error) {
+func (f *FakeKV) Put(pair *api.KVPair, q *api.WriteOptions) (*api.WriteMeta, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.Entries[pair.Key] = pair
 	return &api.WriteMeta{}, nil
 }
 
-func (f FakeKV) List(prefix string, q *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error) {
+func (f *FakeKV) List(prefix string, q *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	ret := make(api.KVPairs, 0)
@@ -68,7 +68,7 @@ func (f FakeKV) List(prefix string, q *api.QueryOptions) (api.KVPairs, *api.Quer
 	return ret, &api.QueryMeta{}, nil
 }
 
-func (f FakeKV) CAS(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error) {
+func (f *FakeKV) CAS(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if keyPair, ok := f.Entries[p.Key]; ok {
@@ -81,14 +81,14 @@ func (f FakeKV) CAS(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, e
 	return true, &api.WriteMeta{}, nil
 }
 
-func (f FakeKV) Delete(key string, w *api.WriteOptions) (*api.WriteMeta, error) {
+func (f *FakeKV) Delete(key string, w *api.WriteOptions) (*api.WriteMeta, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	delete(f.Entries, key)
 	return &api.WriteMeta{}, nil
 }
 
-func (f FakeKV) DeleteTree(prefix string, w *api.WriteOptions) (*api.WriteMeta, error) {
+func (f *FakeKV) DeleteTree(prefix string, w *api.WriteOptions) (*api.WriteMeta, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	for key := range f.Entries {
@@ -102,7 +102,7 @@ func (f FakeKV) DeleteTree(prefix string, w *api.WriteOptions) (*api.WriteMeta, 
 // The fake implementation of this is just the same as writing a key, we expect
 // callers to be using the /lock subtree so real keys won't ever appear like
 // locks
-func (f FakeKV) Acquire(pair *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error) {
+func (f *FakeKV) Acquire(pair *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if _, ok := f.Entries[pair.Key]; ok {
@@ -113,7 +113,7 @@ func (f FakeKV) Acquire(pair *api.KVPair, q *api.WriteOptions) (bool, *api.Write
 	return true, nil, nil
 }
 
-func (f FakeKV) DeleteCAS(pair *api.KVPair, opts *api.WriteOptions) (bool, *api.WriteMeta, error) {
+func (f *FakeKV) DeleteCAS(pair *api.KVPair, opts *api.WriteOptions) (bool, *api.WriteMeta, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	_, ok := f.Entries[pair.Key]
@@ -125,6 +125,6 @@ func (f FakeKV) DeleteCAS(pair *api.KVPair, opts *api.WriteOptions) (bool, *api.
 	return true, &api.WriteMeta{}, nil
 }
 
-func (f FakeKV) Release(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error) {
+func (f *FakeKV) Release(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error) {
 	return false, nil, fmt.Errorf("not yet implemented in FakeKV")
 }

--- a/pkg/kp/kptest/fake_pod_store_test.go
+++ b/pkg/kp/kptest/fake_pod_store_test.go
@@ -14,11 +14,11 @@ func TestFakeServiceHealth(t *testing.T) {
 	targetStatus := "healthy"
 
 	fake.healthResults = map[string]kp.WatchResult{
-		kp.HealthPath("shrimpy", "aaa1.dfw.square"): kp.WatchResult{
+		kp.HealthPath("shrimpy", "aaa1.dfw.square"): {
 			Service: "shrimpy",
 			Status:  "critical",
 		},
-		kp.HealthPath(targetService, targetHost): kp.WatchResult{
+		kp.HealthPath(targetService, targetHost): {
 			Service: targetService,
 			Status:  targetStatus,
 		},

--- a/pkg/kp/kptest/fake_session.go
+++ b/pkg/kp/kptest/fake_session.go
@@ -90,7 +90,7 @@ func (f *fakeSession) Destroy() error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.destroyed = true
-	for k, _ := range f.locksHeld {
+	for k := range f.locksHeld {
 		delete(f.locks, k)
 	}
 	close(f.renewalErrCh)

--- a/pkg/kp/kv_test.go
+++ b/pkg/kp/kv_test.go
@@ -108,7 +108,7 @@ func TestPodUniqueKeyFromConsulPath(t *testing.T) {
 		}
 
 		if err != nil {
-			t.Error("Unexpected error for key '%s': %s", expectation.path, err)
+			t.Errorf("Unexpected error for key '%s': %s", expectation.path, err)
 			continue
 		}
 
@@ -117,7 +117,7 @@ func TestPodUniqueKeyFromConsulPath(t *testing.T) {
 		}
 
 		if expectation.uuid && podUniqueKey.ID != expectation.str {
-			t.Errorf("Expected key string to be %s, was %t", expectation.str, podUniqueKey.ID)
+			t.Errorf("Expected key string to be %s, was %s", expectation.str, podUniqueKey.ID)
 		}
 	}
 }

--- a/pkg/kp/pcstore/consul_store.go
+++ b/pkg/kp/pcstore/consul_store.go
@@ -476,8 +476,6 @@ func (s *consulStore) WatchAndSync(syncer ConcreteSyncer, quit <-chan struct{}) 
 			return nil
 		}
 	}
-
-	return nil
 }
 
 func (s *consulStore) getInitialClusters(syncer ConcreteSyncer) (WatchedPodClusters, error) {

--- a/pkg/kp/podstore/consul_store_test.go
+++ b/pkg/kp/podstore/consul_store_test.go
@@ -210,7 +210,7 @@ func TestReadPodFromIndex(t *testing.T) {
 
 // Returns a store, as well as a reference to the underlying KV so that tests can reach a layer underneath to
 // verify store behavior.
-func storeWithFakeKV(t *testing.T, pods map[string]Pod, indices map[string]PodIndex) (Store, consulutil.FakeKV) {
+func storeWithFakeKV(t *testing.T, pods map[string]Pod, indices map[string]PodIndex) (Store, *consulutil.FakeKV) {
 	entries := make(map[string]*api.KVPair)
 	for key, pod := range pods {
 		bytes, err := json.Marshal(pod)

--- a/pkg/kp/podstore/consul_store_test.go
+++ b/pkg/kp/podstore/consul_store_test.go
@@ -78,14 +78,14 @@ func TestUnschedule(t *testing.T) {
 
 	// Initialize the store with entries at the pod path and index path
 	pods := map[string]Pod{
-		podPath: Pod{
+		podPath: {
 			Manifest: testManifest(),
 			Node:     node,
 		},
 	}
 
 	indices := map[string]PodIndex{
-		indexPath: PodIndex{
+		indexPath: {
 			PodKey: key,
 		},
 	}

--- a/pkg/kp/rcstore/consul_store_test.go
+++ b/pkg/kp/rcstore/consul_store_test.go
@@ -116,7 +116,7 @@ func TestPublishLatestRCsSkipsIfCorrupt(t *testing.T) {
 	}
 
 	// Now push some bogus JSON that will trigger an error
-	corruptData := []*api.KVPair{&api.KVPair{Value: []byte("bad_json")}}
+	corruptData := []*api.KVPair{{Value: []byte("bad_json")}}
 	inCh <- corruptData
 
 	select {
@@ -330,7 +330,7 @@ func TestPublishLatestRCsWithLockInfoNoLocks(t *testing.T) {
 
 	// Create a test case with 2 RCs with no locks
 	unlockedCase := LockInfoTestCase{
-		InputRCs: []fields.RC{fields.RC{ID: "abc"}, fields.RC{ID: "123"}},
+		InputRCs: []fields.RC{{ID: "abc"}, {ID: "123"}},
 		ExpectedOutput: []RCLockResult{
 			{
 				RC: fields.RC{ID: "abc"},
@@ -354,9 +354,9 @@ func TestPublishLatestRCsWithLockInfoNoLocks(t *testing.T) {
 	// create a new case
 	unlockedCase2 := LockInfoTestCase{
 		InputRCs: []fields.RC{
-			fields.RC{ID: "abc"},
-			fields.RC{ID: "123"},
-			fields.RC{ID: "456"},
+			{ID: "abc"},
+			{ID: "123"},
+			{ID: "456"},
 		},
 		ExpectedOutput: []RCLockResult{
 			{
@@ -393,7 +393,7 @@ func TestPublishLatestRCsWithLockInfoWithLocks(t *testing.T) {
 
 	// Create a test case with 2 RCs with no locks
 	lockedCase := LockInfoTestCase{
-		InputRCs: []fields.RC{fields.RC{ID: "abc"}, fields.RC{ID: "123"}},
+		InputRCs: []fields.RC{{ID: "abc"}, {ID: "123"}},
 		ExpectedOutput: []RCLockResult{
 			{
 				RC:                fields.RC{ID: "abc"},
@@ -432,7 +432,7 @@ func TestPublishLatestRCsWithLockInfoWithLocks(t *testing.T) {
 
 	// Add an update creation lock to the second one
 	lockedCase2 := LockInfoTestCase{
-		InputRCs: []fields.RC{fields.RC{ID: "abc"}, fields.RC{ID: "123"}},
+		InputRCs: []fields.RC{{ID: "abc"}, {ID: "123"}},
 		ExpectedOutput: []RCLockResult{
 			{
 				RC:                fields.RC{ID: "abc"},

--- a/pkg/kp/rollstore/consul_store_test.go
+++ b/pkg/kp/rollstore/consul_store_test.go
@@ -104,7 +104,7 @@ func newRollStore(t *testing.T, entries []fields.Update) consulStore {
 		}
 	}
 	return consulStore{
-		kv: consulutil.FakeKV{
+		kv: &consulutil.FakeKV{
 			Entries: storeFields,
 		},
 		store:   kptest.NewFakePodStore(nil, nil),
@@ -913,7 +913,7 @@ func TestPublishLatestRCsSkipsIfCorrupt(t *testing.T) {
 
 	for _, ru := range val {
 		if ru.ID().String() != "a" {
-			t.Errorf("Expected all RUs to have id %s, was %s", "a", ru.ID)
+			t.Errorf("Expected all RUs to have id %s, was %s", "a", ru.ID())
 		}
 	}
 
@@ -947,7 +947,7 @@ func TestPublishLatestRCsSkipsIfCorrupt(t *testing.T) {
 
 	for _, ru := range val {
 		if ru.ID().String() != "b" {
-			t.Errorf("Expected all RUs to have id %s, was %s", "b", ru.ID)
+			t.Errorf("Expected all RUs to have id %s, was %s", "b", ru.ID())
 		}
 	}
 }
@@ -1029,7 +1029,7 @@ func TestPublishQuitsOnInChannelCloseAfterData(t *testing.T) {
 
 	for _, ru := range val {
 		if ru.ID().String() != "a" {
-			t.Errorf("Expected all RUs to have id %s, was %s", "a", ru.ID)
+			t.Errorf("Expected all RUs to have id %s, was %s", "a", ru.ID())
 		}
 	}
 

--- a/pkg/kp/rollstore/consul_store_test.go
+++ b/pkg/kp/rollstore/consul_store_test.go
@@ -918,7 +918,7 @@ func TestPublishLatestRCsSkipsIfCorrupt(t *testing.T) {
 	}
 
 	// Now push some bogus JSON that will trigger an error
-	corruptData := []*api.KVPair{&api.KVPair{Value: []byte("bad_json")}}
+	corruptData := []*api.KVPair{{Value: []byte("bad_json")}}
 	inCh <- corruptData
 
 	select {

--- a/pkg/kp/statusstore/statusstoretest/fake_status_store.go
+++ b/pkg/kp/statusstore/statusstoretest/fake_status_store.go
@@ -57,7 +57,7 @@ func (s *FakeStatusStore) GetStatus(
 	identifier := StatusIdentifier{t, id, namespace}
 	status, ok := s.Statuses[identifier]
 	if !ok {
-		return statusstore.Status{}, statusstore.NoStatusError{identifier.String()}
+		return statusstore.Status{}, statusstore.NoStatusError{Key: identifier.String()}
 	}
 
 	return status, nil

--- a/pkg/labels/consul_aggregator_test.go
+++ b/pkg/labels/consul_aggregator_test.go
@@ -77,7 +77,7 @@ func TestQuitAggregateAfterResults(t *testing.T) {
 	aggreg.Quit()
 	success := make(chan struct{})
 	go func() {
-		for _ = range res {
+		for range res {
 		}
 		success <- struct{}{}
 	}()
@@ -147,7 +147,7 @@ func TestQuitIndividualWatch(t *testing.T) {
 	// in a loop since it is possible that a value was sent on the channel
 	success := make(chan struct{})
 	go func() {
-		for _ = range labeledChannel1 {
+		for range labeledChannel1 {
 		}
 		success <- struct{}{}
 	}()

--- a/pkg/labels/http_applicator.go
+++ b/pkg/labels/http_applicator.go
@@ -119,7 +119,6 @@ func (h *httpApplicator) GetMatches(selector labels.Selector, labelType Type, ca
 
 func (h *httpApplicator) WatchMatches(selector labels.Selector, labelType Type, quitCh <-chan struct{}) chan []Labeled {
 	panic("Not implemented")
-	return nil
 }
 
 func (h *httpApplicator) WatchMatchDiff(

--- a/pkg/logbridge/logbridge_test.go
+++ b/pkg/logbridge/logbridge_test.go
@@ -223,7 +223,7 @@ func TestIsRetriable(t *testing.T) {
 	for i, testCase := range testCases {
 		actual := isRetriable(testCase.err)
 		if actual != testCase.expectation {
-			t.Errorf("test case %d: expected %b got %b", i, testCase.expectation, actual)
+			t.Errorf("test case %d: expected %t got %t", i, testCase.expectation, actual)
 		}
 	}
 }

--- a/pkg/opencontainer/containers.go
+++ b/pkg/opencontainer/containers.go
@@ -233,7 +233,7 @@ func (l *Launchable) makeLast() error {
 func (l *Launchable) Launch(serviceBuilder *runit.ServiceBuilder, sv runit.SV) error {
 	err := l.start(serviceBuilder, sv)
 	if err != nil {
-		return launch.StartError{err}
+		return launch.StartError{Inner: err}
 	}
 	// No "enable" for OpenContainers
 	return nil
@@ -290,7 +290,7 @@ func (l *Launchable) Halt(serviceBuilder *runit.ServiceBuilder, sv runit.SV) err
 	// "disable" script not supported for containers
 	err := l.stop(serviceBuilder, sv)
 	if err != nil {
-		return launch.StopError{err}
+		return launch.StopError{Inner: err}
 	}
 
 	err = l.makeLast()

--- a/pkg/opencontainer/default.go
+++ b/pkg/opencontainer/default.go
@@ -4,7 +4,7 @@ package opencontainer
 var DefaultRuntimeSpec = LinuxRuntimeSpec{
 	RuntimeSpec: RuntimeSpec{
 		Mounts: map[string]Mount{
-			"cgroup": Mount{
+			"cgroup": {
 				Type:   "cgroup",
 				Source: "cgroup",
 				Options: []string{
@@ -14,7 +14,7 @@ var DefaultRuntimeSpec = LinuxRuntimeSpec{
 					"relatime",
 				},
 			},
-			"dev": Mount{
+			"dev": {
 				Type:   "tmpfs",
 				Source: "tmpfs",
 				Options: []string{
@@ -24,7 +24,7 @@ var DefaultRuntimeSpec = LinuxRuntimeSpec{
 					"size=65536k",
 				},
 			},
-			"devpts": Mount{
+			"devpts": {
 				Type:   "devpts",
 				Source: "devpts",
 				Options: []string{
@@ -36,7 +36,7 @@ var DefaultRuntimeSpec = LinuxRuntimeSpec{
 					"gid=5",
 				},
 			},
-			"mqueue": Mount{
+			"mqueue": {
 				Type:   "mqueue",
 				Source: "mqueue",
 				Options: []string{
@@ -45,11 +45,11 @@ var DefaultRuntimeSpec = LinuxRuntimeSpec{
 					"nodev",
 				},
 			},
-			"proc": Mount{
+			"proc": {
 				Type:   "proc",
 				Source: "proc",
 			},
-			"shm": Mount{
+			"shm": {
 				Type:   "tmpfs",
 				Source: "shm",
 				Options: []string{
@@ -60,7 +60,7 @@ var DefaultRuntimeSpec = LinuxRuntimeSpec{
 					"size=65536k",
 				},
 			},
-			"sysfs": Mount{
+			"sysfs": {
 				Type:   "sysfs",
 				Source: "sysfs",
 				Options: []string{

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -320,12 +320,12 @@ func TestBuildRunitServices(t *testing.T) {
 	Assert(t).IsNil(err, "Got an unexpected error reading the servicebuilder yaml file")
 
 	expectedMap := map[string]runit.ServiceTemplate{
-		executables[0].Service.Name: runit.ServiceTemplate{
+		executables[0].Service.Name: {
 			Run:    executables[0].Exec,
 			Log:    runit.DefaultLogExec(),
 			Finish: pod.FinishExecForLaunchable(testLaunchable),
 		},
-		executables[1].Service.Name: runit.ServiceTemplate{
+		executables[1].Service.Name: {
 			Run:    executables[1].Exec,
 			Log:    runit.DefaultLogExec(),
 			Finish: pod.FinishExecForLaunchable(testLaunchable),
@@ -347,7 +347,7 @@ func TestInstall(t *testing.T) {
 	testLocation := testContext.ExpandPath("hoisted-hello_3c021aff048ca8117593f9c71e03b87cf72fd440.tar.gz")
 
 	launchables := map[launch.LaunchableID]launch.LaunchableStanza{
-		"hello": launch.LaunchableStanza{
+		"hello": {
 			LaunchableId:   "hello",
 			Location:       testLocation,
 			LaunchableType: "hoist",

--- a/pkg/preparer/listener_test.go
+++ b/pkg/preparer/listener_test.go
@@ -106,7 +106,7 @@ func testHookListener(t *testing.T) (HookListener, string, <-chan struct{}) {
 		ExecDir:          execDir,
 		HookFactory:      hookFactory,
 		Logger:           logging.DefaultLogger,
-		authPolicy:       auth.FixedKeyringPolicy{openpgp.EntityList{fakeSigner}, nil},
+		authPolicy:       auth.FixedKeyringPolicy{Keyring: openpgp.EntityList{fakeSigner}},
 		artifactVerifier: auth.NopVerifier(),
 		artifactRegistry: artifact.NewRegistry(nil, uri.DefaultFetcher, osversion.DefaultDetector),
 	}

--- a/pkg/preparer/orchestrate_test.go
+++ b/pkg/preparer/orchestrate_test.go
@@ -375,7 +375,7 @@ func TestPreparerWillAcceptSignatureFromKeyring(t *testing.T) {
 	p, _, fakePodRoot := testPreparer(t, &FakeStore{})
 	defer p.Close()
 	defer os.RemoveAll(fakePodRoot)
-	p.authPolicy = auth.FixedKeyringPolicy{openpgp.EntityList{fakeSigner}, nil}
+	p.authPolicy = auth.FixedKeyringPolicy{Keyring: openpgp.EntityList{fakeSigner}}
 
 	Assert(t).IsTrue(
 		p.authorize(manifest, logging.DefaultLogger),
@@ -391,7 +391,7 @@ func TestPreparerWillAcceptSignatureForPreparerWithoutAuthorizedDeployers(t *tes
 	p, _, fakePodRoot := testPreparer(t, &FakeStore{})
 	defer p.Close()
 	defer os.RemoveAll(fakePodRoot)
-	p.authPolicy = auth.FixedKeyringPolicy{openpgp.EntityList{fakeSigner}, nil}
+	p.authPolicy = auth.FixedKeyringPolicy{Keyring: openpgp.EntityList{fakeSigner}}
 
 	Assert(t).IsTrue(
 		p.authorize(manifest, logging.DefaultLogger),

--- a/pkg/rc/farm.go
+++ b/pkg/rc/farm.go
@@ -205,7 +205,7 @@ START_LOOP:
 						if r := recover(); r != nil {
 							err := util.Errorf("Caught panic in rc farm: %s", r)
 							rcLogger.WithError(err).
-								WithField("rc_id", rcField.ID).
+								WithField("rc_id", id).
 								Errorln("Caught panic in rc farm")
 						}
 					}()

--- a/pkg/roll/farm.go
+++ b/pkg/roll/farm.go
@@ -232,12 +232,13 @@ START_LOOP:
 					continue
 				}
 
+				newRC := rlField.NewRC
 				go func(id roll_fields.ID) {
 					defer func() {
 						if r := recover(); r != nil {
 							err := util.Errorf("Caught panic in roll farm: %s", r)
 							rlLogger.WithError(err).
-								WithField("new_rc", rlField.NewRC).
+								WithField("new_rc", newRC).
 								Errorln("Caught panic in roll farm")
 
 							// Release the child so that another farm can reattempt

--- a/pkg/runit/runit_service.go
+++ b/pkg/runit/runit_service.go
@@ -37,6 +37,7 @@ const (
 var DefaultSVPath = "/usr/bin/sv"
 
 var DefaultSV *sv
+
 func init() {
 	// Setup in init so if DefaultSVPath is changed at build time we use the changed value
 	DefaultSV = &sv{Bin: DefaultSVPath}

--- a/pkg/runit/servicebuilder_test.go
+++ b/pkg/runit/servicebuilder_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 var fakeTemplate map[string]ServiceTemplate = map[string]ServiceTemplate{
-	"foo": ServiceTemplate{
+	"foo": {
 		Run: []string{"foo", "one", "two"},
 		Log: []string{"log", "three", "four"},
 	},

--- a/pkg/util/mkdir.go
+++ b/pkg/util/mkdir.go
@@ -12,7 +12,7 @@ func MkdirChownAll(path string, uid, gid int, perm os.FileMode) error {
 		if dir.IsDir() {
 			return nil
 		}
-		return &os.PathError{"mkdir", path, syscall.ENOTDIR}
+		return &os.PathError{Op: "mkdir", Path: path, Err: syscall.ENOTDIR}
 	}
 
 	// Slow path: make sure parent exists and then call Mkdir for path.

--- a/pkg/util/stream/publisher_test.go
+++ b/pkg/util/stream/publisher_test.go
@@ -59,7 +59,7 @@ RecvLoop:
 	for _, r := range received {
 		for i, s := range sent {
 			if r == s {
-				sent = sent[i+1 : len(sent)]
+				sent = sent[i+1:]
 				continue RecvLoop
 			}
 		}


### PR DESCRIPTION
Simplifies the source code formatting via "gofmt" and fixes many questionable practices flagged by "go vet".