### PR TITLE
Unconditionally install hooks on preparer startup.

### DIFF
--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -568,31 +568,8 @@ func (p *Preparer) InstallHooks() error {
 		"pod": p.hooksManifest.ID(),
 	})
 
-	// Figure out if we even need to install anything.
-	// Hooks aren't running services and so there isn't a need
-	// to write the current manifest to the reality store. Instead
-	// we just compare to the manifest on disk.
-	current, err := p.hooksPod.CurrentManifest()
-	if err != nil && err != pods.NoCurrentManifest {
-		p.Logger.WithError(err).Errorln("Could not check current manifest")
-		return err
-	}
-
-	var currentSHA string
-	if current != nil {
-		currentSHA, _ = current.SHA()
-	}
-	newSHA, _ := p.hooksManifest.SHA()
-
-	if err != pods.NoCurrentManifest && currentSHA == newSHA {
-		p.Logger.Infoln("Hooks up to date, nothing to do")
-		// we are up-to-date, continue
-		return nil
-	}
-
-	p.Logger.Infoln("Installing new hook manifest")
-	// The manifest is new, go ahead and install
-	err = p.hooksPod.Install(p.hooksManifest, p.artifactVerifier, p.artifactRegistry)
+	p.Logger.Infoln("Installing hook manifest")
+	err := p.hooksPod.Install(p.hooksManifest, p.artifactVerifier, p.artifactRegistry)
 	if err != nil {
 		sub.WithError(err).Errorln("Could not install hook")
 		return err


### PR DESCRIPTION
Prior to this commit the hook manifest (fetched from preparer manifest
config) was compared to the current manifest written to disk for hooks.
If the manifests were the same, hook installation was skipped.

This commit removes this check and just unconditionally installs the
hooks.

This is for two reasons:
1) Installing is low-cost anyway. We don't redownload artifacts if
they're present on the disk, and the rest is just linking and writing of
the current manifest file.
2) It's possible that the hooks might have been removed but the
current_manifest.yaml file for them was untouched, which will cause the
preparer to incorrectly not install them.