### PR TITLE
Add configurable pause time between RC watches in RC farm.

### DIFF
--- a/bin/p2-rctl-server/main.go
+++ b/bin/p2-rctl-server/main.go
@@ -107,6 +107,7 @@ func main() {
 		logger,
 		klabels.Everything(),
 		alerter,
+		1*time.Second,
 	).Start(nil)
 	roll.NewFarm(
 		roll.UpdateFactory{

--- a/pkg/kp/rcstore/consul_store.go
+++ b/pkg/kp/rcstore/consul_store.go
@@ -214,13 +214,13 @@ type RCLockResult struct {
 // possible that lock information will be out of date as the list is processed.
 // However, a subsequent update will get the correct view of the world so the
 // behavior should be correct
-func (s *consulStore) WatchNewWithRCLockInfo(quit <-chan struct{}) (<-chan []RCLockResult, <-chan error) {
+func (s *consulStore) WatchNewWithRCLockInfo(quit <-chan struct{}, pauseTime time.Duration) (<-chan []RCLockResult, <-chan error) {
 	inCh := make(chan api.KVPairs)
 	lockInfoErrCh := make(chan error)
 	combinedErrCh := make(chan error)
 
 	rcCh, rcErrCh := publishLatestRCs(inCh, quit)
-	go consulutil.WatchPrefix(rcTree+"/", s.kv, inCh, quit, rcErrCh, 1*time.Second)
+	go consulutil.WatchPrefix(rcTree+"/", s.kv, inCh, quit, rcErrCh, pauseTime)
 
 	// Process RC updates and augment them with lock information
 	outCh, lockInfoErrCh := s.publishLatestRCsWithLockInfo(rcCh, quit)

--- a/pkg/kp/rcstore/fake_store.go
+++ b/pkg/kp/rcstore/fake_store.go
@@ -3,6 +3,7 @@ package rcstore
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"k8s.io/kubernetes/pkg/labels"
 
@@ -82,7 +83,7 @@ func (s *fakeStore) WatchNew(quit <-chan struct{}) (<-chan []fields.RC, <-chan e
 	return nil, nil
 }
 
-func (s *fakeStore) WatchNewWithRCLockInfo(quit <-chan struct{}) (<-chan []RCLockResult, <-chan error) {
+func (s *fakeStore) WatchNewWithRCLockInfo(quit <-chan struct{}, pauseTime time.Duration) (<-chan []RCLockResult, <-chan error) {
 	panic("not implemented")
 }
 

--- a/pkg/kp/rcstore/store.go
+++ b/pkg/kp/rcstore/store.go
@@ -2,6 +2,7 @@ package rcstore
 
 import (
 	"errors"
+	"time"
 
 	"k8s.io/kubernetes/pkg/labels"
 
@@ -34,7 +35,7 @@ type Store interface {
 	// Like WatchNew, but returns structures that also indicate which locks
 	// are held at the time the update came in. This can be used to reduce
 	// lock acquisition work required e.g. in the RC farm.
-	WatchNewWithRCLockInfo(quit <-chan struct{}) (<-chan []RCLockResult, <-chan error)
+	WatchNewWithRCLockInfo(quit <-chan struct{}, pauseTime time.Duration) (<-chan []RCLockResult, <-chan error)
 
 	// Set the desired replica count for the given RC to the given integer.
 	SetDesiredReplicas(fields.ID, int) error


### PR DESCRIPTION
The RC tree size can grow up to a few Mb in large deployments, which
means that running many instances of the RC farm results in a sizable
amount of bandwidth consumption.

This commit adds a configurable time.Duration to the RC farm which
causes it to pause in between watches on the entire RC tree. This trades
responsiveness to new replication controllers for a decrease in request
rate to the datastore (and thus a bandwidth reduction).

Individual RC watches are unaffected, so once an RC is noticed and
adopted by a farm, changes to replicas_desired will still be processed
very quickly.