### PR TITLE
Make unmarshaling an RC with missing replicas_desired an error.

### DIFF
--- a/pkg/rc/fields/fields_test.go
+++ b/pkg/rc/fields/fields_test.go
@@ -1,4 +1,4 @@
-package fields_test
+package fields
 
 import (
 	"encoding/json"
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/anthonybishopric/gotcha"
 	"github.com/square/p2/pkg/manifest"
-	"github.com/square/p2/pkg/rc/fields"
 )
 
 func TestJSONMarshal(t *testing.T) {
@@ -14,16 +13,17 @@ func TestJSONMarshal(t *testing.T) {
 	mb.SetID("hello")
 	m := mb.GetManifest()
 
-	rc1 := fields.RC{
-		ID:       "hello",
-		Manifest: m,
+	rc1 := RC{
+		ID:              "hello",
+		Manifest:        m,
+		ReplicasDesired: 2,
 	}
 
 	b, err := json.Marshal(&rc1)
 	Assert(t).IsNil(err, "should have marshaled")
 	t.Log("serialized format:", string(b))
 
-	var rc2 fields.RC
+	var rc2 RC
 	err = json.Unmarshal(b, &rc2)
 	Assert(t).IsNil(err, "should have unmarshaled")
 	Assert(t).AreEqual(rc1.ID, rc2.ID, "RC ID changed when serialized")
@@ -31,7 +31,14 @@ func TestJSONMarshal(t *testing.T) {
 }
 
 func TestZeroUnmarshal(t *testing.T) {
-	var rc fields.RC
+	var rc RC
 	err := json.Unmarshal([]byte(`{}`), &rc)
-	Assert(t).IsNil(err, "error unmarshaling")
+	if err == nil {
+		t.Errorf("expected an error unmarshaling an RC missing the replicas_desired field")
+	}
+
+	err = json.Unmarshal([]byte(`{"replicas_desired": 0}`), &rc)
+	if err != nil {
+		t.Errorf("got an error unmarshaling an otherwise-empty RC with a replicas_desired count of 0: %s", err)
+	}
 }

--- a/pkg/roll/update_test.go
+++ b/pkg/roll/update_test.go
@@ -797,7 +797,9 @@ func assertRCUpdates(t *testing.T, rc *rc_fields.RC, upd <-chan struct{}, expect
 	case <-time.After(1 * time.Second):
 		t.Fatalf("%s didn't update after one second, was waiting for value %d", desc, expect)
 	}
-	Assert(t).AreEqual(rc.ReplicasDesired, expect, "expected "+desc+" to change")
+	if rc.ReplicasDesired != expect {
+		t.Errorf("expected replicas desired count to be %d but was %d", expect, rc.ReplicasDesired)
+	}
 }
 
 func assertRollLoopResult(t *testing.T, channel <-chan bool, expect bool) {
@@ -865,7 +867,9 @@ func TestRollLoopTypicalCase(t *testing.T) {
 
 func failIfRCDesireChanges(t *testing.T, rc *rc_fields.RC, expected int, updates <-chan struct{}) {
 	for range updates {
-		Assert(t).AreEqual(rc.ReplicasDesired, expected, "RC desire changed unexpectedly")
+		if rc.ReplicasDesired != expected {
+			t.Errorf("expected replicas desired count to be %d but was %d", expected, rc.ReplicasDesired)
+		}
 	}
 }
 

--- a/pkg/store/consul/rcstore/consul_store_test.go
+++ b/pkg/store/consul/rcstore/consul_store_test.go
@@ -513,8 +513,9 @@ func rcsWithIDs(t *testing.T, id string, num int) api.KVPairs {
 	manifest := builder.GetManifest()
 	for i := 0; i < num; i++ {
 		rc := fields.RC{
-			ID:       fields.ID(id),
-			Manifest: manifest,
+			ID:              fields.ID(id),
+			Manifest:        manifest,
+			ReplicasDesired: 1,
 		}
 
 		jsonRC, err := json.Marshal(rc)


### PR DESCRIPTION
This adds to the safety of the RC farm, because it allows us to
distinguish a JSON RC missing the replicas_desired field completely from
one that has it but a 0 count for the value.

It is an error to unmarshal an RC that does not have a replicas_desired
field.

This protects us against a scenario where the json tag might be changed
such that all stored RCs will have replica counts of zero. There is
already a failsafe in place that prevents the farm from taking action of
the sum of all of the rc replica counts is zero, but this adds an
additional layer of safety.