### PR TITLE
Fix the format of log output of the rolling update farm.

### DIFF
--- a/pkg/roll/run_update.go
+++ b/pkg/roll/run_update.go
@@ -189,7 +189,7 @@ func (u *update) rollLoop(podID types.PodID, hChecks <-chan map[types.NodeName]h
 			newNodes, err := u.countHealthy(u.NewRC, checks)
 			if err != nil {
 				u.logger.WithErrorAndFields(err, logrus.Fields{
-					"new": newNodes,
+					"new": newNodes.ToString(),
 				}).Errorln("Could not count nodes on new RC")
 				break
 			}
@@ -203,14 +203,14 @@ func (u *update) rollLoop(podID types.PodID, hChecks <-chan map[types.NodeName]h
 
 			if nextAction := u.shouldStop(oldNodes, newNodes); nextAction == ruShouldTerminate {
 				u.logger.WithFields(logrus.Fields{
-					"old": oldNodes,
-					"new": newNodes,
+					"old": oldNodes.ToString(),
+					"new": newNodes.ToString(),
 				}).Debugln("Upgrade complete")
 				return true
 			} else if nextAction == ruShouldBlock {
 				u.logger.WithFields(logrus.Fields{
-					"old": oldNodes,
-					"new": newNodes,
+					"old": oldNodes.ToString(),
+					"new": newNodes.ToString(),
 				}).Debugln("Upgrade almost complete, blocking for more healthy new nodes")
 				break
 			}
@@ -239,8 +239,8 @@ func (u *update) rollLoop(podID types.PodID, hChecks <-chan map[types.NodeName]h
 				}
 
 				u.logger.WithFields(logrus.Fields{
-					"old":        oldNodes,
-					"new":        newNodes,
+					"old":        oldNodes.ToString(),
+					"new":        newNodes.ToString(),
 					"nextRemove": nextRemove,
 					"nextAdd":    nextAdd,
 				}).Infof("Adding %d new nodes and removing %d old nodes", nextAdd, nextRemove)
@@ -260,8 +260,8 @@ func (u *update) rollLoop(podID types.PodID, hChecks <-chan map[types.NodeName]h
 				}
 			} else {
 				u.logger.WithFields(logrus.Fields{
-					"old": oldNodes,
-					"new": newNodes,
+					"old": oldNodes.ToString(),
+					"new": newNodes.ToString(),
 				}).Debugln("Blocking for more healthy nodes")
 			}
 		}
@@ -413,6 +413,10 @@ type rcNodeCounts struct {
 	Healthy   int // the number of real nodes that are healthy
 	Unhealthy int // the number of real nodes that are unhealthy
 	Unknown   int // the number of real nodes that are of unknown health
+}
+
+func (r rcNodeCounts) ToString() string {
+	return fmt.Sprintf("%+v", r)
 }
 
 func (u *update) countHealthy(id rcf.ID, checks map[types.NodeName]health.Result) (rcNodeCounts, error) {

--- a/pkg/roll/update_test.go
+++ b/pkg/roll/update_test.go
@@ -792,7 +792,7 @@ func transferNode(node types.NodeName, manifest manifest.Manifest, upd update) e
 func assertRCUpdates(t *testing.T, rc *rc_fields.RC, upd <-chan struct{}, expect int, desc string) {
 	select {
 	case <-upd:
-	case <-time.After(1 * time.Second):
+	case <-time.After(3 * time.Second):
 		t.Fatalf("%s didn't update after one second, was waiting for value %d", desc, expect)
 	}
 	if rc.ReplicasDesired != expect {


### PR DESCRIPTION
When the logrus logger format was changed from JSON to text format, an
unintended side effect was that struct field names are no longer
printed. This commit fixes a pain point where the rolling update logger
would print structs with no field names.