### PR TITLE
Set the "last" symlink even if there is an error stopping a launchable.

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -97,15 +97,16 @@ func (hl *Launchable) Disable() error {
 }
 
 func (hl *Launchable) Stop(serviceBuilder *runit.ServiceBuilder, sv runit.SV) error {
-	// probably want to do something with output at some point
-	err := hl.stop(serviceBuilder, sv)
-	if err != nil {
-		return launch.StopError{Inner: err}
+	stopErr := hl.stop(serviceBuilder, sv)
+	// We still want to update the "last" symlink even if there was an
+	// error during stop()
+	makeLastErr := hl.makeLast()
+	if stopErr != nil {
+		// if there was a stop error AND a makeLast() error, we want to report the stop error
+		return launch.StopError{Inner: stopErr}
 	}
-
-	err = hl.makeLast()
-	if err != nil {
-		return err
+	if makeLastErr != nil {
+		return makeLastErr
 	}
 
 	return nil


### PR DESCRIPTION
The "last" symlink points to the launchable version that was previously
running. It is used by hoist launchable pruning code to preserve the
last launchable to make sure that rolling back a pod doesn't require
re-downloading the launchable from the network.

A launchable which has a stop error such as missing entry points (which
is sometimes the desired state for a pod) was not having its last
symlink updated, and therefore a very old launchable install was being
preserved by pruning code.