### PR TITLE
Fix p2-rm output when removing a uuid pod.

### DIFF
--- a/bin/p2-rm/main.go
+++ b/bin/p2-rm/main.go
@@ -80,7 +80,11 @@ func handlePodRemoval(consulClient consulutil.ConsulClient, labeler labels.Appli
 		}
 	}
 
-	fmt.Printf("%s: successfully removed %s\n", rm.NodeName, rm.PodID)
+	if rm.NodeName != "" {
+		fmt.Printf("%s: successfully removed %s\n", rm.NodeName, rm.PodID)
+	} else {
+		fmt.Printf("successfully removed %s-%s\n", rm.PodID, rm.PodUniqueKey)
+	}
 	return nil
 }
 


### PR DESCRIPTION
When removing a uuid pod, the uuid is passed on the command line instead
of the node name since a node name is not necessarily enough information
to uniquely identify the pod to be removed.

However the output at the end of the script was always depending on the
node name, resulting in weird output like ": successfully removed
<app>". The output is now dependent on whether the pod removed was a
UUID pod or not.