### PR TITLE
Make grpc WatchMatches() implementation retry after connection loss.

### DIFF
--- a/bin/grpc/clients/podstore/podstore.go
+++ b/bin/grpc/clients/podstore/podstore.go
@@ -123,7 +123,7 @@ func watchStatus(client client.Client, logger logging.Logger) {
 		}
 
 		if val.Error != nil {
-			logger.Fatal(val.Error)
+			logger.WithError(val.Error).Infoln("status watcher encountered an error")
 		}
 
 		bytes, err := json.Marshal(val)


### PR DESCRIPTION
The raw consul applicator implementation of WatchMatches() continually
makes HTTP requests to consul to fetch the latest labels and then
applies the selector in question. This scheme is tolerant of broken or
failed connections to the server due to retries.

The gRPC implementation did not preserve this self-healing behavior if
the connection to the server dies: it would make one RPC call initially
and then loop reading values fromt he stream. This commit retries the
RPC call if the stream is broken for any reason.