### PR TITLE
artifact: Pass both pod ID and artifact name to discover endpoint

### DIFF
--- a/pkg/launch/launchable.go
+++ b/pkg/launch/launchable.go
@@ -15,6 +15,10 @@ import (
 
 const EntryPointEnvVar = "ENTRY_POINT"
 
+type ArtifactName string
+
+func (a ArtifactName) String() string { return string(a) }
+
 type LaunchableID string
 
 func (l LaunchableID) String() string { return string(l) }
@@ -24,8 +28,11 @@ type LaunchableVersionID string
 func (l LaunchableVersionID) String() string { return string(l) }
 
 type LaunchableVersion struct {
-	ID   LaunchableVersionID `yaml:"id"`
-	Tags map[string]string   `yaml:"tags,omitempty"`
+	// If present, overrides the artifact name to be used when discovering the artifact.
+	// If absent, the name used for discovery defaults to the launchable ID.
+	ArtifactOverride ArtifactName        `yaml:"artifact_name,omitempty"`
+	ID               LaunchableVersionID `yaml:"id"`
+	Tags             map[string]string   `yaml:"tags,omitempty"`
 }
 
 type LaunchableStanza struct {

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -418,7 +418,7 @@ func (pod *Pod) Install(manifest manifest.Manifest, verifier auth.ArtifactVerifi
 			continue
 		}
 
-		launchableURL, verificationData, err := artifactRegistry.LocationDataForLaunchable(launchableID, stanza)
+		launchableURL, verificationData, err := artifactRegistry.LocationDataForLaunchable(pod.Id, launchableID, stanza)
 		if err != nil {
 			pod.logLaunchableError(launchable.ServiceID(), err, "Unable to install launchable")
 			return err


### PR DESCRIPTION
Instead of always passing only the launchable ID, we need to allow the
manifest to specify an override for the launchable.
An artifact_name field is added to the version stanza of a launchable
stana for this purpose.

At the same time, we need to also pass the pod ID to the discover
endpoint (and for this there is no override), so that we can check
whether the artifact<->pod pair makes sense.

So now the pod ID is passed as the parameter in the URL, while the
launchable ID is passed as a query parameter.