### PR TITLE
Inject labelers whenever possible

### DIFF
--- a/bin/p2-dsctl/main.go
+++ b/bin/p2-dsctl/main.go
@@ -88,11 +88,10 @@ var (
 )
 
 func main() {
-	cmd, consulOpts := flags.ParseWithConsulOptions()
+	cmd, consulOpts, applicator := flags.ParseWithConsulOptions()
 	client := kp.NewConsulClient(consulOpts)
 	logger := logging.NewLogger(logrus.Fields{})
 	dsstore := dsstore.NewConsul(client, 3, &logger)
-	applicator := labels.NewConsulApplicator(client, 3)
 
 	switch cmd {
 	case CmdCreate:
@@ -323,7 +322,7 @@ func main() {
 func parseNodeSelectorWithPrompt(
 	oldSelector klabels.Selector,
 	newSelectorString string,
-	applicator labels.Applicator,
+	applicator labels.ApplicatorWithoutWatches,
 ) (klabels.Selector, error) {
 	newSelector, err := parseNodeSelector(newSelectorString)
 	if err != nil {
@@ -356,7 +355,7 @@ func parseNodeSelectorWithPrompt(
 	return newSelector, nil
 }
 
-func confirmMinheathForSelector(minHealth int, selector klabels.Selector, applicator labels.Applicator) error {
+func confirmMinheathForSelector(minHealth int, selector klabels.Selector, applicator labels.ApplicatorWithoutWatches) error {
 	matches, err := applicator.GetMatches(selector, labels.NODE, false)
 	if err != nil {
 		return err

--- a/bin/p2-inspect/main.go
+++ b/bin/p2-inspect/main.go
@@ -25,7 +25,7 @@ var (
 
 func main() {
 	kingpin.Version(version.VERSION)
-	_, opts := flags.ParseWithConsulOptions()
+	_, opts, _ := flags.ParseWithConsulOptions()
 	client := kp.NewConsulClient(opts)
 	store := kp.NewConsulStore(client)
 

--- a/bin/p2-label/main.go
+++ b/bin/p2-label/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/kp/flags"
 	"github.com/square/p2/pkg/labels"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -43,9 +42,7 @@ const (
 )
 
 func main() {
-	cmd, opts := flags.ParseWithConsulOptions()
-	client := kp.NewConsulClient(opts)
-	applicator := labels.NewConsulApplicator(client, 3)
+	cmd, _, applicator := flags.ParseWithConsulOptions()
 	exitCode := 0
 
 	switch cmd {
@@ -136,7 +133,7 @@ func main() {
 	os.Exit(exitCode)
 }
 
-func applyLabels(applicator labels.Applicator, entityID string, labelType labels.Type, additiveLabels map[string]string, destructiveKeys []string) error {
+func applyLabels(applicator labels.ApplicatorWithoutWatches, entityID string, labelType labels.Type, additiveLabels map[string]string, destructiveKeys []string) error {
 	var err error
 	if !confirm(fmt.Sprintf("mutate the labels for %s/%s", labelType, entityID)) {
 		return nil

--- a/bin/p2-replicate/main.go
+++ b/bin/p2-replicate/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/square/p2/pkg/health/checker"
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/kp/flags"
-	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/replication"
@@ -48,10 +47,9 @@ func main() {
 `
 
 	kingpin.Version(version.VERSION)
-	_, opts := flags.ParseWithConsulOptions()
+	_, opts, labeler := flags.ParseWithConsulOptions()
 	client := kp.NewConsulClient(opts)
 	store := kp.NewConsulStore(client)
-	labeler := labels.NewConsulApplicator(client, 3)
 	healthChecker := checker.NewConsulHealthChecker(client)
 
 	manifest, err := manifest.FromURI(*manifestURI)

--- a/bin/p2-schedule/main.go
+++ b/bin/p2-schedule/main.go
@@ -20,7 +20,7 @@ var (
 
 func main() {
 	kingpin.Version(version.VERSION)
-	_, opts := flags.ParseWithConsulOptions()
+	_, opts, _ := flags.ParseWithConsulOptions()
 	client := kp.NewConsulClient(opts)
 	store := kp.NewConsulStore(client)
 

--- a/bin/p2-watch/main.go
+++ b/bin/p2-watch/main.go
@@ -30,7 +30,7 @@ var (
 
 func main() {
 	kingpin.Version(version.VERSION)
-	_, opts := flags.ParseWithConsulOptions()
+	_, opts, applicator := flags.ParseWithConsulOptions()
 	client := kp.NewConsulClient(opts)
 	store := kp.NewConsulStore(client)
 
@@ -42,7 +42,7 @@ func main() {
 		*nodeName = hostname
 	}
 	if *podClusters {
-		watchPodClusters(client)
+		watchPodClusters(client, applicator)
 	} else {
 		podPrefix := kp.INTENT_TREE
 		if *watchReality {
@@ -104,11 +104,11 @@ func (p *printSyncer) Type() pcstore.ConcreteSyncerType {
 	return "print_syncer"
 }
 
-func watchPodClusters(client consulutil.ConsulClient) {
+func watchPodClusters(client consulutil.ConsulClient, applicator labels.ApplicatorWithoutWatches) {
 	logger := &logging.DefaultLogger
 	logger.Infoln("Beginning pod cluster watch")
 
-	pcStore := pcstore.NewConsul(client, 0, logger)
+	pcStore := pcstore.NewConsul(client, applicator, labels.NewConsulApplicator(client, 0), logger)
 	quitCh := make(chan struct{})
 	go func() {
 		signalCh := make(chan os.Signal, 2)

--- a/bin/p2-wipe-reality/main.go
+++ b/bin/p2-wipe-reality/main.go
@@ -25,7 +25,7 @@ func main() {
 	// been manually altered in some way and need to be restored to
 	// a known state.
 	kingpin.Version(version.VERSION)
-	_, opts := flags.ParseWithConsulOptions()
+	_, opts, _ := flags.ParseWithConsulOptions()
 
 	client := kp.NewConsulClient(opts)
 	store := kp.NewConsulStore(client)

--- a/pkg/kp/dsstore/consul_store.go
+++ b/pkg/kp/dsstore/consul_store.go
@@ -14,7 +14,6 @@ import (
 	"github.com/square/p2/pkg/ds/fields"
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/kp/consulutil"
-	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/types"
@@ -29,10 +28,9 @@ type consulKV interface {
 }
 
 type consulStore struct {
-	applicator labels.Applicator
-	kv         consulKV
-	logger     logging.Logger
-	retries    int
+	kv      consulKV
+	logger  logging.Logger
+	retries int
 }
 
 // TODO: combine with similar CASError type in pkg/labels
@@ -47,10 +45,9 @@ var _ Store = &consulStore{}
 
 func NewConsul(client consulutil.ConsulClient, retries int, logger *logging.Logger) Store {
 	return &consulStore{
-		retries:    retries,
-		applicator: labels.NewConsulApplicator(client, retries),
-		kv:         client.KV(),
-		logger:     *logger,
+		retries: retries,
+		kv:      client.KV(),
+		logger:  *logger,
 	}
 }
 

--- a/pkg/kp/dsstore/consul_store_test.go
+++ b/pkg/kp/dsstore/consul_store_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/anthonybishopric/gotcha"
 	ds_fields "github.com/square/p2/pkg/ds/fields"
 	"github.com/square/p2/pkg/kp/consulutil"
-	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/manifest"
 	pc_fields "github.com/square/p2/pkg/pc/fields"
@@ -620,9 +619,8 @@ func TestWatchAll(t *testing.T) {
 
 func consulStoreWithFakeKV() *consulStore {
 	return &consulStore{
-		kv:         consulutil.NewFakeClient().KV(),
-		applicator: labels.NewFakeApplicator(),
-		logger:     logging.DefaultLogger,
-		retries:    0,
+		kv:      consulutil.NewFakeClient().KV(),
+		logger:  logging.DefaultLogger,
+		retries: 0,
 	}
 }

--- a/pkg/kp/pcstore/consul_store_test.go
+++ b/pkg/kp/pcstore/consul_store_test.go
@@ -185,7 +185,7 @@ func TestLabelsOnCreate(t *testing.T) {
 		t.Fatalf("Unable to create pod cluster: %s", err)
 	}
 
-	matches, err := store.applicator.GetMatches(selector, labels.PC, false)
+	matches, err := store.labeler.GetMatches(selector, labels.PC, false)
 	if err != nil {
 		t.Fatalf("Unable to check for label match on new pod cluster: %s", err)
 	}
@@ -313,7 +313,7 @@ func TestDelete(t *testing.T) {
 		t.Errorf("The error should have been a pocstore.IsNotExist but was '%s'", err)
 	}
 
-	labels, err := store.applicator.GetLabels(labels.PC, pc.ID.String())
+	labels, err := store.labeler.GetLabels(labels.PC, pc.ID.String())
 	if err != nil {
 		t.Fatalf("Got error when trying to confirm label deletion: %s", err)
 	}
@@ -599,8 +599,8 @@ func TestConcreteSyncer(t *testing.T) {
 	store := consulStoreWithFakeKV()
 	store.logger.Logger.Level = logrus.DebugLevel
 
-	store.applicator.SetLabel(labels.POD, "1234-123-123-1234", "color", "red")
-	store.applicator.SetLabel(labels.POD, "abcd-abc-abc-abcd", "color", "blue")
+	store.labeler.SetLabel(labels.POD, "1234-123-123-1234", "color", "red")
+	store.labeler.SetLabel(labels.POD, "abcd-abc-abc-abcd", "color", "blue")
 
 	syncer := &fakeSyncer{
 		[]fields.ID{},
@@ -713,8 +713,8 @@ func TestConcreteSyncerWithPrevious(t *testing.T) {
 	store := consulStoreWithFakeKV()
 	store.logger.Logger.Level = logrus.DebugLevel
 
-	store.applicator.SetLabel(labels.POD, "1234-123-123-1234", "color", "red")
-	store.applicator.SetLabel(labels.POD, "abcd-abc-abc-abcd", "color", "blue")
+	store.labeler.SetLabel(labels.POD, "1234-123-123-1234", "color", "red")
+	store.labeler.SetLabel(labels.POD, "abcd-abc-abc-abcd", "color", "blue")
 
 	syncer := &fakeSyncer{
 		[]fields.ID{},
@@ -1016,10 +1016,12 @@ func TestWatchAndSync(t *testing.T) {
 }
 
 func consulStoreWithFakeKV() *consulStore {
+	applicator := labels.NewFakeApplicator()
 	return &consulStore{
-		kv:         consulutil.NewFakeClient().KV(),
-		applicator: labels.NewFakeApplicator(),
-		logger:     logging.DefaultLogger,
+		kv:      consulutil.NewFakeClient().KV(),
+		labeler: applicator,
+		watcher: applicator,
+		logger:  logging.DefaultLogger,
 	}
 }
 

--- a/pkg/kp/rcstore/consul_store_test.go
+++ b/pkg/kp/rcstore/consul_store_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/square/p2/pkg/kp/consulutil"
+	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/rc/fields"
 
@@ -314,7 +315,7 @@ type LockInfoTestCase struct {
 
 func TestPublishLatestRCsWithLockInfoNoLocks(t *testing.T) {
 	client := consulutil.NewFakeClient()
-	rcstore := NewConsul(client, 1)
+	rcstore := NewConsul(client, labels.NewFakeApplicator(), 1)
 
 	inCh := make(chan []fields.RC)
 	defer close(inCh)
@@ -377,7 +378,7 @@ func TestPublishLatestRCsWithLockInfoNoLocks(t *testing.T) {
 func TestPublishLatestRCsWithLockInfoWithLocks(t *testing.T) {
 	client := consulutil.NewFakeClient()
 	fakeKV := client.KV()
-	rcstore := NewConsul(client, 1)
+	rcstore := NewConsul(client, labels.NewFakeApplicator(), 1)
 
 	inCh := make(chan []fields.RC)
 	defer close(inCh)

--- a/pkg/kp/rollstore/consul_store_test.go
+++ b/pkg/kp/rollstore/consul_store_test.go
@@ -25,7 +25,7 @@ const (
 )
 
 func TestNewConsul(t *testing.T) {
-	store := NewConsul(kp.NewConsulClient(kp.Options{}), nil)
+	store := NewConsul(kp.NewConsulClient(kp.Options{}), labels.NewFakeApplicator(), nil)
 	rollstore := store.(consulStore)
 	if rollstore.kv == nil {
 		t.Fatal("kv should not be nil for constructed rollstore")


### PR DESCRIPTION
This reduces the number of hardcoded instantiations of
`labels.NewConsulApplicator` in favor of injected labeler
interfaces that are constrained to the needs of the given client.

It also allows all CLIs to use HTTP applicators as a default option
in `kv.ParseWithConsulOptions`.