### PR TITLE
Move POD_ID constant from pkg/preparer to pkg/constants

### DIFF
--- a/bin/p2-launch/main.go
+++ b/bin/p2-launch/main.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/square/p2/pkg/artifact"
 	"github.com/square/p2/pkg/auth"
+	"github.com/square/p2/pkg/constants"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/osversion"
 	"github.com/square/p2/pkg/pods"
-	"github.com/square/p2/pkg/preparer"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/uri"
 	"github.com/square/p2/pkg/util"
@@ -98,7 +98,7 @@ func authorize(manifest manifest.Manifest) error {
 		policy, err = auth.NewFileKeyringPolicy(
 			*keyring,
 			map[types.PodID][]string{
-				preparer.POD_ID: *allowedUsers,
+				constants.PreparerPodID: *allowedUsers,
 			},
 		)
 		if err != nil {
@@ -115,8 +115,8 @@ func authorize(manifest manifest.Manifest) error {
 		policy, err = auth.NewUserPolicy(
 			*keyring,
 			*deployPolicy,
-			preparer.POD_ID,
-			string(preparer.POD_ID),
+			constants.PreparerPodID,
+			constants.PreparerPodID.String(),
 		)
 		if err != nil {
 			return err

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,9 @@
+package constants
+
+import (
+	"github.com/square/p2/pkg/types"
+)
+
+const (
+	PreparerPodID = types.PodID("p2-preparer")
+)

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/square/p2/pkg/artifact"
 	"github.com/square/p2/pkg/auth"
+	"github.com/square/p2/pkg/constants"
 	"github.com/square/p2/pkg/hooks"
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/kp/statusstore"
@@ -22,7 +23,6 @@ import (
 // The Pod ID of the preparer.
 // Used because the preparer special-cases itself in a few places.
 const (
-	POD_ID             = types.PodID("p2-preparer")
 	minimumBackoffTime = 1 * time.Second
 )
 
@@ -123,7 +123,7 @@ func (p *Preparer) WatchForPodManifestsForNode(quitAndAck chan struct{}) {
 			} else {
 				// if the preparer's own ID is missing from the intent set, we
 				// assume it was damaged and discard it
-				if !checkResultsForID(intentResults, POD_ID) {
+				if !checkResultsForID(intentResults, constants.PreparerPodID) {
 					p.Logger.NoFields().Errorln("Intent results set did not contain p2-preparer pod ID, consul data may be corrupted")
 				} else {
 					pairs := p.ZipResultSets(intentResults, realityResults)
@@ -230,7 +230,7 @@ func (p *Preparer) handlePods(podChan <-chan ManifestPair, quit <-chan struct{})
 				}
 
 				// TODO better solution: force the preparer to have a 0s default timeout, prevent KILLs
-				if pod.Id == POD_ID {
+				if pod.Id == constants.PreparerPodID {
 					pod.DefaultTimeout = time.Duration(0)
 				}
 

--- a/pkg/preparer/orchestrate_test.go
+++ b/pkg/preparer/orchestrate_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/anthonybishopric/gotcha"
 	"github.com/square/p2/pkg/artifact"
 	"github.com/square/p2/pkg/auth"
+	"github.com/square/p2/pkg/constants"
 	"github.com/square/p2/pkg/hooks"
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/logging"
@@ -289,7 +290,7 @@ func TestPreparerFailsIfInstallFails(t *testing.T) {
 
 func TestPreparerWillLaunchPreparerAsRoot(t *testing.T) {
 	builder := manifest.NewBuilder()
-	builder.SetID(POD_ID)
+	builder.SetID(constants.PreparerPodID)
 	builder.SetRunAsUser("root")
 	illegalManifest := builder.GetManifest()
 	newPair := ManifestPair{
@@ -389,7 +390,7 @@ func TestPreparerWillAcceptSignatureFromKeyring(t *testing.T) {
 
 func TestPreparerWillAcceptSignatureForPreparerWithoutAuthorizedDeployers(t *testing.T) {
 	manifest, fakeSigner := testSignedManifest(t, func(b manifest.Builder, _ *openpgp.Entity) {
-		b.SetID(POD_ID)
+		b.SetID(constants.PreparerPodID)
 	})
 
 	p, _, fakePodRoot := testPreparer(t, &FakeStore{})
@@ -405,7 +406,7 @@ func TestPreparerWillAcceptSignatureForPreparerWithoutAuthorizedDeployers(t *tes
 
 func TestPreparerWillRejectUnauthorizedSignatureForPreparer(t *testing.T) {
 	manifest, fakeSigner := testSignedManifest(t, func(b manifest.Builder, _ *openpgp.Entity) {
-		b.SetID(POD_ID)
+		b.SetID(constants.PreparerPodID)
 	})
 
 	p, _, fakePodRoot := testPreparer(t, &FakeStore{})
@@ -413,7 +414,7 @@ func TestPreparerWillRejectUnauthorizedSignatureForPreparer(t *testing.T) {
 	defer os.RemoveAll(fakePodRoot)
 	p.authPolicy = auth.FixedKeyringPolicy{
 		Keyring:             openpgp.EntityList{fakeSigner},
-		AuthorizedDeployers: map[types.PodID][]string{POD_ID: {"nobodylol"}},
+		AuthorizedDeployers: map[types.PodID][]string{constants.PreparerPodID: {"nobodylol"}},
 	}
 
 	Assert(t).IsFalse(
@@ -425,7 +426,7 @@ func TestPreparerWillRejectUnauthorizedSignatureForPreparer(t *testing.T) {
 func TestPreparerWillAcceptAuthorizedSignatureForPreparer(t *testing.T) {
 	sig := ""
 	manifest, fakeSigner := testSignedManifest(t, func(b manifest.Builder, e *openpgp.Entity) {
-		b.SetID(POD_ID)
+		b.SetID(constants.PreparerPodID)
 		sig = fmt.Sprintf("%X", e.PrimaryKey.Fingerprint)
 	})
 
@@ -434,7 +435,7 @@ func TestPreparerWillAcceptAuthorizedSignatureForPreparer(t *testing.T) {
 	defer os.RemoveAll(fakePodRoot)
 	p.authPolicy = auth.FixedKeyringPolicy{
 		Keyring:             openpgp.EntityList{fakeSigner},
-		AuthorizedDeployers: map[types.PodID][]string{POD_ID: {sig}},
+		AuthorizedDeployers: map[types.PodID][]string{constants.PreparerPodID: {sig}},
 	}
 
 	Assert(t).IsTrue(

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/square/p2/pkg/artifact"
 	"github.com/square/p2/pkg/auth"
+	"github.com/square/p2/pkg/constants"
 	"github.com/square/p2/pkg/hooks"
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/kp/consulutil"
@@ -437,7 +438,7 @@ func getDeployerAuth(preparerConfig *PreparerConfig) (auth.Policy, error) {
 		}
 		authPolicy, err = auth.NewFileKeyringPolicy(
 			authConfig.KeyringPath,
-			map[types.PodID][]string{POD_ID: authConfig.AuthorizedDeployers},
+			map[types.PodID][]string{constants.PreparerPodID: authConfig.AuthorizedDeployers},
 		)
 		if err != nil {
 			return nil, util.Errorf("error configuring keyring auth: %s", err)
@@ -457,8 +458,8 @@ func getDeployerAuth(preparerConfig *PreparerConfig) (auth.Policy, error) {
 		authPolicy, err = auth.NewUserPolicy(
 			userConfig.KeyringPath,
 			userConfig.DeployPolicyPath,
-			POD_ID,
-			string(POD_ID),
+			constants.PreparerPodID,
+			constants.PreparerPodID.String(),
 		)
 		if err != nil {
 			return nil, util.Errorf("error configuring user auth: %s", err)

--- a/pkg/replication/replicator.go
+++ b/pkg/replication/replicator.go
@@ -4,12 +4,12 @@ import (
 	"errors"
 	"time"
 
+	"github.com/square/p2/pkg/constants"
 	"github.com/square/p2/pkg/health"
 	"github.com/square/p2/pkg/health/checker"
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/manifest"
-	"github.com/square/p2/pkg/preparer"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
 )
@@ -202,9 +202,9 @@ func (r replicator) initializeReplicationWithCheck(
 // Checks that the preparer is running on every host being deployed to.
 func (r replicator) checkPreparers() error {
 	for _, host := range r.nodes {
-		_, _, err := r.store.Pod(kp.REALITY_TREE, host, preparer.POD_ID)
+		_, _, err := r.store.Pod(kp.REALITY_TREE, host, constants.PreparerPodID)
 		if err != nil {
-			return util.Errorf("Could not verify %v state on %q: %v", preparer.POD_ID, host, err)
+			return util.Errorf("Could not verify %v state on %q: %v", constants.PreparerPodID, host, err)
 		}
 	}
 	return nil

--- a/pkg/replication/replicator_test.go
+++ b/pkg/replication/replicator_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/square/p2/pkg/constants"
 	"github.com/square/p2/pkg/kp"
 	"github.com/square/p2/pkg/labels"
-	"github.com/square/p2/pkg/preparer"
 	"github.com/square/p2/pkg/rc"
 	"github.com/square/p2/pkg/types"
 )
@@ -57,7 +57,7 @@ func TestInitializeReplicationFailsIfNoPreparers(t *testing.T) {
 		t.Fatalf("Expected error due to preparer not existing in reality, but no error occurred")
 	}
 
-	matched, err := regexp.MatchString(fmt.Sprintf("verify %s state", preparer.POD_ID), testErr.Error())
+	matched, err := regexp.MatchString(fmt.Sprintf("verify %s state", constants.PreparerPodID), testErr.Error())
 	if err != nil {
 		t.Fatalf("Unable to compare error message to expected string")
 	}


### PR DESCRIPTION
Many other packages refer to this constant, but pkg/preparer has many
dependencies that are not necessary to import to other places. Notably,
libraries wishing to use this constant would be importing sqlite
libraries and maybe even need to vendor them.

Additionally, rename POD_ID to PreparerPodID.