### PR TITLE
ds: report eligible and healthy pods per daemon set

### DIFF
--- a/bin/p2-ds-farm/main.go
+++ b/bin/p2-ds-farm/main.go
@@ -54,7 +54,7 @@ func main() {
 		TTL:       "15s",
 	}, client, sessions, quitCh, logger)
 
-	dsf := ds_farm.NewFarm(consulStore, dsStore, labeler, labels.NewConsulApplicator(client, 0), sessions, logger, nil, &healthChecker, 1*time.Second, *useCachePodMatches)
+	dsf := ds_farm.NewFarm(consulStore, dsStore, labeler, labels.NewConsulApplicator(client, 0), sessions, logger, nil, &healthChecker, 1*time.Second, false, *useCachePodMatches)
 
 	go func() {
 		// clear lock immediately on ctrl-C

--- a/pkg/ds/fields/fields.go
+++ b/pkg/ds/fields/fields.go
@@ -20,6 +20,10 @@ func (id ID) String() string {
 // Cluster name is where the DaemonSet lives on
 type ClusterName string
 
+func (cn ClusterName) String() string {
+	return string(cn)
+}
+
 // DaemonSet holds the runtime state of a Daemon Set as saved in Consul.
 type DaemonSet struct {
 	// UUID for this DaemonSet

--- a/pkg/replication/health_aggregator.go
+++ b/pkg/replication/health_aggregator.go
@@ -80,6 +80,19 @@ func (p *podHealth) GetHealth(host types.NodeName) (health.Result, bool) {
 	return h, ok
 }
 
+func (p *podHealth) NumHealthyOf(hosts []types.NodeName) int {
+	p.cond.L.Lock()
+	defer p.cond.L.Unlock()
+	count := 0
+	for _, host := range hosts {
+		h, ok := p.curHealth[host]
+		if ok && h.Status == health.Passing {
+			count++
+		}
+	}
+	return count
+}
+
 func (p *podHealth) Stop() {
 	close(p.quit)
 }

--- a/pkg/replication/health_aggregator.go
+++ b/pkg/replication/health_aggregator.go
@@ -22,6 +22,7 @@ func AggregateHealth(id types.PodID, checker checker.ConsulHealthChecker) *podHe
 		podId:   id,
 		checker: checker,
 		cond:    sync.NewCond(&sync.Mutex{}),
+		quit:    make(chan struct{}),
 	}
 	go p.beginWatch()
 


### PR DESCRIPTION
We'd like to get more insight into how our daemon sets are doing
health-wise. Adding this reporting will help us do that.