### PR TITLE
use a serializable Nothing()

### DIFF
--- a/bin/p2-dsctl/main.go
+++ b/bin/p2-dsctl/main.go
@@ -116,10 +116,10 @@ func main() {
 		if *createEverywhere {
 			selectorString = klabels.Everything().String()
 		} else if selectorString == "" {
-			selectorString = klabels.Nothing().String()
+			selectorString = labels.Nothing().String()
 			log.Fatal("Explicit everything selector not allowed, please use the --everwhere flag")
 		}
-		selector, err := parseNodeSelectorWithPrompt(klabels.Nothing(), selectorString, applicator)
+		selector, err := parseNodeSelectorWithPrompt(labels.Nothing(), selectorString, applicator)
 		if err != nil {
 			log.Fatalf("Error occurred: %v", err)
 		}

--- a/pkg/labels/applicator.go
+++ b/pkg/labels/applicator.go
@@ -110,3 +110,14 @@ type Applicator interface {
 		quitCh <-chan struct{},
 	) <-chan *LabeledChanges
 }
+
+// Nothing returns a selector that cannot match any labels. It is different
+// from klabels.Nothing() in that it can be serialzed as a string and re-
+// parsed as a selector while being in the grammar for selectors.
+func Nothing() labels.Selector {
+	sel, err := labels.Parse("x=1,x=0")
+	if err != nil {
+		panic(err)
+	}
+	return sel
+}

--- a/pkg/labels/applicator_test.go
+++ b/pkg/labels/applicator_test.go
@@ -1,0 +1,31 @@
+package labels
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func TestNothingReallyMatchesNothing(t *testing.T) {
+	check := func(sel labels.Selector) {
+		if sel.Matches(labels.Set{}) {
+			t.Fatalf("Should not have matched the empty set: %v", sel.String())
+		}
+		if sel.Matches(labels.Set{"x": "1"}) {
+			t.Fatalf("Should not have matched x=1: %v", sel.String())
+		}
+		if sel.Matches(labels.Set{"x": "0"}) {
+			t.Fatalf("Should not have matched x=0: %v", sel.String())
+		}
+		if sel.Matches(labels.Set{"x": "2"}) {
+			t.Fatalf("Should not have matched x=2: %v", sel.String())
+		}
+	}
+	check(Nothing())
+	// test that it can be serialized
+	sel, err := labels.Parse(Nothing().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	check(sel)
+}


### PR DESCRIPTION
The Kubernetes labels package ships with helper `labels.Nothing()` that returns a selector that cannot match anything. Unfortunately, this helper selector is not serializable to and from strings - attempts to do `labels.Parse(labels.Nothing().String())` result in parse errors. 

This adds a helper to P2's labels package to create a selector that is serializable. 