### PR TITLE
Further constrain the interface required for the HTTP label server.

### DIFF
--- a/pkg/labels/http_applicator.go
+++ b/pkg/labels/http_applicator.go
@@ -25,6 +25,8 @@ type httpApplicator struct {
 	logger          logging.Logger
 }
 
+var _ ApplicatorWithoutWatches = &httpApplicator{}
+
 func NewHTTPApplicator(client *http.Client, matchesEndpoint *url.URL) (*httpApplicator, error) {
 	if matchesEndpoint == nil {
 		return nil, util.Errorf("matches endpoint cannot be nil")


### PR DESCRIPTION
The HTTP label server does not need to have access to the Watch functions yet.