### PR TITLE
roll: cleanup unused (scheduler, alerter) args

### DIFF
--- a/bin/p2-rctl-server/main.go
+++ b/bin/p2-rctl-server/main.go
@@ -123,6 +123,5 @@ func main() {
 		logger,
 		labeler,
 		klabels.Everything(),
-		alerter,
 	).Start(nil)
 }

--- a/bin/p2-rctl-server/main.go
+++ b/bin/p2-rctl-server/main.go
@@ -115,7 +115,6 @@ func main() {
 			RCStore:       rcStore,
 			HealthChecker: healthChecker,
 			Labeler:       labeler,
-			Scheduler:     sched,
 		},
 		consulStore,
 		rollStore,

--- a/pkg/roll/farm.go
+++ b/pkg/roll/farm.go
@@ -64,8 +64,7 @@ type Farm struct {
 	childMu  sync.Mutex
 	session  consul.Session
 
-	logger  logging.Logger
-	alerter alerting.Alerter
+	logger logging.Logger
 
 	labeler    rc.Labeler
 	rcSelector klabels.Selector
@@ -86,11 +85,8 @@ func NewFarm(
 	logger logging.Logger,
 	labeler rc.Labeler,
 	rcSelector klabels.Selector,
-	alerter alerting.Alerter,
+	_ alerting.Alerter,
 ) *Farm {
-	if alerter == nil {
-		alerter = alerting.NewNop()
-	}
 	return &Farm{
 		factory:    factory,
 		store:      store,
@@ -101,7 +97,6 @@ func NewFarm(
 		children:   make(map[roll_fields.ID]childRU),
 		labeler:    labeler,
 		rcSelector: rcSelector,
-		alerter:    alerter,
 	}
 }
 

--- a/pkg/roll/farm.go
+++ b/pkg/roll/farm.go
@@ -38,12 +38,8 @@ type UpdateFactory struct {
 	Scheduler     scheduler.Scheduler
 }
 
-func (f UpdateFactory) New(u roll_fields.Update, l logging.Logger, session consul.Session, alerter alerting.Alerter) Update {
-	if alerter == nil {
-		alerter = alerting.NewNop()
-	}
-
-	return NewUpdate(u, f.Store, f.RCStore, f.HealthChecker, f.Labeler, f.Scheduler, l, session, alerter)
+func (f UpdateFactory) New(u roll_fields.Update, l logging.Logger, session consul.Session, _ alerting.Alerter) Update {
+	return NewUpdate(u, f.Store, f.RCStore, f.HealthChecker, f.Labeler, l, session)
 }
 
 type RCGetter interface {

--- a/pkg/roll/farm.go
+++ b/pkg/roll/farm.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/rcrowley/go-metrics"
 
-	"github.com/square/p2/pkg/alerting"
 	"github.com/square/p2/pkg/health/checker"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
@@ -85,7 +84,6 @@ func NewFarm(
 	logger logging.Logger,
 	labeler rc.Labeler,
 	rcSelector klabels.Selector,
-	_ alerting.Alerter,
 ) *Farm {
 	return &Farm{
 		factory:    factory,

--- a/pkg/roll/farm.go
+++ b/pkg/roll/farm.go
@@ -27,7 +27,7 @@ import (
 )
 
 type Factory interface {
-	New(roll_fields.Update, logging.Logger, consul.Session, alerting.Alerter) Update
+	New(roll_fields.Update, logging.Logger, consul.Session) Update
 }
 
 type UpdateFactory struct {
@@ -38,7 +38,7 @@ type UpdateFactory struct {
 	Scheduler     scheduler.Scheduler
 }
 
-func (f UpdateFactory) New(u roll_fields.Update, l logging.Logger, session consul.Session, _ alerting.Alerter) Update {
+func (f UpdateFactory) New(u roll_fields.Update, l logging.Logger, session consul.Session) Update {
 	return NewUpdate(u, f.Store, f.RCStore, f.HealthChecker, f.Labeler, l, session)
 }
 
@@ -211,7 +211,7 @@ START_LOOP:
 				// at this point the ru is ours, time to spin it up
 				rlLogger.WithField("new_rc", rlField.ID()).Infof("Acquired lock on update %s -> %s, spawning", rlField.OldRC, rlField.ID())
 
-				newChild := rlf.factory.New(rlField, rlLogger, rlf.session, rlf.alerter)
+				newChild := rlf.factory.New(rlField, rlLogger, rlf.session)
 				childQuit := make(chan struct{})
 				rlf.children[rlField.ID()] = childRU{
 					ru:       newChild,

--- a/pkg/roll/farm.go
+++ b/pkg/roll/farm.go
@@ -16,7 +16,6 @@ import (
 	"github.com/square/p2/pkg/rc"
 	"github.com/square/p2/pkg/rc/fields"
 	roll_fields "github.com/square/p2/pkg/roll/fields"
-	"github.com/square/p2/pkg/scheduler"
 	"github.com/square/p2/pkg/store/consul"
 	"github.com/square/p2/pkg/store/consul/consulutil"
 	"github.com/square/p2/pkg/store/consul/rcstore"
@@ -35,7 +34,6 @@ type UpdateFactory struct {
 	RCStore       rcstore.Store
 	HealthChecker checker.ConsulHealthChecker
 	Labeler       rc.Labeler
-	Scheduler     scheduler.Scheduler
 }
 
 func (f UpdateFactory) New(u roll_fields.Update, l logging.Logger, session consul.Session) Update {

--- a/pkg/roll/run_update.go
+++ b/pkg/roll/run_update.go
@@ -38,10 +38,8 @@ type update struct {
 	rcs     rcstore.Store
 	hcheck  checker.ConsulHealthChecker
 	labeler rc.Labeler
-	sched   scheduler.Scheduler
 
-	logger  logging.Logger
-	alerter alerting.Alerter
+	logger logging.Logger
 
 	session consul.Session
 
@@ -59,15 +57,11 @@ func NewUpdate(
 	rcs rcstore.Store,
 	hcheck checker.ConsulHealthChecker,
 	labeler rc.Labeler,
-	sched scheduler.Scheduler,
+	_ scheduler.Scheduler,
 	logger logging.Logger,
 	session consul.Session,
-	alerter alerting.Alerter,
+	_ alerting.Alerter,
 ) Update {
-	if alerter == nil {
-		alerter = alerting.NewNop()
-	}
-
 	logger = logger.SubLogger(logrus.Fields{
 		"desired_replicas": f.DesiredReplicas,
 		"minimum_replicas": f.MinimumReplicas,
@@ -78,10 +72,8 @@ func NewUpdate(
 		rcs:     rcs,
 		hcheck:  hcheck,
 		labeler: labeler,
-		sched:   sched,
 		logger:  logger,
 		session: session,
-		alerter: alerter,
 	}
 }
 

--- a/pkg/roll/run_update.go
+++ b/pkg/roll/run_update.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 
-	"github.com/square/p2/pkg/alerting"
 	"github.com/square/p2/pkg/health"
 	"github.com/square/p2/pkg/health/checker"
 	"github.com/square/p2/pkg/logging"
@@ -16,7 +15,6 @@ import (
 	"github.com/square/p2/pkg/rc"
 	rcf "github.com/square/p2/pkg/rc/fields"
 	"github.com/square/p2/pkg/roll/fields"
-	"github.com/square/p2/pkg/scheduler"
 	"github.com/square/p2/pkg/store/consul"
 	"github.com/square/p2/pkg/store/consul/consulutil"
 	"github.com/square/p2/pkg/store/consul/rcstore"
@@ -57,10 +55,8 @@ func NewUpdate(
 	rcs rcstore.Store,
 	hcheck checker.ConsulHealthChecker,
 	labeler rc.Labeler,
-	_ scheduler.Scheduler,
 	logger logging.Logger,
 	session consul.Session,
-	_ alerting.Alerter,
 ) Update {
 	logger = logger.SubLogger(logrus.Fields{
 		"desired_replicas": f.DesiredReplicas,

--- a/pkg/roll/update_test.go
+++ b/pkg/roll/update_test.go
@@ -194,10 +194,8 @@ func TestLockRCs(t *testing.T) {
 		rcstore.NewFake(),
 		nil,
 		nil,
-		nil,
 		logging.DefaultLogger,
 		session,
-		nil,
 	).(*update)
 	err = update.lockRCs(make(<-chan struct{}))
 	Assert(t).IsNil(err, "should not have erred locking RCs")


### PR DESCRIPTION
The roll farm/factory took some alerter and scheduler args for the sole purpose of passing them to `rc.New`. However, with https://github.com/square/p2/pull/792/commits/59c5525c8bc80dd0d33780662904460223301d4c in #792, we no longer construct an RC, so we don't need these arguments. This PR cleans them up.