### PR TITLE
Add retry behavior to p2-finish-env-extractor.

### DIFF
--- a/bin/p2-finish-env-extractor/main.go
+++ b/bin/p2-finish-env-extractor/main.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	"log"
+	"time"
 
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/preparer/podprocess"
@@ -20,6 +21,11 @@ var (
 	exitCode     = kingpin.Arg("exitcode", "The exit code to be recorded to the sqlite database, automatically provided by runit's ./finish system").Required().Int()
 	exitStatus   = kingpin.Arg("exitstatus", "The least significant byte of exit stasus as determined by waitpid(2), automatically provided by runit's ./finish system").Required().Int()
 	databasePath = kingpin.Flag("database-path", "The path to the sqlite database to which finish information should be written").Required().ExistingFile()
+	retries      = kingpin.Flag("retries", "The number of times to retry the database insert. This can avoid temporary database lock conflicts from multiple writers").Default("3").Int()
+)
+
+const (
+	backoffTime = 2 * time.Second
 )
 
 func main() {
@@ -30,7 +36,21 @@ func main() {
 		Logger:       logging.DefaultLogger,
 	}
 
-	err := envExtractor.WriteFinish(*exitCode, *exitStatus)
+	var err error
+	// WriteFinish() is writing to a sqlite database that may be shared
+	// across many pods across a physical host. The nature of sqlite is
+	// that writes lock the entire database, which can cause transient
+	// failures. To reduce the likelihood of writes fighting each other, we
+	// retry writes a few times after they fail
+	for i := 0; i < *retries; i++ {
+		err = envExtractor.WriteFinish(*exitCode, *exitStatus)
+		if !podprocess.IsRetryable(err) {
+			break
+		}
+
+		time.Sleep(backoffTime)
+	}
+
 	if err != nil {
 		log.Fatalf("Could not write finish information to database: %s", err)
 	}


### PR DESCRIPTION
p2-finish-env-extractor is a binary that p2-preparer wires into runit to
capture the exit code of the processes that runit manages. In the case
of uuid pods p2-finish-env-extractor writes a row to a sqlite database
on disk to capture the exit code.

This scheme can result in lost information because writing to a sqlite
database always locks the entire database, so if multiple processes exit
at the same time they will compete for the ability to write to the
database.

This commit adds the ability to make p2-finish-env-extractor retry
errors writing to the database to improve the likelihood of a row making
it into the database.