### PR TITLE
Add TransferReplicaCounts function to consul RC store.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ install:
   - go get github.com/tools/godep
   - go get github.com/kisielk/errcheck
   - rake install
-  - wget https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_linux_amd64.zip
-  - unzip consul_0.5.2_linux_amd64.zip
+  - wget https://releases.hashicorp.com/consul/0.7.1/consul_0.7.1_linux_amd64.zip
+  - unzip consul_0.7.1_linux_amd64.zip
   - sudo mv consul /usr/bin/
 
 script:

--- a/integration/common-provision.sh
+++ b/integration/common-provision.sh
@@ -46,5 +46,6 @@ cp $GOPATH/bin/p2-exec /usr/local/bin
 
 # Install P2 test dependencies
 sudo yum -y --nogpgcheck localinstall $GOPATH/src/github.com/square/p2/integration/test-deps/*rpm
+sudo yum -y install unzip
 sudo mkdir -p /etc/servicebuilder.d
 sudo mkdir -p /var/service-stage

--- a/pkg/store/consul/consulutil/clients.go
+++ b/pkg/store/consul/consulutil/clients.go
@@ -24,6 +24,7 @@ type ConsulKVClient interface {
 	List(prefix string, q *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error)
 	Put(pair *api.KVPair, w *api.WriteOptions) (*api.WriteMeta, error)
 	Release(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error)
+	Txn(txn api.KVTxnOps, q *api.QueryOptions) (bool, *api.KVTxnResponse, *api.QueryMeta, error)
 }
 
 // Specifies the functionality provided by the *api.Session struct for managing

--- a/pkg/store/consul/consulutil/fake_kv.go
+++ b/pkg/store/consul/consulutil/fake_kv.go
@@ -130,3 +130,6 @@ func (f *FakeKV) DeleteCAS(pair *api.KVPair, opts *api.WriteOptions) (bool, *api
 func (f *FakeKV) Release(p *api.KVPair, q *api.WriteOptions) (bool, *api.WriteMeta, error) {
 	return false, nil, fmt.Errorf("not yet implemented in FakeKV")
 }
+func (f *FakeKV) Txn(txn api.KVTxnOps, q *api.QueryOptions) (bool, *api.KVTxnResponse, *api.QueryMeta, error) {
+	return false, nil, nil, fmt.Errorf("not yet implemented in FakeKV")
+}

--- a/pkg/store/consul/consulutil/watch.go
+++ b/pkg/store/consul/consulutil/watch.go
@@ -57,6 +57,7 @@ func WatchKeys(
 				}:
 				}
 				timer.Reset(2*time.Second + pause) // back off a little
+				continue
 			}
 
 			// This might happen if a watch expires on a node that was stale for a

--- a/pkg/store/consul/rcstore/fake_store.go
+++ b/pkg/store/consul/rcstore/fake_store.go
@@ -231,3 +231,7 @@ func (s *fakeStore) LockForUpdateCreation(rcID fields.ID, session consul.Session
 	key := fmt.Sprintf("%s/%s", rcID, "update_creation_lock")
 	return session.Lock(key)
 }
+
+func (s *fakeStore) TransferReplicaCounts(toRCID fields.ID, replicasToAdd int, fromRCID fields.ID, replicasToRemove int) error {
+	return util.Errorf("TransferReplicaCounts not implemented in the fake store")
+}

--- a/pkg/store/consul/rcstore/store.go
+++ b/pkg/store/consul/rcstore/store.go
@@ -76,6 +76,8 @@ type Store interface {
 	// that no two RUs are admitted that operate on the same RCs, which is
 	// accomplished by locking them first
 	LockForUpdateCreation(rcID fields.ID, session consul.Session) (consulutil.Unlocker, error)
+
+	TransferReplicaCounts(toRCID fields.ID, replicasToAdd int, fromRCID fields.ID, replicasToRemove int) error
 }
 
 func IsNotExist(err error) bool {


### PR DESCRIPTION
TransferReplicaCounts() "transfers" a number of replicas from one RC to
another utilizing consul's transaction functionality. This allows
invariants to be maintained about the total of the replica counts of two
RCs even across consul server failures.

An integration test was added to test this functionality since it is
hard to implement a fake consul server that has the full transaction
capability.