### PR TITLE
Fix health path and add feature to p2-label

### DIFF
--- a/pkg/health/checker/checker.go
+++ b/pkg/health/checker/checker.go
@@ -189,11 +189,11 @@ func (c consulHealthChecker) WatchService(
 		case <-quitCh:
 			return
 		case <-time.After(1 * time.Second):
-			results, queryMeta, err := c.client.KV().List(kp.HealthPath(serviceID, ""), &api.QueryOptions{
+			results, queryMeta, err := c.client.KV().List(kp.HealthPath(serviceID, "/"), &api.QueryOptions{
 				WaitIndex: curIndex,
 			})
 			if err != nil {
-				errCh <- consulutil.NewKVError("list", kp.HealthPath(serviceID, ""), err)
+				errCh <- consulutil.NewKVError("list", kp.HealthPath(serviceID, "/"), err)
 			} else {
 				curIndex = queryMeta.LastIndex
 				out := make(map[types.NodeName]health.Result)

--- a/pkg/kp/kv.go
+++ b/pkg/kp/kv.go
@@ -166,7 +166,7 @@ func (c consulStore) GetHealth(service string, node types.NodeName) (WatchResult
 
 func (c consulStore) GetServiceHealth(service string) (map[string]WatchResult, error) {
 	healthRes := make(map[string]WatchResult)
-	key := HealthPath(service, "")
+	key := HealthPath(service, "/")
 	res, _, err := c.client.KV().List(key, nil)
 	if err != nil {
 		return healthRes, consulutil.NewKVError("list", key, err)

--- a/pkg/kp/kv_test.go
+++ b/pkg/kp/kv_test.go
@@ -41,6 +41,27 @@ func TestGetHealthWithEntry(t *testing.T) {
 		t.Fatalf("PutHealth failed: %v", err)
 	}
 
+	watch2 := WatchResult{
+		Id:      "id2",
+		Node:    "node2",
+		Service: "service",
+	}
+
+	_, _, err = f.Store.PutHealth(watch2)
+	if err != nil {
+		t.Fatalf("PutHealth failed: %v", err)
+	}
+
+	otherWatch := WatchResult{
+		Id:      "id3",
+		Node:    "node3",
+		Service: "servicewithsuffix",
+	}
+	_, _, err = f.Store.PutHealth(otherWatch)
+	if err != nil {
+		t.Fatalf("PutHealth failed: %v", err)
+	}
+
 	// Get should work
 	watchRes, err := f.Store.GetHealth(watch.Service, watch.Node)
 	if err != nil {
@@ -54,6 +75,15 @@ func TestGetHealthWithEntry(t *testing.T) {
 	}
 	if watchRes.Service != watch.Service {
 		t.Fatalf("watchRes and watch Service did not match. GetHealth failed: %#v", watchRes)
+	}
+
+	// List should work
+	results, err := f.Store.GetServiceHealth(watch.Service)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("Expected to have 2 results, got %v", len(results))
 	}
 }
 


### PR DESCRIPTION
Two unrelated commits in this PR. 

First, there is a bugfix for health watches. You can accidentally get the health for any service matching the string prefix of the name.

The other is a small feature for `p2-label` to allow setting labels on specific entities.