### PR TITLE
Break up kp.Store interface into subsets

### DIFF
--- a/bin/p2-rctl-server/main.go
+++ b/bin/p2-rctl-server/main.go
@@ -110,7 +110,7 @@ func main() {
 	).Start(nil)
 	roll.NewFarm(
 		roll.UpdateFactory{
-			KPStore:       kpStore,
+			Store:         kpStore,
 			RCStore:       rcStore,
 			HealthChecker: healthChecker,
 			Labeler:       labeler,

--- a/bin/p2-rctl/main.go
+++ b/bin/p2-rctl/main.go
@@ -156,6 +156,11 @@ func SessionName() string {
 	return fmt.Sprintf("p2-rctl:%s:%s", hostname, timeStr)
 }
 
+type Store interface {
+	// for passing into a roll farm
+	roll.Store
+}
+
 // rctl is a struct for the data structures shared between commands
 // each member function represents a single command that takes over from main
 // and terminates the program on failure
@@ -166,7 +171,7 @@ type rctlParams struct {
 	rls        rollstore.Store
 	sched      scheduler.Scheduler
 	labeler    labels.ApplicatorWithoutWatches
-	kps        kp.Store
+	kps        Store
 	hcheck     checker.ConsulHealthChecker
 	logger     logging.Logger
 }

--- a/bin/p2-rm/main.go
+++ b/bin/p2-rm/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/user"
 	"path"
+	"time"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 
@@ -27,9 +28,14 @@ var (
 	deallocation = kingpin.Flag("deallocate", "Specifies that we are deallocating this pod on this node. Using this switch will mutate the desired_replicas value on a managing RC, if one exists.").Bool()
 )
 
+type store interface {
+	NewSession(name string, renewalCh <-chan time.Time) (kp.Session, chan error, error)
+	DeletePod(podPrefix kp.PodPrefix, nodename types.NodeName, podId types.PodID) (time.Duration, error)
+}
+
 // P2RM contains the state necessary to safely remove a pod from a node
 type P2RM struct {
-	Store   kp.Store
+	Store   store
 	RCStore rcstore.Store
 	Client  consulutil.ConsulClient
 	Labeler labels.ApplicatorWithoutWatches

--- a/pkg/ds/farm_test.go
+++ b/pkg/ds/farm_test.go
@@ -55,7 +55,7 @@ func TestContendNodes(t *testing.T) {
 
 	dsf := &Farm{
 		dsStore:       dsStore,
-		kpStore:       kpStore,
+		store:         kpStore,
 		scheduler:     scheduler.NewApplicatorScheduler(applicator),
 		labeler:       applicator,
 		watcher:       applicator,
@@ -166,7 +166,7 @@ func TestContendSelectors(t *testing.T) {
 
 	dsf := &Farm{
 		dsStore:       dsStore,
-		kpStore:       kpStore,
+		store:         kpStore,
 		scheduler:     scheduler.NewApplicatorScheduler(applicator),
 		labeler:       applicator,
 		watcher:       applicator,
@@ -317,7 +317,7 @@ func TestFarmSchedule(t *testing.T) {
 
 	dsf := &Farm{
 		dsStore:       dsStore,
-		kpStore:       kpStore,
+		store:         kpStore,
 		scheduler:     scheduler.NewApplicatorScheduler(applicator),
 		labeler:       applicator,
 		watcher:       applicator,
@@ -527,7 +527,7 @@ func TestCleanupPods(t *testing.T) {
 	})
 	dsf := &Farm{
 		dsStore:       dsStore,
-		kpStore:       kpStore,
+		store:         kpStore,
 		scheduler:     scheduler.NewApplicatorScheduler(applicator),
 		labeler:       applicator,
 		watcher:       applicator,
@@ -592,7 +592,7 @@ func TestMultipleFarms(t *testing.T) {
 	//
 	firstFarm := &Farm{
 		dsStore:       dsStore,
-		kpStore:       kpStore,
+		store:         kpStore,
 		scheduler:     scheduler.NewApplicatorScheduler(applicator),
 		labeler:       applicator,
 		watcher:       applicator,
@@ -617,7 +617,7 @@ func TestMultipleFarms(t *testing.T) {
 	})
 	secondFarm := &Farm{
 		dsStore:       dsStore,
-		kpStore:       kpStore,
+		store:         kpStore,
 		scheduler:     scheduler.NewApplicatorScheduler(applicator),
 		labeler:       applicator,
 		watcher:       applicator,

--- a/pkg/kp/fixtures_test.go
+++ b/pkg/kp/fixtures_test.go
@@ -11,7 +11,7 @@ import (
 
 type ConsulTestFixture struct {
 	consulutil.Fixture
-	Store Store
+	Store *consulStore
 }
 
 // Create a new test fixture that spins up a local Consul server.

--- a/pkg/kp/kptest/fake_store.go
+++ b/pkg/kp/kptest/fake_store.go
@@ -29,8 +29,6 @@ type FakePodStore struct {
 	podLock sync.Mutex
 }
 
-var _ kp.Store = &FakePodStore{}
-
 func NewFakePodStore(podResults map[FakePodStoreKey]manifest.Manifest, healthResults map[string]kp.WatchResult) *FakePodStore {
 	if podResults == nil {
 		podResults = make(map[FakePodStoreKey]manifest.Manifest)

--- a/pkg/kp/kv.go
+++ b/pkg/kp/kv.go
@@ -39,25 +39,6 @@ type ManifestResult struct {
 	PodUniqueKey *types.PodUniqueKey
 }
 
-type Store interface {
-	SetPod(podPrefix PodPrefix, nodename types.NodeName, manifest manifest.Manifest) (time.Duration, error)
-	Pod(podPrefix PodPrefix, nodename types.NodeName, podId types.PodID) (manifest.Manifest, time.Duration, error)
-	DeletePod(podPrefix PodPrefix, nodename types.NodeName, podId types.PodID) (time.Duration, error)
-	PutHealth(res WatchResult) (time.Time, time.Duration, error)
-	GetHealth(service string, node types.NodeName) (WatchResult, error)
-	GetServiceHealth(service string) (map[string]WatchResult, error)
-	WatchPod(podPrefix PodPrefix, nodename types.NodeName, podId types.PodID, quitChan <-chan struct{}, errChan chan<- error, podChan chan<- ManifestResult)
-	WatchPods(podPrefix PodPrefix, nodename types.NodeName, quitChan <-chan struct{}, errChan chan<- error, podChan chan<- []ManifestResult)
-	WatchAllPods(podPrefix PodPrefix, quitChan <-chan struct{}, errChan chan<- error, podChan chan<- []ManifestResult, pauseTime time.Duration)
-	ListPods(podPrefix PodPrefix, nodename types.NodeName) ([]ManifestResult, time.Duration, error)
-	AllPods(podPrefix PodPrefix) ([]ManifestResult, time.Duration, error)
-	LockHolder(key string) (string, string, error)
-	DestroyLockHolder(id string) error
-	NewSession(name string, renewalCh <-chan time.Time) (Session, chan error, error)
-	NewUnmanagedSession(session, name string) Session
-	NewHealthManager(node types.NodeName, logger logging.Logger) HealthManager
-}
-
 // HealthManager manages a collection of health checks that share configuration and
 // resources.
 type HealthManager interface {
@@ -121,7 +102,7 @@ type consulStore struct {
 	podStatusStore podstatus.Store
 }
 
-func NewConsulStore(client consulutil.ConsulClient) Store {
+func NewConsulStore(client consulutil.ConsulClient) *consulStore {
 	statusStore := statusstore.NewConsul(client)
 	podStatusStore := podstatus.NewConsul(statusStore, PreparerPodStatusNamespace)
 	podStore := podstore.NewConsul(client.KV())

--- a/pkg/kp/kv_test.go
+++ b/pkg/kp/kv_test.go
@@ -157,25 +157,20 @@ func TestAllPods(t *testing.T) {
 	fakeConsulClient := consulutil.NewFakeClient()
 	store := NewConsulStore(fakeConsulClient)
 
-	consulStore, ok := store.(*consulStore)
-	if !ok {
-		t.Fatal("Type assertion to consulStore struct type failed")
-	}
-
 	// Add a new uuid pod (i.e. we expect an index rather than a manifest to be written to /intent)
-	uuidKey, err := consulStore.podStore.Schedule(testManifest("first_pod"), "node1")
+	uuidKey, err := store.podStore.Schedule(testManifest("first_pod"), "node1")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Add a status entry for the pod
-	err = consulStore.podStatusStore.Set(uuidKey, podstatus.PodStatus{Manifest: "id: first_pod"})
+	err = store.podStatusStore.Set(uuidKey, podstatus.PodStatus{Manifest: "id: first_pod"})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Write the /reality index for the pod
-	err = consulStore.podStore.WriteRealityIndex(uuidKey, "node1")
+	err = store.podStore.WriteRealityIndex(uuidKey, "node1")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -26,6 +26,7 @@ import (
 	"github.com/square/p2/pkg/kp/statusstore/podstatus"
 	"github.com/square/p2/pkg/launch"
 	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/osversion"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/runit"
@@ -70,6 +71,20 @@ type Preparer struct {
 	artifactRegistry       artifact.Registry
 }
 
+type store interface {
+	SetPod(podPrefix kp.PodPrefix, nodename types.NodeName, manifest manifest.Manifest) (time.Duration, error)
+	Pod(podPrefix kp.PodPrefix, nodename types.NodeName, podId types.PodID) (manifest.Manifest, time.Duration, error)
+	DeletePod(podPrefix kp.PodPrefix, nodename types.NodeName, podId types.PodID) (time.Duration, error)
+	ListPods(podPrefix kp.PodPrefix, nodename types.NodeName) ([]kp.ManifestResult, time.Duration, error)
+	WatchPods(
+		podPrefix kp.PodPrefix,
+		hostname types.NodeName,
+		quit <-chan struct{},
+		errCh chan<- error,
+		manifests chan<- []kp.ManifestResult,
+	)
+}
+
 type PreparerConfig struct {
 	NodeName               types.NodeName         `yaml:"node_name"`
 	ConsulAddress          string                 `yaml:"consul_address"`
@@ -97,7 +112,7 @@ type PreparerConfig struct {
 	// source files.
 	Params param.Values `yaml:"params"`
 
-	// Use a single consul client so that all requests go through the same HTTP client.
+	// Use a single Store so that all requests go through the same HTTP client.
 	mux          sync.Mutex
 	consulClient consulutil.ConsulClient
 }
@@ -323,10 +338,11 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 		return nil, err
 	}
 
-	store := kp.NewConsulStore(client)
 	statusStore := statusstore.NewConsul(client)
 	podStatusStore := podstatus.NewConsul(statusStore, kp.PreparerPodStatusNamespace)
 	podStore := podstore.NewConsul(client.KV())
+
+	store := kp.NewConsulStore(client)
 
 	maxLaunchableDiskUsage := launch.DefaultAllowableDiskUsage
 	if preparerConfig.MaxLaunchableDiskUsage != "" {

--- a/pkg/replication/common_setup_test.go
+++ b/pkg/replication/common_setup_test.go
@@ -25,7 +25,7 @@ const (
 	testPreparerManifest = `id: p2-preparer`
 )
 
-func testReplicatorAndServer(t *testing.T) (Replicator, kp.Store, consulutil.Fixture) {
+func testReplicatorAndServer(t *testing.T) (Replicator, Store, consulutil.Fixture) {
 	active := 1
 	store, f := makeStore(t)
 
@@ -50,7 +50,7 @@ func testReplicatorAndServer(t *testing.T) (Replicator, kp.Store, consulutil.Fix
 	return replicator, store, f
 }
 
-func makeStore(t *testing.T) (kp.Store, consulutil.Fixture) {
+func makeStore(t *testing.T) (Store, consulutil.Fixture) {
 	f := consulutil.NewFixture(t)
 	store := kp.NewConsulStore(f.Client)
 	return store, f

--- a/pkg/replication/replication.go
+++ b/pkg/replication/replication.go
@@ -63,11 +63,19 @@ type Replication interface {
 	WaitForReplication()
 }
 
+type Store interface {
+	SetPod(podPrefix kp.PodPrefix, nodename types.NodeName, manifest manifest.Manifest) (time.Duration, error)
+	Pod(podPrefix kp.PodPrefix, nodename types.NodeName, podId types.PodID) (manifest.Manifest, time.Duration, error)
+	NewSession(name string, renewalCh <-chan time.Time) (kp.Session, chan error, error)
+	LockHolder(key string) (string, string, error)
+	DestroyLockHolder(id string) error
+}
+
 // A replication contains the information required to do a single replication (deploy).
 type replication struct {
 	active    int
 	nodes     []types.NodeName
-	store     kp.Store
+	store     Store
 	labeler   Labeler
 	manifest  manifest.Manifest
 	health    checker.ConsulHealthChecker

--- a/pkg/replication/replicator.go
+++ b/pkg/replication/replicator.go
@@ -53,7 +53,7 @@ type replicator struct {
 	logger    logging.Logger
 	nodes     []types.NodeName
 	active    int // maximum number of nodes to update concurrently
-	store     kp.Store
+	store     Store
 	labeler   Labeler
 	health    checker.ConsulHealthChecker
 	threshold health.HealthState // minimum state to treat as "healthy"
@@ -69,7 +69,7 @@ func NewReplicator(
 	logger logging.Logger,
 	nodes []types.NodeName,
 	active int,
-	store kp.Store,
+	store Store,
 	labeler Labeler,
 	health checker.ConsulHealthChecker,
 	threshold health.HealthState,

--- a/pkg/roll/run_update.go
+++ b/pkg/roll/run_update.go
@@ -14,6 +14,7 @@ import (
 	"github.com/square/p2/pkg/kp/consulutil"
 	"github.com/square/p2/pkg/kp/rcstore"
 	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/pods"
 	"github.com/square/p2/pkg/rc"
 	rcf "github.com/square/p2/pkg/rc/fields"
@@ -23,10 +24,17 @@ import (
 	"github.com/square/p2/pkg/util"
 )
 
+type Store interface {
+	SetPod(podPrefix kp.PodPrefix, nodename types.NodeName, manifest manifest.Manifest) (time.Duration, error)
+	Pod(podPrefix kp.PodPrefix, nodename types.NodeName, podId types.PodID) (manifest.Manifest, time.Duration, error)
+	DeletePod(podPrefix kp.PodPrefix, nodename types.NodeName, podId types.PodID) (time.Duration, error)
+	NewUnmanagedSession(session, name string) kp.Session
+}
+
 type update struct {
 	fields.Update
 
-	kps     kp.Store
+	kps     Store
 	rcs     rcstore.Store
 	hcheck  checker.ConsulHealthChecker
 	labeler rc.Labeler
@@ -47,7 +55,7 @@ type update struct {
 // responsibility of the caller.
 func NewUpdate(
 	f fields.Update,
-	kps kp.Store,
+	kps Store,
 	rcs rcstore.Store,
 	hcheck checker.ConsulHealthChecker,
 	labeler rc.Labeler,

--- a/pkg/watch/health.go
+++ b/pkg/watch/health.go
@@ -55,6 +55,11 @@ type StatusChecker struct {
 	Client *http.Client
 }
 
+type store interface {
+	NewHealthManager(node types.NodeName, logger logging.Logger) kp.HealthManager
+	WatchPods(podPrefix kp.PodPrefix, nodename types.NodeName, quitChan <-chan struct{}, errChan chan<- error, podChan chan<- []kp.ManifestResult)
+}
+
 // MonitorPodHealth is meant to be a long running go routine.
 // MonitorPodHealth reads from a consul store to determine which
 // services should be running on the host. MonitorPodHealth
@@ -65,7 +70,7 @@ func MonitorPodHealth(config *preparer.PreparerConfig, logger *logging.Logger, s
 	client, err := config.GetConsulClient()
 	if err != nil {
 		// A bad config should have already produced a nice, user-friendly error message.
-		logger.WithError(err).Fatalln("error creating health monitor KV store")
+		logger.WithError(err).Fatalln("error creating health monitor KV client")
 	}
 	store := kp.NewConsulStore(client)
 	healthManager := store.NewHealthManager(config.NodeName, *logger)


### PR DESCRIPTION
kp.Store was a massive interface which makes it hard to implement with
new stores. This commit breaks up the interface into package-defined
interfaces where they are needed that only contain the functions that
are used.

This will enable implementing individual store interfaces with a GRPC
storage server.