### PR TITLE
Make size.ByteCount type serialize to yaml in human-readable form.

### DIFF
--- a/pkg/util/size/bytes.go
+++ b/pkg/util/size/bytes.go
@@ -69,11 +69,10 @@ func Parse(sizeStr string) (ByteCount, error) {
 	return ByteCount(size), nil
 }
 
-// MarshalYAML() serializes a ByteCount into YAML. To maintain a canonical representation
-// of the value and to preserve compatibility with older parsers, the byte count will
-// always be serialized as a plain integer without a suffix.
+// MarshalYAML() serializes a ByteCount into YAML as a human-readable value
+// with a suffix.
 func (b ByteCount) MarshalYAML() (interface{}, error) {
-	return uint64(b), nil
+	return b.String(), nil
 }
 
 // UnmarshalYAML unserializes a YAML representation of the ByteCount.


### PR DESCRIPTION
In particular this makes p2-norm more user friendly. Prior to this
commit, passing a launchable with "memory: 1.0G" through p2-norm would
result in the memory value becoming an integer byte count instead of the
human readable notation.