### PR TITLE
introduce p2-shutdown

### DIFF
--- a/bin/p2-shutdown/main.go
+++ b/bin/p2-shutdown/main.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
+	"sync"
+
+	"github.com/square/p2/pkg/manifest"
+	"github.com/square/p2/pkg/pods"
+	"github.com/square/p2/pkg/store/consul"
+	"github.com/square/p2/pkg/store/consul/flags"
+	"github.com/square/p2/pkg/types"
+)
+
+const helpMessage = `
+p2-shutdown is a command that is useful to gracefully shutdown pods on a host
+before doing maintenance. Ideally, these pods would be relocated to a different
+host but we live in a world where hosts are pets.
+`
+
+var (
+	verbose      = kingpin.Flag("verbose", "Print debugging information").Short('v').Bool()
+	dryRun       = kingpin.Flag("dry", "Dry run: do not stop any pods").Short('d').Bool()
+	shutdownPods = kingpin.Flag("pods", "The list of pods to shutdown. Leave empty for all").Short('p').Strings()
+	podRoot      = kingpin.Flag("pod-root", "The base directory for pods").Default(pods.DefaultPath).String()
+)
+
+func main() {
+	_, consulOpts, _ := flags.ParseWithConsulOptions()
+	client := consul.NewConsulClient(consulOpts)
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Fatalf("error getting hostname name: %v", err)
+	}
+
+	node := types.NodeName(hostname)
+	consulStore := consul.NewConsulStore(client)
+	reality, _, err := consulStore.ListPods(consul.REALITY_TREE, node)
+	if err != nil {
+		log.Fatalf("caught fatal error while querying datastore: %v", err)
+	}
+
+	podsToShutdown := make([]types.PodID, 0, len(*shutdownPods))
+	for _, pod := range *shutdownPods {
+		podsToShutdown = append(podsToShutdown, types.PodID(pod))
+	}
+
+	podFactory := pods.NewFactory(*podRoot, node)
+	var haltWG sync.WaitGroup
+	for _, realityEntry := range reality {
+		pod := podFactory.NewLegacyPod(realityEntry.Manifest.ID())
+		if *dryRun {
+			log.Printf("dry run, skipping this pod: %s", pod.Id)
+			continue
+		}
+		if !shutdownPod(pod.Id, podsToShutdown) {
+			log.Printf("pod %s not in set of pods to shutdown, skipping", pod.Id)
+			continue
+		}
+
+		haltWG.Add(1)
+		// Halt in the background because Halt() waits for lifecycle scripts
+		go func(man manifest.Manifest, podID types.PodID) {
+			defer haltWG.Done()
+			success, err := pod.Halt(man)
+			if !success {
+				log.Printf("[ERROR]: at least one launchable of %s did not halt successfully.", podID)
+			}
+			if err != nil {
+				log.Printf("[ERROR]: Got error while halting pod %s. Consider retrying the command. \n %s", podID, err)
+			}
+		}(realityEntry.Manifest, pod.Id)
+	}
+	haltWG.Wait()
+}
+
+func shutdownPod(podID types.PodID, podsToShutdown []types.PodID) bool {
+	if len(podsToShutdown) == 0 {
+		return true
+	}
+	for _, pod := range podsToShutdown {
+		if pod == podID {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/runit/runit_service.go
+++ b/pkg/runit/runit_service.go
@@ -63,6 +63,7 @@ type StatError error
 
 var (
 	NotRunning         StatError = errors.New("RunSV is not running and must be started")
+	NotRunningTimeout  StatError = errors.New("Timed out while waiting to stop service: either RunSV or this service is not running")
 	SuperviseOkMissing           = errors.New("The supervise/ok file is missing")
 	Killed                       = errors.New("The process was forcibly killed")
 )
@@ -77,7 +78,7 @@ func (sv *sv) waitForSupervision(service *Service) error {
 		}
 		select {
 		case <-maxWait:
-			return NotRunning
+			return NotRunningTimeout
 		case <-time.After(150 * time.Millisecond):
 			// no op
 		}


### PR DESCRIPTION
There is a desire to gracefully shutdown pods while preserving their /intent
records. An example of when this is desirable is when performing host
maintenance on a pet host.