### PR TITLE
Fix the TestWatchAll test in dsstore package.

### DIFF
--- a/pkg/kp/dsstore/consul_store.go
+++ b/pkg/kp/dsstore/consul_store.go
@@ -329,13 +329,13 @@ func (s *consulStore) Watch(quitCh <-chan struct{}) <-chan WatchedDaemonSets {
 // WatchAll watches dsTree for all the daemon sets and returns a blocking
 // channel where the client can read a WatchedDaemonSetsList object which
 // contain all of the daemon sets currently on the tree
-func (s *consulStore) WatchAll(quitCh <-chan struct{}) <-chan WatchedDaemonSetList {
+func (s *consulStore) WatchAll(quitCh <-chan struct{}, pauseTime time.Duration) <-chan WatchedDaemonSetList {
 	inCh := make(chan api.KVPairs)
 	outCh := make(chan WatchedDaemonSetList)
 	errCh := make(chan error, 1)
 
 	// Watch for changes in the dsTree and deletedDSTree
-	go consulutil.WatchPrefix(dsTree, s.kv, inCh, quitCh, errCh, 5*time.Second)
+	go consulutil.WatchPrefix(dsTree, s.kv, inCh, quitCh, errCh, pauseTime)
 
 	go func() {
 		defer close(outCh)

--- a/pkg/kp/dsstore/consul_store_test.go
+++ b/pkg/kp/dsstore/consul_store_test.go
@@ -547,7 +547,7 @@ func TestWatchAll(t *testing.T) {
 	// Watch for create and verify
 	//
 	quitCh := make(chan struct{})
-	inCh := store.WatchAll(quitCh)
+	inCh := store.WatchAll(quitCh, 0)
 	defer close(quitCh)
 
 	var watched WatchedDaemonSetList

--- a/pkg/kp/dsstore/dsstoretest/fake_dsstore.go
+++ b/pkg/kp/dsstore/dsstoretest/fake_dsstore.go
@@ -181,7 +181,8 @@ func (s *FakeDSStore) Watch(quitCh <-chan struct{}) <-chan dsstore.WatchedDaemon
 	return s.watchDiffDaemonSets(inCh, quitCh)
 }
 
-func (s *FakeDSStore) WatchAll(quitCh <-chan struct{}) <-chan dsstore.WatchedDaemonSetList {
+// pauseTime not implemented
+func (s *FakeDSStore) WatchAll(quitCh <-chan struct{}, _ time.Duration) <-chan dsstore.WatchedDaemonSetList {
 	inCh := s.WatchList(quitCh)
 	outCh := make(chan dsstore.WatchedDaemonSetList)
 

--- a/pkg/kp/dsstore/store.go
+++ b/pkg/kp/dsstore/store.go
@@ -63,7 +63,7 @@ type Store interface {
 	Watch(quit <-chan struct{}) <-chan WatchedDaemonSets
 
 	// Returns a list of all the daemon sets that are on the tree
-	WatchAll(quit <-chan struct{}) <-chan WatchedDaemonSetList
+	WatchAll(quit <-chan struct{}, pauseTime time.Duration) <-chan WatchedDaemonSetList
 
 	// Disables daemon set and produces logging, if there are problems disabling,
 	// disable the daemon set, and if there are still problems, return a fatal error


### PR DESCRIPTION
The test watches the daemon set channel returned by WatchAll, and the
test times out if a value is not sent on the channel after 5 seconds.
However, WatchAll() had a hardcoded 5 second time duration to wait after
receiving a daemon set update from WatchPrefix. This meant that the test
would always fail.

Now the pause time is passed in as a function argument, with a value of
0 used in the test so that it proceeds as fast as possible.