### PR TITLE
Restore old naming scheme for runit service directories for legacy pods.

### DIFF
--- a/integration/single-node-slug-deploy/check.go
+++ b/integration/single-node-slug-deploy/check.go
@@ -319,7 +319,7 @@ func verifyProcessExit(errCh chan error, tempDir string, logger logging.Logger) 
 		select {
 		case <-timeout:
 			// Try to manually run the finish script in order to make debugging the test failure easier
-			output, err := exec.Command("sudo", fmt.Sprintf("/var/service/hello-%s__hello__bin__launch/finish", podUniqueKey), "1", "2").CombinedOutput()
+			output, err := exec.Command("sudo", fmt.Sprintf("/var/service/hello-%s__hello__launch/finish", podUniqueKey), "1", "2").CombinedOutput()
 			if err != nil {
 				logger.WithError(err).Infoln("DEBUG: Debug attempt to run finish script failed")
 			}
@@ -812,7 +812,7 @@ func verifyHelloRunning(podUniqueKey types.PodUniqueKey, logger logging.Logger) 
 	quit := make(chan struct{})
 	defer close(quit)
 
-	serviceDir := "/var/service/hello__hello__bin__launch"
+	serviceDir := "/var/service/hello__hello__launch"
 	if podUniqueKey != "" {
 		serviceDir = fmt.Sprintf("/var/service/hello-%s__hello__bin__launch", podUniqueKey)
 	}
@@ -886,10 +886,10 @@ func targetUUIDLogs(podUniqueKey types.PodUniqueKey) string {
 
 func targetLogs() string {
 	var helloTail, preparerTail bytes.Buffer
-	helloT := exec.Command("tail", "/var/service/hello__hello__bin__launch/log/main/current")
+	helloT := exec.Command("tail", "/var/service/hello__hello__launch/log/main/current")
 	helloT.Stdout = &helloTail
 	helloT.Run()
-	preparerT := exec.Command("tail", "/var/service/p2-preparer__p2-preparer__bin__launch/log/main/current")
+	preparerT := exec.Command("tail", "/var/service/p2-preparer__p2-preparer__launch/log/main/current")
 	preparerT.Stdout = &preparerTail
 	preparerT.Run()
 	return fmt.Sprintf("hello tail: \n%s\n\n preparer tail: \n%s", helloTail.String(), preparerTail.String())

--- a/pkg/hoist/test_helper.go
+++ b/pkg/hoist/test_helper.go
@@ -10,7 +10,15 @@ import (
 	"github.com/square/p2/pkg/util"
 )
 
-func FakeHoistLaunchableForDir(dirName string) (*Launchable, *runit.ServiceBuilder) {
+func FakeHoistLaunchableForDirUUIDPod(dirName string) (*Launchable, *runit.ServiceBuilder) {
+	return fakeHoistLaunchableForDir(dirName, true)
+}
+
+func FakeHoistLaunchableForDirLegacyPod(dirName string) (*Launchable, *runit.ServiceBuilder) {
+	return fakeHoistLaunchableForDir(dirName, false)
+}
+
+func fakeHoistLaunchableForDir(dirName string, isUUIDPod bool) (*Launchable, *runit.ServiceBuilder) {
 	tempDir, _ := ioutil.TempDir("", "fakeenv")
 	launchableInstallDir := util.From(runtime.Caller(0)).ExpandPath(dirName)
 
@@ -23,6 +31,7 @@ func FakeHoistLaunchableForDir(dirName string) (*Launchable, *runit.ServiceBuild
 		P2Exec:      util.From(runtime.Caller(0)).ExpandPath("fake_p2-exec"),
 		Version:     "abc123",
 		EntryPoints: []string{"bin/launch"},
+		IsUUIDPod:   isUUIDPod,
 	}
 
 	curUser, err := user.Current()

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -732,6 +732,7 @@ func (pod *Pod) getLaunchable(launchableID launch.LaunchableID, launchableStanza
 			CgroupName:       cgroupName,
 			SuppliedEnvVars:  launchableStanza.Env,
 			EntryPoints:      entryPoints,
+			IsUUIDPod:        pod.uniqueKey != "",
 		}
 		ret.CgroupConfig.Name = ret.ServiceId
 		return ret.If(), nil

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -301,7 +301,7 @@ func TestBuildRunitServices(t *testing.T) {
 		LogExec:        runit.DefaultLogExec(),
 		FinishExec:     NopFinishExec,
 	}
-	hl, sb := hoist.FakeHoistLaunchableForDir("multiple_script_test_hoist_launchable")
+	hl, sb := hoist.FakeHoistLaunchableForDirLegacyPod("multiple_script_test_hoist_launchable")
 	defer hoist.CleanupFakeLaunchable(hl, sb)
 	hl.RunAs = "testPod"
 	executables, err := hl.Executables(serviceBuilder)

--- a/pkg/preparer/setup_test.go
+++ b/pkg/preparer/setup_test.go
@@ -77,7 +77,7 @@ func TestInstallHooks(t *testing.T) {
 	_, err = os.Stat(currentAlias)
 	Assert(t).IsNil(err, fmt.Sprintf("%s should have been created", currentAlias))
 
-	hookFile := filepath.Join(execDir, "users__create__bin__launch")
+	hookFile := filepath.Join(execDir, "users__create__launch")
 	_, err = os.Stat(hookFile)
 	Assert(t).IsNil(err, "should have created the user launch script")
 }


### PR DESCRIPTION
Commit b22751cc08446367b6181ee5b602fc0d3a469c0e had modified the naming
scheme for runit service directories (i.e. /var/service/*).

Prior to that commit, the directory names were built like the following:
"/var/service/{podID}__{launchableID}__{filepath.Base(entryPointPath)}
yielding "/var/service/some-pod__some-launchable__launch" for a pod
named "some-pod", launchable named "some-launchable" with the bin/launch
entry point used.

After that commit, the naming scheme was modified to include information
about the directory hierarchy to the entry point relative to the root of
the artifact: e.g. bin__launch is used for the entry point portion
instead of just the file basename. This allows artifacts to have
multiple entry points with the same filename (in different directories).

This commit reverts this naming scheme change for "legacy" pods which do
not have a UUID, and keeps the new naming scheme if the pod has a UUID.