### PR TITLE
Ask for confirmation before changing RC replica count in p2-rctl.

### DIFF
--- a/integration/single-node-slug-deploy/check.go
+++ b/integration/single-node-slug-deploy/check.go
@@ -763,7 +763,7 @@ func createHelloReplicationController(dir string) (fields.ID, error) {
 		return fields.ID(""), fmt.Errorf("Couldn't read RC ID out of p2-rctl invocation result: %v", err)
 	}
 
-	output, err := exec.Command("p2-rctl", "set-replicas", rctlOut.ID, "1").CombinedOutput()
+	output, err := exec.Command("p2-rctl", "set-replicas", rctlOut.ID, "1", "-y").CombinedOutput()
 	if err != nil {
 		fmt.Println(string(output))
 		return "", err


### PR DESCRIPTION
The p2-rctl set-replicas command is very useful and powerfull, however
it's easy to make a typo and cause a problem. If the replica count being
set is lower than the currently set one, it will cause pod
uninstallations.

This commit adds a confirmation prompt which will give a user time to
confirm that the count they typed in was in fact what they wanted.