### PR TITLE
Make restart policy a per-launchable setting instead of per-pod.

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -34,7 +34,7 @@ type Launchable struct {
 	CgroupConfigName string                     // The string in PLATFORM_CONFIG to pass to p2-exec
 	CgroupName       string                     // The name of the cgroup to run this launchable in
 	RestartTimeout   time.Duration              // How long to wait when restarting the services in this launchable.
-	RestartPolicy    runit.RestartPolicy        // Dictates whether the launchable should be automatically restarted upon exit.
+	RestartPolicy_   runit.RestartPolicy        // Dictates whether the launchable should be automatically restarted upon exit.
 	SuppliedEnvVars  map[string]string          // A map of user-supplied environment variables to be exported for this launchable
 	Location         *url.URL                   // URL to download the artifact from
 	VerificationData auth.VerificationData      // Paths to files used to verify the artifact
@@ -195,7 +195,7 @@ func (hl *Launchable) start(serviceBuilder *runit.ServiceBuilder, sv runit.SV) e
 
 	for _, executable := range executables {
 		var err error
-		if hl.RestartPolicy == runit.RestartPolicyAlways {
+		if hl.RestartPolicy_ == runit.RestartPolicyAlways {
 			_, err = sv.Restart(&executable.Service, hl.RestartTimeout)
 		} else {
 			_, err = sv.Once(&executable.Service)
@@ -390,4 +390,8 @@ func (hl *Launchable) InstallDir() string {
 
 func (hl *Launchable) EnvVars() map[string]string {
 	return hl.SuppliedEnvVars
+}
+
+func (hl *Launchable) RestartPolicy() runit.RestartPolicy {
+	return hl.RestartPolicy_
 }

--- a/pkg/hoist/hoist_launchable_test.go
+++ b/pkg/hoist/hoist_launchable_test.go
@@ -392,7 +392,7 @@ func TestOnceIfRestartNever(t *testing.T) {
 
 	// If the launchable isn't intended to be restarted, the launchable
 	// should launch using 'sv once' instead of 'sv restart'
-	hl.RestartPolicy = runit.RestartPolicyNever
+	hl.RestartPolicy_ = runit.RestartPolicyNever
 
 	sv := runit.NewRecordingSV()
 	err := hl.Launch(sb, sv)
@@ -409,7 +409,7 @@ func TestRestartIfRestartAlways(t *testing.T) {
 
 	// If the launchable is intended to be restarted, the launchable
 	// should launch using 'sv restart'
-	hl.RestartPolicy = runit.RestartPolicyAlways
+	hl.RestartPolicy_ = runit.RestartPolicyAlways
 
 	sv := runit.NewRecordingSV()
 	err := hl.Launch(sb, sv)
@@ -422,7 +422,7 @@ func TestRestartServiceAndLogAgent(t *testing.T) {
 	defer CleanupFakeLaunchable(hl, sb)
 	sv := runit.NewRecordingSV()
 
-	hl.RestartPolicy = runit.RestartPolicyAlways
+	hl.RestartPolicy_ = runit.RestartPolicyAlways
 	hl.start(sb, sv)
 
 	commands := sv.(*runit.RecordingSV).Commands

--- a/pkg/launch/launchable.go
+++ b/pkg/launch/launchable.go
@@ -37,6 +37,11 @@ type LaunchableStanza struct {
 	CgroupConfig            cgroups.Config    `yaml:"cgroup,omitempty"`
 	Env                     map[string]string `yaml:"env,omitempty"`
 
+	// Indicates whether the processes started for the launchable should be
+	// restarted when they terminate.  When unspecified, the default is
+	// "always".
+	RestartPolicy_ runit.RestartPolicy `yaml:"restart_policy,omitempty"`
+
 	// Specifies which files or directories (relative to launchable root)
 	// should be launched under runit. Only launchables of type "hoist"
 	// make use of this field, and if empty, a default of ["bin/launch"]
@@ -59,6 +64,14 @@ func (l LaunchableStanza) LaunchableVersion() (LaunchableVersionID, error) {
 	}
 
 	return versionFromLocation(l.Location)
+}
+
+func (l LaunchableStanza) RestartPolicy() runit.RestartPolicy {
+	if l.RestartPolicy_ == "" {
+		return runit.DefaultRestartPolicy
+	}
+
+	return l.RestartPolicy_
 }
 
 // Uses the assumption that all locations have a Path component ending in
@@ -140,6 +153,8 @@ type Launchable interface {
 
 	// Env vars that will be exported to the launchable for its launch script and other hooks.
 	EnvVars() map[string]string
+
+	RestartPolicy() runit.RestartPolicy
 }
 
 // Executable describes a command and its arguments that should be executed to start a

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -15,7 +15,6 @@ import (
 	"path"
 
 	"github.com/square/p2/pkg/launch"
-	"github.com/square/p2/pkg/runit"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/uri"
 	"github.com/square/p2/pkg/util"
@@ -39,7 +38,6 @@ type Builder interface {
 	SetStatusPath(statusPath string)
 	SetStatusPort(port int)
 	SetLaunchables(launchableStanzas map[launch.LaunchableID]launch.LaunchableStanza)
-	SetRestartPolicy(runit.RestartPolicy)
 }
 
 var _ Builder = builder{}
@@ -75,7 +73,6 @@ type Manifest interface {
 	GetStatusLocalhostOnly() bool
 	Marshal() ([]byte, error)
 	SignatureData() (plaintext, signature []byte)
-	GetRestartPolicy() runit.RestartPolicy
 
 	GetBuilder() Builder
 }
@@ -91,7 +88,6 @@ type manifest struct {
 	StatusPort        int                                             `yaml:"status_port,omitempty"`
 	StatusHTTP        bool                                            `yaml:"status_http,omitempty"`
 	Status            StatusStanza                                    `yaml:"status,omitempty"`
-	RestartPolicy     runit.RestartPolicy                             `yaml:"restart_policy,omitempty"`
 
 	// Used to track the original bytes so that we don't reorder them when
 	// doing a yaml.Unmarshal and a yaml.Marshal in succession
@@ -127,10 +123,6 @@ func (manifest *manifest) GetLaunchableStanzas() map[launch.LaunchableID]launch.
 
 func (manifest *manifest) SetLaunchables(launchableStanzas map[launch.LaunchableID]launch.LaunchableStanza) {
 	manifest.LaunchableStanzas = launchableStanzas
-}
-
-func (manifest *manifest) SetRestartPolicy(restartPolicy runit.RestartPolicy) {
-	manifest.RestartPolicy = restartPolicy
 }
 
 func (manifest *manifest) GetConfig() map[interface{}]interface{} {
@@ -398,13 +390,6 @@ func (m manifest) SignatureData() (plaintext, signature []byte) {
 		return nil, nil
 	}
 	return m.plaintext, m.signature
-}
-
-func (m manifest) GetRestartPolicy() runit.RestartPolicy {
-	if m.RestartPolicy == "" {
-		return runit.DefaultRestartPolicy
-	}
-	return m.RestartPolicy
 }
 
 // ValidManifest checks the internal consistency of a manifest. Returns an error if the

--- a/pkg/opencontainer/containers.go
+++ b/pkg/opencontainer/containers.go
@@ -44,7 +44,7 @@ type Launchable struct {
 	RootDir         string              // The root directory of the launchable, containing N:N>=1 installs.
 	P2Exec          string              // The path to p2-exec
 	RestartTimeout  time.Duration       // How long to wait when restarting the services in this launchable.
-	RestartPolicy   runit.RestartPolicy // Dictates whether the container should be automatically restarted upon exit.
+	RestartPolicy_  runit.RestartPolicy // Dictates whether the container should be automatically restarted upon exit.
 	CgroupConfig    cgroups.Config      // Cgroup parameters to use with p2-exec
 	SuppliedEnvVars map[string]string   // User-supplied env variables
 
@@ -247,7 +247,7 @@ func (l *Launchable) start(serviceBuilder *runit.ServiceBuilder, sv runit.SV) er
 
 	for _, executable := range executables {
 		var err error
-		if l.RestartPolicy == runit.RestartPolicyAlways {
+		if l.RestartPolicy_ == runit.RestartPolicyAlways {
 			_, err = sv.Restart(&executable.Service, l.RestartTimeout)
 		} else {
 			_, err = sv.Once(&executable.Service)
@@ -307,4 +307,8 @@ func (l *Launchable) Stop(serviceBuilder *runit.ServiceBuilder, sv runit.SV) err
 func (l *Launchable) Prune(max size.ByteCount) error {
 	// No-op for now
 	return nil
+}
+
+func (l *Launchable) RestartPolicy() runit.RestartPolicy {
+	return l.RestartPolicy_
 }

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -56,7 +56,7 @@ func TestGetLaunchable(t *testing.T) {
 	pod := getTestPod()
 	Assert(t).AreNotEqual(0, len(launchableStanzas), "Expected there to be at least one launchable stanza in the test manifest")
 	for _, stanza := range launchableStanzas {
-		l, _ := pod.getLaunchable(stanza, "foouser", runit.RestartPolicyAlways)
+		l, _ := pod.getLaunchable(stanza, "foouser")
 		launchable := l.(hoist.LaunchAdapter).Launchable
 		if launchable.Id != "app" {
 			t.Errorf("Launchable Id did not have expected value: wanted '%s' was '%s'", "app", launchable.Id)
@@ -69,7 +69,7 @@ func TestGetLaunchable(t *testing.T) {
 		Assert(t).AreEqual("hello__app", launchable.ServiceId, "Launchable ServiceId did not have expected value")
 		Assert(t).AreEqual("foouser", launchable.RunAs, "Launchable run as did not have expected username")
 		Assert(t).IsTrue(launchable.ExecNoLimit, "GetLaunchable() should always set ExecNoLimit to true for hoist launchables")
-		Assert(t).AreEqual(launchable.RestartPolicy, runit.RestartPolicyAlways, "Default RestartPolicy for a launchable should be 'always'")
+		Assert(t).AreEqual(launchable.RestartPolicy(), runit.RestartPolicyAlways, "Default RestartPolicy for a launchable should be 'always'")
 	}
 }
 
@@ -80,7 +80,7 @@ func TestGetLaunchableNoVersion(t *testing.T) {
 		LaunchableType: "hoist",
 	}
 	pod := getTestPod()
-	l, _ := pod.getLaunchable(launchableStanza, "foouser", runit.RestartPolicyAlways)
+	l, _ := pod.getLaunchable(launchableStanza, "foouser")
 	launchable := l.(hoist.LaunchAdapter).Launchable
 
 	if launchable.Id != "somelaunchable" {
@@ -93,7 +93,7 @@ func TestGetLaunchableNoVersion(t *testing.T) {
 	Assert(t).AreEqual("hello__somelaunchable", launchable.ServiceId, "Launchable ServiceId did not have expected value")
 	Assert(t).AreEqual("foouser", launchable.RunAs, "Launchable run as did not have expected username")
 	Assert(t).IsTrue(launchable.ExecNoLimit, "GetLaunchable() should always set ExecNoLimit to true for hoist launchables")
-	Assert(t).AreEqual(launchable.RestartPolicy, runit.RestartPolicyAlways, "Default RestartPolicy for a launchable should be 'always'")
+	Assert(t).AreEqual(launchable.RestartPolicy(), runit.RestartPolicyAlways, "Default RestartPolicy for a launchable should be 'always'")
 }
 
 func TestPodCanWriteEnvFile(t *testing.T) {
@@ -148,7 +148,7 @@ config:
 
 	launchables := make([]launch.Launchable, 0)
 	for _, stanza := range manifest.GetLaunchableStanzas() {
-		launchable, err := pod.getLaunchable(stanza, manifest.RunAsUser(), manifest.GetRestartPolicy())
+		launchable, err := pod.getLaunchable(stanza, manifest.RunAsUser())
 		Assert(t).IsNil(err, "There shouldn't have been an error getting launchable")
 		launchables = append(launchables, launchable)
 	}
@@ -313,7 +313,6 @@ func TestBuildRunitServices(t *testing.T) {
 	outFilePath := filepath.Join(serviceBuilder.ConfigRoot, "testPod.yaml")
 
 	testManifest := manifest.NewBuilder()
-	testManifest.SetRestartPolicy(runit.RestartPolicyAlways)
 	testLaunchable := hl.If()
 	pod.buildRunitServices([]launch.Launchable{testLaunchable}, testManifest.GetManifest())
 


### PR DESCRIPTION
This will allow greater flexibility in the way pods are composed and
run. For example, the scheduled pod may have an entry point that should
only run once, such as a job like a database backfill. There may be
supporting launchables that need to be up to support the job, e.g. an
instance of stunnel which should be restarted if it crashes. However,
the job should not be restarted.