### PR TITLE
Revert "Merge pull request #739 from petertseng/gzip-as-user"

### DIFF
--- a/pkg/artifact/downloader.go
+++ b/pkg/artifact/downloader.go
@@ -65,12 +65,13 @@ func (l *downloader) Download(location *url.URL, verificationData auth.Verificat
 		return err
 	}
 
-	err = artifactFile.Chmod(0644)
+	// rewind a second time to allow the archive to be unpacked
+	_, err = artifactFile.Seek(0, os.SEEK_SET)
 	if err != nil {
-		return err
+		return util.Errorf("Could not reset artifact file position after verification: %v", err)
 	}
 
-	err = gzip.ExtractTarGz(owner, artifactFile.Name(), dst)
+	err = gzip.ExtractTarGz(owner, artifactFile, dst)
 	if err != nil {
 		_ = os.RemoveAll(dst)
 		return util.Errorf("error while extracting artifact: %s", err)

--- a/pkg/gzip/gzip.go
+++ b/pkg/gzip/gzip.go
@@ -1,26 +1,37 @@
 package gzip
 
 import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
 	"os"
-	"os/exec"
-	"os/user"
-	"syscall"
+	"path/filepath"
+	"strings"
 
-	p2user "github.com/square/p2/pkg/user"
+	"github.com/square/p2/pkg/user"
 	"github.com/square/p2/pkg/util"
 )
 
