### PR TITLE
Make p2-inspect able to understand launchable versions.

### DIFF
--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"github.com/square/p2/pkg/health"
+	"github.com/square/p2/pkg/launch"
 	"github.com/square/p2/pkg/store/consul"
 	"github.com/square/p2/pkg/types"
 )
@@ -14,14 +15,25 @@ const (
 	REALITY_SOURCE
 )
 
+type LaunchableVersion struct {
+	Location string                    `json:"location,omitempty"`
+	Version  *launch.LaunchableVersion `json:"version,omitempty"`
+}
+
 type NodePodStatus struct {
-	NodeName           types.NodeName     `json:"node,omitempty"`
-	PodId              types.PodID        `json:"pod,omitempty"`
-	IntentManifestSHA  string             `json:"intent_manifest_sha"`
-	RealityManifestSHA string             `json:"reality_manifest_sha"`
-	IntentLocations    []string           `json:"intent_locations"`
-	RealityLocations   []string           `json:"reality_locations"`
-	Health             health.HealthState `json:"health,omitempty"`
+	NodeName           types.NodeName                            `json:"node,omitempty"`
+	PodId              types.PodID                               `json:"pod,omitempty"`
+	IntentManifestSHA  string                                    `json:"intent_manifest_sha"`
+	RealityManifestSHA string                                    `json:"reality_manifest_sha"`
+	IntentVersions     map[launch.LaunchableID]LaunchableVersion `json:"intent_versions,omitempty"`
+	RealityVersions    map[launch.LaunchableID]LaunchableVersion `json:"reality_versions,omitempty"`
+	Health             health.HealthState                        `json:"health,omitempty"`
+
+	// These fields are kept for backwards compatibility with tools that
+	// parse the output of p2-inspect. intent_versions and reality_versions
+	// are preferred since those handle multiple versions of manifest syntax
+	IntentLocations  []string `json:"intent_locations"`
+	RealityLocations []string `json:"reality_locations"`
 }
 
 func AddKVPToMap(result consul.ManifestResult, source int, filterNode types.NodeName, filterPod types.PodID, statuses map[types.PodID]map[types.NodeName]NodePodStatus) error {
@@ -39,6 +51,8 @@ func AddKVPToMap(result consul.ManifestResult, source int, filterNode types.Node
 		statuses[podId] = make(map[types.NodeName]NodePodStatus)
 	}
 	old := statuses[podId][nodeName]
+	old.IntentVersions = make(map[launch.LaunchableID]LaunchableVersion)
+	old.RealityVersions = make(map[launch.LaunchableID]LaunchableVersion)
 
 	manifestSHA, err := result.Manifest.SHA()
 	if err != nil {
@@ -51,7 +65,16 @@ func AddKVPToMap(result consul.ManifestResult, source int, filterNode types.Node
 			return fmt.Errorf("Two intent manifests for node %s pod %s", nodeName, podId)
 		}
 		old.IntentManifestSHA = manifestSHA
-		for _, launchable := range result.Manifest.GetLaunchableStanzas() {
+		for launchableID, launchable := range result.Manifest.GetLaunchableStanzas() {
+			var version *launch.LaunchableVersion
+			if launchable.Version.ID != "" {
+				version = &launchable.Version
+			}
+
+			old.IntentVersions[launchableID] = LaunchableVersion{
+				Location: launchable.Location,
+				Version:  version,
+			}
 			old.IntentLocations = append(old.IntentLocations, launchable.Location)
 		}
 		sort.Strings(old.IntentLocations)
@@ -60,7 +83,16 @@ func AddKVPToMap(result consul.ManifestResult, source int, filterNode types.Node
 			return fmt.Errorf("Two reality manifests for node %s pod %s", nodeName, podId)
 		}
 		old.RealityManifestSHA = manifestSHA
-		for _, launchable := range result.Manifest.GetLaunchableStanzas() {
+		for launchableID, launchable := range result.Manifest.GetLaunchableStanzas() {
+			var version *launch.LaunchableVersion
+
+			if launchable.Version.ID != "" {
+				version = &launchable.Version
+			}
+			old.RealityVersions[launchableID] = LaunchableVersion{
+				Location: launchable.Location,
+				Version:  version,
+			}
 			old.RealityLocations = append(old.RealityLocations, launchable.Location)
 		}
 		sort.Strings(old.RealityLocations)

--- a/pkg/launch/launchable.go
+++ b/pkg/launch/launchable.go
@@ -30,9 +30,9 @@ func (l LaunchableVersionID) String() string { return string(l) }
 type LaunchableVersion struct {
 	// If present, overrides the artifact name to be used when discovering the artifact.
 	// If absent, the name used for discovery defaults to the launchable ID.
-	ArtifactOverride ArtifactName        `yaml:"artifact_name,omitempty"`
-	ID               LaunchableVersionID `yaml:"id"`
-	Tags             map[string]string   `yaml:"tags,omitempty"`
+	ArtifactOverride ArtifactName        `json:"artifact_name,omitempty" yaml:"artifact_name,omitempty"`
+	ID               LaunchableVersionID `json:"id" yaml:"id"`
+	Tags             map[string]string   `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 type LaunchableStanza struct {


### PR DESCRIPTION
Launchables are not required to specify a Location anymore, which
changes the way we want p2-inspect to show version information.