### PR TITLE
kp: HealthManager waits for session termination

### DIFF
--- a/pkg/kp/healthmanager_test.go
+++ b/pkg/kp/healthmanager_test.go
@@ -62,6 +62,7 @@ func TestHealthUpdate(t *testing.T) {
 	manager := f.Store.NewHealthManager("node", logging.TestLogger())
 	defer manager.Close()
 	updater := manager.NewUpdater("svc", "svc")
+	defer updater.Close()
 	waiter := f.NewKeyWaiter(hKey)
 
 	// Count how many changes to the health value there are

--- a/pkg/watch/health.go
+++ b/pkg/watch/health.go
@@ -108,8 +108,8 @@ func MonitorPodHealth(config *preparer.PreparerConfig, logger *logging.Logger, s
 			for _, pod := range pods {
 				pod.shutdownCh <- true
 			}
-			healthManager.Close()
 			close(watchQuitCh)
+			healthManager.Close()
 			return
 		}
 	}


### PR DESCRIPTION
When shutting down a consulHealthManager, its Close method will now wait for
its Consul session to be destroyed. This new behavior makes it more likely that
a clean restart of p2-preparer will be able to immediately write health values.
Otherwise, the new p2-preparer will have to wait for its previous session to
expire.