### PR TITLE
Make rolling update loop use rcstore's TransferReplicaCounts()

### DIFF
--- a/pkg/store/consul/rcstore/fake_store.go
+++ b/pkg/store/consul/rcstore/fake_store.go
@@ -233,5 +233,15 @@ func (s *fakeStore) LockForUpdateCreation(rcID fields.ID, session consul.Session
 }
 
 func (s *fakeStore) TransferReplicaCounts(toRCID fields.ID, replicasToAdd int, fromRCID fields.ID, replicasToRemove int) error {
-	return util.Errorf("TransferReplicaCounts not implemented in the fake store")
+	err := s.AddDesiredReplicas(toRCID, replicasToAdd)
+	if err != nil {
+		return err
+	}
+
+	err = s.AddDesiredReplicas(fromRCID, -replicasToRemove)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
This makes the updating of RC counts during a rolling update
transactional which means if the p2-master server or consul cluster
faults the invariant of RC count totals will not be violated.

This change notably removes the old check-and-set functionality on
updating RCs, but given that the RC mutation locks are held during a
rolling update we have reasonable confidence that the RC counts were not
mutated underneath the rolling update loop.