### PR TITLE
Add ability to repair the workspace file in pod finish reporter.

### DIFF
--- a/pkg/preparer/podprocess/finish_service_test.go
+++ b/pkg/preparer/podprocess/finish_service_test.go
@@ -135,3 +135,33 @@ func TestPruneRowsBefore(t *testing.T) {
 		t.Fatalf("Expected only 1 row after pruning, but there were %d", len(finishes))
 	}
 }
+
+func TestLastFinishID(t *testing.T) {
+	finishService, _, closeFunc := initFinishService(t)
+	defer closeFunc()
+	defer finishService.Close()
+
+	// Insert 3 rows
+	for i := 0; i < 3; i++ {
+		err := finishService.Insert(FinishOutput{
+			PodID:        "some_pod",
+			PodUniqueKey: types.NewPodUUID(),
+			LaunchableID: "some_launchable",
+			EntryPoint:   "launch",
+			ExitCode:     4,
+			ExitStatus:   127,
+		})
+		if err != nil {
+			t.Errorf("Could not insert a finish row, the finishes table might not have been created: %s", err)
+		}
+	}
+
+	lastID, err := finishService.LastFinishID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if lastID != 3 {
+		t.Errorf("expected last written ID to be %d but was %d", 3, lastID)
+	}
+}


### PR DESCRIPTION
In order to publish information about the exit status of processes
started by a uuid pod, a runit hook is written that writes information
about each process exit to a local sqlite database. The preparer has a
"pod process reporter" which routinely polls this database for new
entries and writes them to consul.

To track the highest ID it has already seen in the database, it writes
the ID to a file at the end of each processing loop.

Sometimes we see the file end up with 0 bytes in it which means the pod
process reporter gets an error on every loop and can't do its job.

This commit adds the ability for the reporter to repair the file by
looking up the last ID in the database and writing that to the file.
This means that some finish data may be lost, but the alternative is to
double submit exit information to consul that might be old, so this
scheme is preferable.