### PR TITLE
Remove unused hook quit channel from p2-preparer entry point.

### DIFF
--- a/bin/p2-preparer/main.go
+++ b/bin/p2-preparer/main.go
@@ -62,8 +62,7 @@ func main() {
 	}).Infoln("Preparer started successfully")
 
 	quitMainUpdate := make(chan struct{})
-	quitHookUpdate := make(chan struct{})
-	quitChans := []chan struct{}{quitHookUpdate}
+	var quitChans []chan struct{}
 
 	// Install the latest hooks before any pods are processed
 	err = prep.InstallHooks()


### PR DESCRIPTION
P2-preparer waits for some channels to close before exiting after
receiving a SIGTERM. Commit 6d4e158e93a393b3e90f4b8fa5b39e9f9714f1e4
removed the goroutine for syncing hooks from consul, and therefore does
not close one of the channels being waited on, meaning the preparer had
to be SIGKILL'd. This PR remove the unused channel and allows the
preparer to exit after TERM.