### PR TITLE
[RFC] Perform a HEAD request instead of a GET

### DIFF
--- a/pkg/watch/health.go
+++ b/pkg/watch/health.go
@@ -267,7 +267,6 @@ func (sc *StatusChecker) resultFromCheck(resp *http.Response, err error) (health
 		return res, nil
 	}
 
-	res.Output, err = getBody(resp)
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		res.Status = health.Passing
 	} else {
@@ -278,7 +277,7 @@ func (sc *StatusChecker) resultFromCheck(resp *http.Response, err error) (health
 
 // Go version of http status check
 func (sc *StatusChecker) StatusCheck() (*http.Response, error) {
-	return sc.Client.Get(sc.URI)
+	return sc.Client.Head(sc.URI)
 }
 
 func getBody(resp *http.Response) (string, error) {

--- a/pkg/watch/health_test.go
+++ b/pkg/watch/health_test.go
@@ -117,7 +117,7 @@ output`))), nil)
 
 	val, _ := sc.resultFromCheck(resp, nil)
 	Assert(t).AreEqual(health.Passing, val.Status, "200 should correspond to health.Passing")
-	Assert(t).AreEqual("output", val.Output, "body of response should have been captured")
+	Assert(t).AreEqual("", val.Output, "Expected no body to be present.")
 
 	resp.StatusCode = 282
 	val, _ = sc.resultFromCheck(resp, nil)


### PR DESCRIPTION
This matches the convention of other backend systems and protects us from any extra bytes in the response.