-// ExtractTarGz extracts the specified tarball to the specified destination,
-// as the specified user.
-func ExtractTarGz(owner string, filename string, dest string) (err error) {
-	ownerUID, ownerGID, err := p2user.IDs(owner)
+// ExtractTarGz reads a gzipped tar stream and extracts all files to the destination
+// directory. If an owner name is specified, all files will be created to be owned by that
+// user; otherwise, the tar specifies ownership.
+//
+// If any file would be extracted outside of the destination directory due to relative paths
+// containing '..', the archive will be rejected with an error.
+func ExtractTarGz(owner string, fp io.Reader, dest string) (err error) {
+	fz, err := gzip.NewReader(fp)
 	if err != nil {
-		return err
+		return util.Errorf("error reading gzip data: %s", err)
 	}
+	defer fz.Close()
+	tr := tar.NewReader(fz)
 
-	currentUser, err := user.Current()
-	if err != nil {
-		return err
+	var ownerUID, ownerGID int
+	if owner != "" {
+		ownerUID, ownerGID, err = user.IDs(owner)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = util.MkdirChownAll(dest, ownerUID, ownerGID, 0755)
@@ -32,18 +43,132 @@ func ExtractTarGz(owner string, filename string, dest string) (err error) {
 		return util.Errorf("error setting ownership of root directory %s: %s", dest, err)
 	}
 
-	cmd := exec.Command("tar", "xpzf", filename, "-C", dest)
-	if currentUser.Username != owner {
-		// If we are running as a non-root user (e.g. in tests), don't change user.
-		// Non-root users are understandably not allowed to change to other users...
-		// not even themselves.
-		cmd.SysProcAttr = &syscall.SysProcAttr{
-			Credential: &syscall.Credential{Uid: uint32(ownerUID), Gid: uint32(ownerGID)},
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
 		}
-	}
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return util.Errorf("error extracting: %v %s", err, string(output))
+		if err != nil {
+			return util.Errorf("read error: %s", err)
+		}
+		fpath := filepath.Join(dest, hdr.Name)
+		var uid, gid int
+		if owner == "" {
+			uid, gid = hdr.Uid, hdr.Gid
+		} else {
+			uid, gid = ownerUID, ownerGID
+		}
+
+		// Error on all files that would end up outside the destination directory.
+		if !strings.HasPrefix(fpath, dest) {
+			return util.Errorf(
+				"cannot extract %s, as its target %s is outside the root directory %s",
+				hdr.Name,
+				fpath,
+				dest,
+			)
+		}
+
+		parent := filepath.Dir(fpath)
+		if err := util.MkdirChownAll(parent, ownerUID, ownerGID, 0755); err != nil {
+			return util.Errorf(
+				"error creating directory %s (parent of %s): %s",
+				parent,
+				hdr.Name,
+				err,
+			)
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeSymlink:
+			err = os.Symlink(hdr.Linkname, fpath)
+			if err != nil {
+				return util.Errorf(
+					"error creating symlink %s -> %s: %s",
+					fpath,
+					hdr.Linkname,
+					err,
+				)
+			}
+			err = os.Lchown(fpath, uid, gid)
+			if err != nil {
+				return util.Errorf("error setting owner of %s: %s", fpath, err)
+			}
+		case tar.TypeLink:
+			// If you include a file multiple times in an invocation of
+			// Gnu tar, it stores anything after the first as a hard link
+			// to itself.  Since such a structure can't otherwise exist, we
+			// can simply skip it.
+			if hdr.Name == hdr.Linkname {
+				continue
+			}
+			// hardlink paths are encoded relative to the tarball root, rather than
+			// the path of the link itself, so we need to resolve that path
+			linkTarget, err := filepath.Rel(filepath.Dir(hdr.Name), hdr.Linkname)
+			if err != nil {
+				return util.Errorf(
+					"error resolving link: %s -> %s: %s",
+					fpath,
+					hdr.Linkname,
+					err,
+				)
+			}
+			// we can't make the hardlink right away because the target might not
+			// exist, so we'll just make a symlink instead
+			err = os.Symlink(linkTarget, fpath)
+			if err != nil {
+				return util.Errorf(
+					"error creating symlink %s -> %s (originally hardlink): %s",
+					fpath,
+					linkTarget,
+					err,
+				)
+			}
+		case tar.TypeDir:
+			err = os.Mkdir(fpath, hdr.FileInfo().Mode())
+			if err != nil && !os.IsExist(err) {
+				return util.Errorf("error creating directory %s: %s", fpath, err)
+			}
+
+			err = os.Chown(fpath, uid, gid)
+			if err != nil {
+				return util.Errorf("error setting ownership of %s: %s", fpath, err)
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			// Extract the file inside a closure to limit the scope of its open FD
+			err = func() (innerErr error) {
+				f, err := os.OpenFile(
+					fpath,
+					os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+					hdr.FileInfo().Mode(),
+				)
+				if err != nil {
+					return util.Errorf("error creating %s: %s", fpath, err)
+				}
+				// Released at end of "case" statement
+				defer func() {
+					if closeErr := f.Close(); innerErr == nil {
+						innerErr = closeErr
+					}
+				}()
+
+				err = f.Chown(uid, gid)
+				if err != nil {
+					return util.Errorf("error setting file ownership of %s: %s", fpath, err)
+				}
+
+				_, err = io.Copy(f, tr)
+				if err != nil {
+					return util.Errorf("error extracting to %s: %s", fpath, err)
+				}
+				return nil
+			}()
+			if err != nil {
+				return err
+			}
+		default:
+			return util.Errorf("unhandled type flag %q (header %v)", hdr.Typeflag, hdr)
+		}
 	}
 	return nil
 }

--- a/pkg/gzip/gzip_test.go
+++ b/pkg/gzip/gzip_test.go
@@ -18,6 +18,8 @@ func testExtraction(t *testing.T, tarfile string,
 ) {
 	tarfile = path.Join("testdata", tarfile) // prefix with testdata so this is ignored by downstream dep management
 	tarPath := util.From(runtime.Caller(0)).ExpandPath(tarfile)
+	file, err := os.Open(tarPath)
+	Assert(t).IsNil(err, "expected no error opening file")
 
 	tmpdir, err := ioutil.TempDir("", "gziptest")
 	defer os.RemoveAll(tmpdir)
@@ -30,7 +32,7 @@ func testExtraction(t *testing.T, tarfile string,
 	user, err := user.Current()
 	Assert(t).IsNil(err, "expected no error getting current user")
 
-	err = ExtractTarGz(user.Username, tarPath, dest)
+	err = ExtractTarGz(user.Username, file, dest)
 
 	check(err, dest)
 }
@@ -45,10 +47,6 @@ func TestFileWithoutDir(t *testing.T) {
 }
 
 func TestSelfHardlink(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("bsdtar doesn't handle a selflink tarball")
-	}
-
 	testExtraction(t, "file_with_selflink.tar.gz", func(tarErr error, dest string) {
 		Assert(t).IsNil(tarErr, "expected no error extracting tarball")
 


### PR DESCRIPTION
This reverts commit c2d478a9633c68bef0d64845d56c492b7df94890, reversing
changes made to 94d5805d6a377b16ff2e2b440efad37345aee5f9.

We're not quite ready for this to go out yet, since:

1. The **tmp directory** (to which files are downloaded) needs to be
   world-readable, and it is not on some machines.
2. We're not sure whether it's safe to make it world-readable, or why it
   is not.