### PR TITLE
Make the exit code reporter log at debug level

### DIFF
--- a/pkg/preparer/podprocess/reporter.go
+++ b/pkg/preparer/podprocess/reporter.go
@@ -354,7 +354,7 @@ func (r *Reporter) reportLatestExits() {
 			"finish_id":      finish.ID,
 			"exit_time":      finish.ExitTime,
 		})
-		subLogger.Infoln("Received process exit information")
+		subLogger.Debugln("Received process exit information")
 
 		if finish.PodUniqueKey == "" {
 			// Status is only written to consul for uuid pods
@@ -372,7 +372,7 @@ func (r *Reporter) reportLatestExits() {
 			return
 		}
 
-		subLogger.Infoln("Successfully recorded status")
+		subLogger.Debugln("Successfully recorded status")
 		lastID = finish.ID
 	}
 }


### PR DESCRIPTION
Generating log messages for every finish event written to the sqlite
database can be very chatty. This commit makes these messages debug
level.