### PR TITLE
store: Ignore old data produced by stale Consul queries

### DIFF
--- a/pkg/store/consul/consulutil/watch.go
+++ b/pkg/store/consul/consulutil/watch.go
@@ -62,6 +62,11 @@ func WatchPrefix(
 		case CanceledError:
 			return
 		case nil:
+			if queryMeta.LastIndex < currentIndex {
+				// The "stale" query returned data that's older than what this watcher has
+				// already seen. Ignore the old data.
+				continue
+			}
 			currentIndex = queryMeta.LastIndex
 			consulLatencyHistogram.Update(int64(queryMeta.RequestTime))
 			outputPairsStart = time.Now()
@@ -319,6 +324,11 @@ func WatchDiff(
 				continue
 			}
 
+			if queryMeta.LastIndex < currentIndex {
+				// The "stale" query returned data that's older than what this watcher has
+				// already seen. Ignore the old data.
+				continue
+			}
 			consulLatencyHistogram.Update(int64(queryMeta.RequestTime))
 			currentIndex = queryMeta.LastIndex
 			// A copy used to keep track of what was deleted


### PR DESCRIPTION
"Stale" requests can be handled by any server node, which will then
service the request from its local state. While unlikely, it is possible
that two consecutive client requests might be serviced by two different
nodes operating under two different versions of state. This could allow
the client's second request to return data that is older than its first
one.

Fortunately, it's straightforward to check for this problem: responses
contain logical clocks, so older data can be identified by looking for a
decreasing clock. This commit adds such a check and ignores data that is
known to be old.