### PR TITLE
Return error in GetMatches() for non-200 code in http applicator.

### DIFF
--- a/pkg/labels/http_applicator.go
+++ b/pkg/labels/http_applicator.go
@@ -247,6 +247,10 @@ func (h *httpApplicator) GetMatches(selector labels.Selector, labelType Type, ca
 		return []Labeled{}, err
 	}
 
+	if resp.StatusCode != 200 {
+		return nil, util.Errorf("got %d response from http label server: %s", resp.StatusCode, string(bodyData))
+	}
+
 	// try to unmarshal as a set of labeled objects.
 	var labeled []Labeled
 	err = json.Unmarshal(bodyData, &labeled)


### PR DESCRIPTION
Prior to this commit, the http applicator's GetMatches() function only
returned an error if there was an error executing the http request: not
if the successfully-returned http response had an http error code.

This commit considers anything other than 200 to be an error that
calling code should care about.