### PR TITLE
Add stack to recovered panic output in farms.

### DIFF
--- a/pkg/rc/farm.go
+++ b/pkg/rc/farm.go
@@ -1,6 +1,7 @@
 package rc
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -229,9 +230,15 @@ START_LOOP:
 					defer func() {
 						if r := recover(); r != nil {
 							err := util.Errorf("Caught panic in rc farm: %s", r)
+
+							stackErr, ok := err.(util.StackError)
+							msg := "Caught panic in rc farm"
+							if ok {
+								msg = fmt.Sprintf("%s:\n%s", msg, stackErr.Stack())
+							}
 							rcLogger.WithError(err).
 								WithField("rc_id", id).
-								Errorln("Caught panic in rc farm")
+								Errorln(msg)
 						}
 					}()
 					// disabled-ness is handled in watchdesires

--- a/pkg/roll/farm.go
+++ b/pkg/roll/farm.go
@@ -238,9 +238,16 @@ START_LOOP:
 					defer func() {
 						if r := recover(); r != nil {
 							err := util.Errorf("Caught panic in roll farm: %s", r)
+
+							stackErr, ok := err.(util.StackError)
+							msg := "Caught panic in roll farm"
+							if ok {
+								msg = fmt.Sprintf("%s:\n%s", msg, stackErr.Stack())
+							}
+
 							rlLogger.WithError(err).
 								WithField("new_rc", newRC).
-								Errorln("Caught panic in roll farm")
+								Errorln(msg)
 
 							// Release the child so that another farm can reattempt
 							rlf.childMu.Lock()


### PR DESCRIPTION
The replication controller and rolling update farms run many workers in
separate goroutines. Since panics such as nil pointer dereferences
happen from time to time, each worker is wrapped in a recover() in order
to catch panics and log them. However, only the panic message e.g.
"runtime error: invalid memory address or nil pointer dereference" was
being shown, with no line number or stack information.

This commit adds stack information to the output of the log message,
making it trivial to find where the original panic occurred.