### PR TITLE
Remove launchable_id key from launchable stanza

### DIFF
--- a/bin/p2-bin2pod/main.go
+++ b/bin/p2-bin2pod/main.go
@@ -80,7 +80,6 @@ func main() {
 	manifestBuilder.SetID(podID())
 
 	stanza := launch.LaunchableStanza{}
-	stanza.LaunchableId = launch.LaunchableID(podID())
 	stanza.LaunchableType = "hoist"
 
 	workingDir := activeDir()

--- a/integration/single-node-slug-deploy/check.go
+++ b/integration/single-node-slug-deploy/check.go
@@ -345,7 +345,6 @@ func getConsulManifest(dir string) (string, error) {
 	builder.SetID("consul")
 	stanzas := map[launch.LaunchableID]launch.LaunchableStanza{
 		"consul": {
-			LaunchableId:   "consul",
 			LaunchableType: "hoist",
 			Location:       consulTar,
 		},
@@ -424,7 +423,6 @@ func writeHelloManifest(dir string, manifestName string, port int) (string, erro
 	builder.SetStatusHTTP(true)
 	stanzas := map[launch.LaunchableID]launch.LaunchableStanza{
 		"hello": {
-			LaunchableId:   "hello",
 			LaunchableType: "hoist",
 			Location:       hello,
 		},

--- a/pkg/launch/launchable.go
+++ b/pkg/launch/launchable.go
@@ -30,7 +30,6 @@ type LaunchableVersion struct {
 
 type LaunchableStanza struct {
 	LaunchableType          string            `yaml:"launchable_type"`
-	LaunchableId            LaunchableID      `yaml:"launchable_id"`
 	DigestLocation          string            `yaml:"digest_location,omitempty"`
 	DigestSignatureLocation string            `yaml:"digest_signature_location,omitempty"`
 	RestartTimeout          string            `yaml:"restart_timeout,omitempty"`

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -331,8 +331,8 @@ func (manifest *manifest) WriteConfig(out io.Writer) error {
 
 func (manifest *manifest) WritePlatformConfig(out io.Writer) error {
 	platConf := make(map[launch.LaunchableID]interface{})
-	for _, stanza := range manifest.LaunchableStanzas {
-		platConf[stanza.LaunchableId] = map[launch.LaunchableID]interface{}{
+	for launchableID, stanza := range manifest.LaunchableStanzas {
+		platConf[launchableID] = map[launch.LaunchableID]interface{}{
 			"cgroup": stanza.CgroupConfig,
 		}
 	}
@@ -398,16 +398,14 @@ func ValidManifest(m Manifest) error {
 	if m.ID() == "" {
 		return fmt.Errorf("manifest must contain an 'id'")
 	}
-	for key, stanza := range m.GetLaunchableStanzas() {
+	for launchableID, stanza := range m.GetLaunchableStanzas() {
 		switch {
 		case stanza.LaunchableType == "":
-			return fmt.Errorf("'%s': launchable must contain a 'launchable_type'", key)
-		case stanza.LaunchableId == "":
-			return fmt.Errorf("'%s': launchable must contain a 'launchable_id'", key)
+			return fmt.Errorf("'%s': launchable must contain a 'launchable_type'", launchableID)
 		case stanza.Location == "" && stanza.Version.ID == "":
-			return fmt.Errorf("'%s': launchable must contain a 'location' or 'version'", key)
+			return fmt.Errorf("'%s': launchable must contain a 'location' or 'version'", launchableID)
 		case stanza.Location != "" && stanza.Version.ID != "":
-			return fmt.Errorf("'%s': launchable must not contain both 'location' and 'version'", key)
+			return fmt.Errorf("'%s': launchable must not contain both 'location' and 'version'", launchableID)
 		}
 	}
 	return nil

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -25,10 +25,6 @@ func TestPodManifestCanBeRead(t *testing.T) {
 	Assert(t).AreEqual(manifest.GetLaunchableStanzas()["app"].Location, "hoisted-hello_def456.tar.gz", "Location read from manifest didn't have expected value")
 	Assert(t).AreEqual("hoist", manifest.GetLaunchableStanzas()["app"].LaunchableType, "LaunchableType read from manifest didn't have expected value")
 
-	if manifest.GetLaunchableStanzas()["app"].LaunchableId != "app" {
-		t.Errorf("Expected launchable id to be '%s', but was '%s'", "app", manifest.GetLaunchableStanzas()["app"].LaunchableId)
-	}
-
 	Assert(t).AreEqual("staging", manifest.GetConfig()["ENVIRONMENT"], "Should have read the ENVIRONMENT from the config stanza")
 	hoptoad := manifest.GetConfig()["hoptoad"].(map[interface{}]interface{})
 	Assert(t).IsTrue(len(hoptoad) == 3, "Should have read the hoptoad value from the config stanza")
@@ -42,7 +38,6 @@ func testPod() string {
 launchables:
   my-app:
     launchable_type: hoist
-    launchable_id: web
     cgroup:
       cpus: 4
       memory: 1073741824
@@ -59,7 +54,6 @@ func testPodOldStatus() string {
 launchables:
   my-app:
     launchable_type: hoist
-    launchable_id: web
     cgroup:
       cpus: 4
       memory: 1073741824
@@ -79,7 +73,6 @@ id: thepod
 launchables:
   my-app:
     launchable_type: hoist
-    launchable_id: web
     location: https://localhost:4444/foo/bar/baz.tar.gz
 status_port: 8000
 config:
@@ -103,7 +96,6 @@ func TestPodManifestCanBeWritten(t *testing.T) {
 	launchables := map[launch.LaunchableID]launch.LaunchableStanza{
 		"my-app": {
 			LaunchableType: "hoist",
-			LaunchableId:   "web",
 			Location:       "https://localhost:4444/foo/bar/baz.tar.gz",
 			CgroupConfig: cgroups.Config{
 				CPUs:   4,
@@ -145,11 +137,10 @@ func TestPodManifestCanReportItsSHA(t *testing.T) {
 	Assert(t).IsNil(err, "should not have erred when building manifest")
 	val, err := manifest.SHA()
 	Assert(t).IsNil(err, "should not have erred when getting SHA")
-	Assert(t).AreEqual(
-		"92d47f397fbf6679bb7af7e68692df95de811b2993199c2626570984e5c5de3e",
-		val,
-		"SHA mismatched expectations - if this was expected, change the assertion value",
-	)
+	expected := "f7fdad6e2362c9345a83196701dafb989fa8229b8d671642976cb35b5166c6f0"
+	if val != expected {
+		t.Errorf("Expected manifest sha to be %s but was %s. If this was expected, change the assertion value", expected, val)
+	}
 }
 
 func TestPodManifestLaunchablesCGroups(t *testing.T) {
@@ -247,7 +238,6 @@ func TestByteOrderPreserved(t *testing.T) {
 launchables:
   my-app:
     launchable_type: hoist
-    launchable_id: web
     location: https://localhost:4444/foo/bar/baz.tar.gz
 status_port: 8000
 config:
@@ -289,7 +279,6 @@ func TestBuilderHasOriginalFields(t *testing.T) {
 launchables:
   my-app:
     launchable_type: hoist
-    launchable_id: web
     location: https://localhost:4444/foo/bar/baz.tar.gz
 status_port: 8000
 config:

--- a/pkg/preparer/listener_test.go
+++ b/pkg/preparer/listener_test.go
@@ -74,7 +74,6 @@ func testHookListener(t *testing.T) (HookListener, string, <-chan struct{}) {
 		"create": {
 			Location:       util.From(runtime.Caller(0)).ExpandPath("testdata/hoisted-hello_def456.tar.gz"),
 			LaunchableType: "hoist",
-			LaunchableId:   "create",
 		},
 	})
 	podManifest := builder.GetManifest()


### PR DESCRIPTION
Currently P2 has two notions of launchable_id, one being the key in the
launchable stanza map, and the other being the value under
launchable_id: in the launchable stanza itself. Typically these are the
same and they cause confusion to our users.

Since maps always need keys, it makes sense to remove the inner
launchable_id key from launchable stanza and use the map key instead.