### PR TITLE
ds: failsafe: If no nodes are eligible, do nothing (and supporting commits - test changes)

### DIFF
--- a/pkg/ds/daemon_set.go
+++ b/pkg/ds/daemon_set.go
@@ -432,6 +432,10 @@ func (ds *daemonSet) removePods() error {
 		return util.Errorf("Error retrieving eligible nodes for daemon set: %v", err)
 	}
 
+	if len(eligible) == 0 {
+		return util.Errorf("No nodes eligible; daemon set refuses to unschedule everything.")
+	}
+
 	// Get the difference in nodes that we need to unschedule on and then sort them
 	// for deterministic ordering
 	toUnscheduleSorted := types.NewNodeSet(currentNodes...).Difference(types.NewNodeSet(eligible...)).ListNodes()

--- a/pkg/ds/farm_test.go
+++ b/pkg/ds/farm_test.go
@@ -308,7 +308,7 @@ func TestFarmSchedule(t *testing.T) {
 	defer preparer.Disable()
 
 	var allNodes []types.NodeName
-	allNodes = append(allNodes, "node1", "node2", "node3")
+	allNodes = append(allNodes, "node1", "node2", "node3", "node4")
 	for i := 0; i < 10; i++ {
 		nodeName := fmt.Sprintf("good_node%v", i)
 		allNodes = append(allNodes, types.NodeName(nodeName))
@@ -373,10 +373,13 @@ func TestFarmSchedule(t *testing.T) {
 	dsID = labeled.Labels.Get(DSIDLabel)
 	Assert(t).AreEqual(anotherDSData.ID.String(), dsID, "Unexpected dsID labeled")
 
-	// Make a third unschedulable node and verify it doesn't get scheduled by anything
-	applicator.SetLabel(labels.NODE, "node3", pc_fields.AvailabilityZoneLabel, "undefined")
+	// Make unschedulable nodes and verify they don't get scheduled by anything
+	applicator.SetLabel(labels.NODE, "node3", pc_fields.AvailabilityZoneLabel, "az3")
+	applicator.SetLabel(labels.NODE, "node4", pc_fields.AvailabilityZoneLabel, "undefined")
 
 	labeled, err = waitForPodLabel(applicator, false, "node3/testPod")
+	Assert(t).IsNil(err, "Expected pod not to have a dsID label")
+	labeled, err = waitForPodLabel(applicator, false, "node4/testPod")
 	Assert(t).IsNil(err, "Expected pod not to have a dsID label")
 
 	// Now add 10 new nodes and verify that they are scheduled by the first daemon set
@@ -580,7 +583,7 @@ func TestMultipleFarms(t *testing.T) {
 	})
 
 	var allNodes []types.NodeName
-	allNodes = append(allNodes, "node1", "node2", "node3")
+	allNodes = append(allNodes, "node1", "node2", "node3", "node4")
 	for i := 0; i < 10; i++ {
 		nodeName := fmt.Sprintf("good_node%v", i)
 		allNodes = append(allNodes, types.NodeName(nodeName))
@@ -669,10 +672,13 @@ func TestMultipleFarms(t *testing.T) {
 	dsID = labeled.Labels.Get(DSIDLabel)
 	Assert(t).AreEqual(anotherDSData.ID.String(), dsID, "Unexpected dsID labeled")
 
-	// Make a third unschedulable node and verify it doesn't get scheduled by anything
-	applicator.SetLabel(labels.NODE, "node3", pc_fields.AvailabilityZoneLabel, "undefined")
+	// Make unschedulable nodes and verify they don't get scheduled by anything
+	applicator.SetLabel(labels.NODE, "node3", pc_fields.AvailabilityZoneLabel, "az3")
+	applicator.SetLabel(labels.NODE, "node4", pc_fields.AvailabilityZoneLabel, "undefined")
 
 	labeled, err = waitForPodLabel(applicator, false, "node3/testPod")
+	Assert(t).IsNil(err, "Expected pod not to have a dsID label")
+	labeled, err = waitForPodLabel(applicator, false, "node4/testPod")
 	Assert(t).IsNil(err, "Expected pod not to have a dsID label")
 
 	// Now add 10 new nodes and verify that they are scheduled by the first daemon set

--- a/pkg/ds/farm_test.go
+++ b/pkg/ds/farm_test.go
@@ -397,10 +397,10 @@ func TestFarmSchedule(t *testing.T) {
 	}
 
 	//
-	// Update a daemon set's node selector and expect a node to be unscheduled
+	// Update a daemon set's node selector and expect one node to be scheduled, one to be unscheduled
 	//
 	mutator := func(dsToUpdate ds_fields.DaemonSet) (ds_fields.DaemonSet, error) {
-		someSelector := klabels.Everything().Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{"az99"})
+		someSelector := klabels.Everything().Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{"az3"})
 		dsToUpdate.NodeSelector = someSelector
 		return dsToUpdate, nil
 	}
@@ -412,6 +412,11 @@ func TestFarmSchedule(t *testing.T) {
 	// Verify node2 is unscheduled
 	labeled, err = waitForPodLabel(applicator, false, "node2/testPod")
 	Assert(t).IsNil(err, "Expected pod not to have a dsID label")
+	// Verify node3 is scheduled
+	labeled, err = waitForPodLabel(applicator, true, "node3/testPod")
+	Assert(t).IsNil(err, "Expected pod to have a dsID label")
+	dsID = labeled.Labels.Get(DSIDLabel)
+	Assert(t).AreEqual(anotherDSData.ID.String(), dsID, "Unexpected dsID labeled")
 
 	//
 	// Now update the node selector to schedule node2 again and verify
@@ -432,12 +437,12 @@ func TestFarmSchedule(t *testing.T) {
 	Assert(t).AreEqual(anotherDSData.ID.String(), dsID, "Unexpected dsID labeled")
 
 	//
-	// Disabling a daemon set should not unschedule any nodes
+	// Disabling a daemon set should not schedule or unschedule any nodes
 	//
 	mutator = func(dsToUpdate ds_fields.DaemonSet) (ds_fields.DaemonSet, error) {
 		dsToUpdate.Disabled = true
 
-		someSelector := klabels.Everything().Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{"az99"})
+		someSelector := klabels.Everything().Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{"az3"})
 		dsToUpdate.NodeSelector = someSelector
 		return dsToUpdate, nil
 	}
@@ -457,6 +462,10 @@ func TestFarmSchedule(t *testing.T) {
 	dsID = labeled.Labels.Get(DSIDLabel)
 	Assert(t).AreEqual(anotherDSData.ID.String(), dsID, "Unexpected dsID labeled")
 
+	// Verify node3 is unscheduled
+	labeled, err = waitForPodLabel(applicator, false, "node3/testPod")
+	Assert(t).IsNil(err, "Expected pod to have a dsID label")
+
 	//
 	// Enable a daemon set should make the dameon set resume its regular activities
 	//
@@ -474,6 +483,11 @@ func TestFarmSchedule(t *testing.T) {
 	// Verify node2 is unscheduled
 	labeled, err = waitForPodLabel(applicator, false, "node2/testPod")
 	Assert(t).IsNil(err, "Expected pod not to have a dsID label")
+	// Verify node3 is scheduled
+	labeled, err = waitForPodLabel(applicator, true, "node3/testPod")
+	Assert(t).IsNil(err, "Expected pod to have a dsID label")
+	dsID = labeled.Labels.Get(DSIDLabel)
+	Assert(t).AreEqual(anotherDSData.ID.String(), dsID, "Unexpected dsID labeled")
 }
 
 func TestCleanupPods(t *testing.T) {
@@ -696,10 +710,10 @@ func TestMultipleFarms(t *testing.T) {
 	}
 
 	//
-	// Update a daemon set's node selector and expect a node to be unscheduled
+	// Update a daemon set's node selector and expect one node to be scheduled, one to be unscheduled
 	//
 	mutator := func(dsToUpdate ds_fields.DaemonSet) (ds_fields.DaemonSet, error) {
-		someSelector := klabels.Everything().Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{"az99"})
+		someSelector := klabels.Everything().Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{"az3"})
 		dsToUpdate.NodeSelector = someSelector
 		return dsToUpdate, nil
 	}
@@ -711,6 +725,11 @@ func TestMultipleFarms(t *testing.T) {
 	// Verify node2 is unscheduled
 	labeled, err = waitForPodLabel(applicator, false, "node2/testPod")
 	Assert(t).IsNil(err, "Expected pod not to have a dsID label")
+	// Verify node3 is scheduled
+	labeled, err = waitForPodLabel(applicator, true, "node3/testPod")
+	Assert(t).IsNil(err, "Expected pod to have a dsID label")
+	dsID = labeled.Labels.Get(DSIDLabel)
+	Assert(t).AreEqual(anotherDSData.ID.String(), dsID, "Unexpected dsID labeled")
 
 	//
 	// Now update the node selector to schedule node2 again and verify
@@ -730,14 +749,17 @@ func TestMultipleFarms(t *testing.T) {
 	Assert(t).IsNil(err, "Expected pod to have a dsID label")
 	dsID = labeled.Labels.Get(DSIDLabel)
 	Assert(t).AreEqual(anotherDSData.ID.String(), dsID, "Unexpected dsID labeled")
+	// Verify node3 is unscheduled
+	labeled, err = waitForPodLabel(applicator, false, "node3/testPod")
+	Assert(t).IsNil(err, "Expected pod not to have a dsID label")
 
 	//
-	// Disabling a daemon set should not unschedule any nodes
+	// Disabling a daemon set should not schedule or unschedule any nodes
 	//
 	mutator = func(dsToUpdate ds_fields.DaemonSet) (ds_fields.DaemonSet, error) {
 		dsToUpdate.Disabled = true
 
-		someSelector := klabels.Everything().Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{"az99"})
+		someSelector := klabels.Everything().Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{"az3"})
 		dsToUpdate.NodeSelector = someSelector
 		return dsToUpdate, nil
 	}
@@ -783,6 +805,9 @@ func TestMultipleFarms(t *testing.T) {
 	Assert(t).IsNil(err, "Expected pod to have a dsID label")
 	dsID = labeled.Labels.Get(DSIDLabel)
 	Assert(t).AreEqual(anotherDSData.ID.String(), dsID, "Unexpected dsID labeled")
+	// Verify node3 is unscheduled
+	labeled, err = waitForPodLabel(applicator, false, "node3/testPod")
+	Assert(t).IsNil(err, "Expected pod not to have a dsID label")
 
 	//
 	// Enable a daemon set should make the dameon set resume its regular activities
@@ -829,6 +854,11 @@ func TestMultipleFarms(t *testing.T) {
 	// Verify node2 is unscheduled
 	labeled, err = waitForPodLabel(applicator, false, "node2/testPod")
 	Assert(t).IsNil(err, "Expected pod not to have a dsID label")
+	// Verify node3 is scheduled
+	labeled, err = waitForPodLabel(applicator, true, "node3/testPod")
+	Assert(t).IsNil(err, "Expected pod to have a dsID label")
+	dsID = labeled.Labels.Get(DSIDLabel)
+	Assert(t).AreEqual(anotherDSData.ID.String(), dsID, "Unexpected dsID labeled")
 }
 
 func waitForPodLabel(applicator labels.Applicator, hasDSIDLabel bool, podPath string) (labels.Labeled, error) {


### PR DESCRIPTION
It is expected that all daemon sets have non-empty target node sets at
all times.

If our label store ever indicates otherwise, we assume the label store
has erroneously returned empty results, and do nothing, to be safe.

This is similar to the p2-preparer's failsafe where it refuses to act if
it does not see its own key in intent.

The proper way to unschedule a daemon set on all its current nodes is to
delete it.