### PR TITLE
Use text formatting for log messages except for in socket hook.

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -32,7 +32,7 @@ var DefaultLogger = NewLogger(logrus.Fields{})
 
 func NewLogger(baseFields logrus.Fields) Logger {
 	logger := logrus.New()
-	logger.Formatter = new(logrus.JSONFormatter)
+	logger.Formatter = new(logrus.TextFormatter)
 	logger.Hooks.Add(&processCounter)
 	return Logger{logrus.NewEntry(logger).WithFields(baseFields)}
 }

--- a/pkg/logging/socket_hook.go
+++ b/pkg/logging/socket_hook.go
@@ -22,6 +22,8 @@ func (SocketHook) Levels() []logrus.Level {
 	}
 }
 
+var jsonFormatter = new(logrus.JSONFormatter)
+
 func (s SocketHook) Fire(entry *logrus.Entry) error {
 	c, err := net.Dial("unix", s.socketPath)
 	if err != nil {
@@ -31,7 +33,9 @@ func (s SocketHook) Fire(entry *logrus.Entry) error {
 	}
 	defer c.Close()
 
-	logMessage, err := entry.Logger.Formatter.Format(entry)
+	// always use the JSON formatter when logging to a socket. The thing on
+	// the other end is a program.
+	logMessage, err := jsonFormatter.Format(entry)
 	if err != nil {
 		// Airbrake someday
 		return nil

--- a/pkg/logging/socket_hook_test.go
+++ b/pkg/logging/socket_hook_test.go
@@ -1,0 +1,96 @@
+package logging
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+)
+
+func TestSocketHookAlwaysJSON(t *testing.T) {
+	logger := NewLogger(logrus.Fields{
+		"some_field": "some_value",
+	})
+
+	socketDir, err := ioutil.TempDir("", "socket_hook_test")
+	if err != nil {
+		t.Fatalf("could not create temp dir for logging socket hook test: %s", err)
+	}
+	defer os.RemoveAll(socketDir)
+
+	socketPath := filepath.Join(socketDir, "logging.sock")
+	err = logger.AddHook(OutSocket, socketPath)
+	if err != nil {
+		t.Fatalf("could not add socket logging hook to logger: %s", err)
+	}
+
+	messages := make(chan []byte)
+	errors := make(chan error)
+	defer close(messages)
+	defer close(errors)
+
+	go func() {
+		ln, err := net.Listen("unix", socketPath)
+		if err != nil {
+			errors <- err
+			return
+		}
+
+		go func() {
+			logger.WithFields(logrus.Fields{
+				"another_field": "another_value",
+			}).Infoln("some message")
+		}()
+
+		conn, err := ln.Accept()
+		if err != nil {
+			errors <- err
+			return
+		}
+
+		message, err := ioutil.ReadAll(conn)
+		if err != nil {
+			errors <- err
+			return
+		}
+		messages <- message
+	}()
+
+	var rawMessage []byte
+	select {
+	case err := <-errors:
+		t.Fatalf("unexpected error reading from logging socket: %s", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for log message on socket")
+	case rawMessage = <-messages:
+	}
+
+	var message struct {
+		SomeField    string `json:"some_field"`
+		AnotherField string `json:"another_field"`
+
+		// this one is added automatically by logrus
+		Message string `json:"msg"`
+	}
+	err = json.Unmarshal(rawMessage, &message)
+	if err != nil {
+		t.Fatalf("could not decode log message %q from socket as JSON: %s", string(rawMessage), err)
+	}
+
+	if message.SomeField != "some_value" {
+		t.Errorf("The default logger field of %q didn't have value of %q. Full message: %s", "some_field", "some_value", string(rawMessage))
+	}
+
+	if message.AnotherField != "another_value" {
+		t.Errorf("The default logger field of %q didn't have value of %q. Full message: %s", "another_field", "another_value", string(rawMessage))
+	}
+
+	if message.Message != "some message" {
+		t.Errorf("The default logger field of %q didn't have value of %q. Full message: %s", "msg", "some message", string(rawMessage))
+	}
+}


### PR DESCRIPTION
p2-preparer's logger allows adding a hook that will write log messages
to a socket in addition to stdout/stderr. This is useful to have another
program consume the log messages from the socket.

To allow this to work, we were always using logrus's JSON formatter
since parsing json is much easier for the program on the other end of
the socket. However this is a worse experience for humans trying to read
log messages.

This commit makes the logging package use the text formatter but makes
the socket hook a special case that will always use the JSON formatter
regardless of the formatter actually set on the logger.