### PR TITLE
Add fail safe in pcstore.WatchAndSync to protect missing pod clusters.

### DIFF
--- a/pkg/store/consul/pcstore/consul_store.go
+++ b/pkg/store/consul/pcstore/consul_store.go
@@ -454,6 +454,12 @@ func (s *consulStore) WatchAndSync(syncer ConcreteSyncer, quit <-chan struct{}) 
 				s.logger.WithError(curResults.Err).Errorln("Could not sync pod clusters")
 				continue
 			}
+
+			if len(curResults.Clusters) == 0 {
+				s.logger.Warnln("could not sync pod clusters because watch returned 0 pod clusters")
+				continue
+			}
+
 			// zip up the previous and current results, act based on the difference.
 			zipped := s.zipResults(curResults, prevResults)
 			for id, change := range zipped {


### PR DESCRIPTION
To protect against data loss or misfiring consul queries, this commit
adds a failsafe to the pcstore.WatchAndSync function in which it will
not call "SyncCluster" or "DeleteCluster" when the pod cluster watch
returns no data.

This is because a syncer may wish to perform destructive action at the
time of a pod cluster deletion, and if the entire set goes away it may
be disastrous.