### PR TITLE
Disable each launchable before stopping any of them.

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -61,7 +61,7 @@ func (hl *Launchable) If() launch.Launchable {
 	return LaunchAdapter{Launchable: hl}
 }
 
-func (hl *Launchable) Halt(serviceBuilder *runit.ServiceBuilder, sv runit.SV) error {
+func (hl *Launchable) Disable() error {
 	// the error return from os/exec.Run is almost always meaningless
 	// ("exit status 1")
 	// since the output is more useful to the user, that's what we'll preserve
@@ -70,8 +70,12 @@ func (hl *Launchable) Halt(serviceBuilder *runit.ServiceBuilder, sv runit.SV) er
 		return launch.DisableError{Inner: util.Errorf("%s", out)}
 	}
 
+	return nil
+}
+
+func (hl *Launchable) Stop(serviceBuilder *runit.ServiceBuilder, sv runit.SV) error {
 	// probably want to do something with output at some point
-	err = hl.stop(serviceBuilder, sv)
+	err := hl.stop(serviceBuilder, sv)
 	if err != nil {
 		return launch.StopError{Inner: err}
 	}

--- a/pkg/hoist/hoist_launchable_test.go
+++ b/pkg/hoist/hoist_launchable_test.go
@@ -326,28 +326,18 @@ func TestStop(t *testing.T) {
 	Assert(t).IsNil(err, "Got an unexpected error when attempting to stop runit services")
 }
 
-func TestHaltWithFailingDisable(t *testing.T) {
-	hl, sb := FakeHoistLaunchableForDir("failing_scripts_test_hoist_launchable")
-	defer CleanupFakeLaunchable(hl, sb)
-
-	sv := runit.FakeSV()
-	err := hl.Halt(sb, sv)
-	Assert(t).IsNotNil(err, "Expected error while halting")
+func TestDisableWithFailingDisable(t *testing.T) {
+	hl, _ := FakeHoistLaunchableForDir("failing_scripts_test_hoist_launchable")
+	err := hl.Disable()
+	Assert(t).IsNotNil(err, "Expected error while disabling")
 	_, ok := err.(launch.DisableError)
 	Assert(t).IsTrue(ok, "Expected disable error to be returned")
-	_, ok = err.(launch.StopError)
-	Assert(t).IsFalse(ok, "Did not expect stop error to be returned")
 }
 
-func TestHaltWithPassingDisable(t *testing.T) {
-	hl, sb := FakeHoistLaunchableForDir("successful_scripts_test_hoist_launchable")
-	defer CleanupFakeLaunchable(hl, sb)
-
-	sv := runit.FakeSV()
-	err := hl.Halt(sb, sv)
-	Assert(t).IsNil(err, "Expected halt to succeed")
-
-	Assert(t).IsNil(os.Remove(hl.LastDir()), "expected halt to create last symlink")
+func TestDisableWithPassingDisable(t *testing.T) {
+	hl, _ := FakeHoistLaunchableForDir("successful_scripts_test_hoist_launchable")
+	err := hl.Disable()
+	Assert(t).IsNil(err, "Expected disable to succeed")
 }
 
 func TestLaunchWithFailingEnable(t *testing.T) {
@@ -372,17 +362,15 @@ func TestLaunchWithPassingEnable(t *testing.T) {
 	Assert(t).IsNil(err, "Expected launch to succeed")
 }
 
-func TestHaltWithFailingStop(t *testing.T) {
+func TestStopWithFailure(t *testing.T) {
 	hl, sb := FakeHoistLaunchableForDir("successful_scripts_test_hoist_launchable")
 	defer CleanupFakeLaunchable(hl, sb)
 
 	sv := runit.ErringSV()
-	err := hl.Halt(sb, sv)
+	err := hl.Stop(sb, sv)
 	Assert(t).IsNotNil(err, "Expected error while halting")
 	_, ok := err.(launch.StopError)
 	Assert(t).IsTrue(ok, "Expected stop error to be returned")
-	_, ok = err.(launch.DisableError)
-	Assert(t).IsFalse(ok, "Did not expect disable error to be returned")
 }
 
 func TestLaunchWithFailingStart(t *testing.T) {

--- a/pkg/launch/launchable.go
+++ b/pkg/launch/launchable.go
@@ -124,8 +124,10 @@ type Launchable interface {
 	PostActivate() (string, error)
 	// Launch begins execution.
 	Launch(serviceBuilder *runit.ServiceBuilder, sv runit.SV) error
-	// Halt stops execution.
-	Halt(serviceBuilder *runit.ServiceBuilder, sv runit.SV) error
+	// Disable allows a launchable to stop work and do cleanup prior to Stop
+	Disable() error
+	// Stop stops execution.
+	Stop(serviceBuilder *runit.ServiceBuilder, sv runit.SV) error
 	// MakeCurrent adjusts a "current" symlink for this launchable name to point to this
 	// launchable's version.
 	MakeCurrent() error

--- a/pkg/opencontainer/containers.go
+++ b/pkg/opencontainer/containers.go
@@ -285,9 +285,13 @@ func (l *Launchable) stop(serviceBuilder *runit.ServiceBuilder, sv runit.SV) err
 	return nil
 }
 
-// Halt causes the launchable to halt execution if it is running.
-func (l *Launchable) Halt(serviceBuilder *runit.ServiceBuilder, sv runit.SV) error {
+func (l *Launchable) Disable() error {
 	// "disable" script not supported for containers
+	return nil
+}
+
+// Halt causes the launchable to halt execution if it is running.
+func (l *Launchable) Stop(serviceBuilder *runit.ServiceBuilder, sv runit.SV) error {
 	err := l.stop(serviceBuilder, sv)
 	if err != nil {
 		return launch.StopError{Inner: err}

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/square/p2/pkg/auth"
 	"github.com/square/p2/pkg/hoist"
 	"github.com/square/p2/pkg/launch"
+	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/osversion"
 	"github.com/square/p2/pkg/runit"
@@ -401,6 +402,7 @@ func TestUninstall(t *testing.T) {
 		Id:             "testPod",
 		home:           testPodDir,
 		ServiceBuilder: serviceBuilder,
+		logger:         logging.DefaultLogger,
 	}
 	manifest := getTestPodManifest(t)
 	manifestContent, err := manifest.Marshal()


### PR DESCRIPTION
The previous behavior was to shut down with the following sequence:
1) disable 1st launchable
2) stop 1st launchable
3) disable 2nd launchable
...

The new behavior is to disable all launchables before stopping
launchables. This allows a launchable that depends on others for
successful operation to do shutdown handling prior to the other
launchables receiving term or kill signals.