### PR TITLE
Don't run disable/enable for oneoff pods.

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -319,6 +319,14 @@ func (hl *Launchable) Executables(
 
 		for _, relativePath := range relativeExecutablePaths {
 			var entryPointName string
+
+			// This is a hack to preserve the runit service
+			// directory layout for legacy pods. From a theoretical
+			// standpoint we would like to include all parts of the
+			// path in the service name so that there could be
+			// multiple files started with the same basename but
+			// different paths. UUID pods are new so we can adopt
+			// the scheme we want
 			if hl.IsUUIDPod {
 				entryPointName = strings.Replace(relativePath, "/", "__", -1)
 			} else {

--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -74,7 +74,17 @@ func (hl *Launchable) If() launch.Launchable {
 	return LaunchAdapter{Launchable: hl}
 }
 
+func (hl *Launchable) IsOneoff() bool {
+	return hl.IsUUIDPod
+}
+
 func (hl *Launchable) Disable() error {
+	if hl.IsOneoff() {
+		// oneoff pods have nothing to disable/enable, they only run once and there's
+		// no server component
+		return nil
+	}
+
 	// the error return from os/exec.Run is almost always meaningless
 	// ("exit status 1")
 	// since the output is more useful to the user, that's what we'll preserve
@@ -151,6 +161,12 @@ func (hl *Launchable) disable() (string, error) {
 }
 
 func (hl *Launchable) enable() (string, error) {
+	if hl.IsOneoff() {
+		// For oneoff pods, there is nothing to enable. It's just an entry
+		// point that runs once.
+		return "", nil
+	}
+
 	output, err := hl.InvokeBinScript("enable")
 
 	// providing an enable script is optional, ignore those errors

--- a/pkg/hoist/hoist_launchable_test.go
+++ b/pkg/hoist/hoist_launchable_test.go
@@ -269,6 +269,18 @@ func TestEnable(t *testing.T) {
 	Assert(t).AreEqual(enableOutput, expectedEnableOutput, "Did not get expected output from test enable script")
 }
 
+func TestNoEnableForUUIDPods(t *testing.T) {
+	hl, sb := FakeHoistLaunchableForDirUUIDPod("failing_scripts_test_hoist_launchable")
+	defer CleanupFakeLaunchable(hl, sb)
+
+	// If enable actually gets run, we'll get an error because we chose the launchable
+	// with failing scripts
+	_, err := hl.enable()
+	if err != nil {
+		t.Error("enable script shouldn't have run for a uuid pod")
+	}
+}
+
 func TestFailingEnable(t *testing.T) {
 	// This test's behavior is not dependent on whether the pod is a legacy or uuid pod
 	hl, sb := FakeHoistLaunchableForDirLegacyPod("failing_scripts_test_hoist_launchable")
@@ -372,6 +384,18 @@ func TestStop(t *testing.T) {
 	err := hl.stop(sb, sv)
 
 	Assert(t).IsNil(err, "Got an unexpected error when attempting to stop runit services")
+}
+
+func TestNoDisableForUUIDPods(t *testing.T) {
+	hl, sb := FakeHoistLaunchableForDirUUIDPod("failing_scripts_test_hoist_launchable")
+	defer CleanupFakeLaunchable(hl, sb)
+
+	// If disable actually gets run, we'll get an error because we chose the launchable
+	// with failing scripts
+	err := hl.Disable()
+	if err != nil {
+		t.Error("disable script shouldn't have run for a uuid pod")
+	}
 }
 
 func TestDisableWithFailingDisable(t *testing.T) {


### PR DESCRIPTION
oneoff pods don't need to have their disable/enable scripts run because
they are oneoff jobs with immutable state. Furthermore running
disable/enable scripts may impact other pods with the same pod ID on the
same physical hardware depending on the implementation if
enable/disable.

This commit creates a (artificial at this point) distinction between
uuid pods and oneoff pods. A uuid pod is a pod whose data is stored in
the pods/ consul tree with an associated uuid. A oneoff pod is a pod
that is meant to run once and does not represent a repeatedly running
service like a web server.

These two concepts are tied together currently but now there is a
IsOneoff() function on the hoist launchable type which may change at
some point.

This commi