### PR TITLE
Add a new -w/--write flag to p2-norm

### DIFF
--- a/bin/p2-norm/main.go
+++ b/bin/p2-norm/main.go
@@ -32,10 +32,10 @@ func main() {
 	var err error
 	output := os.Stdout
 	if *filename == "" || *filename == "-" {
-		data, err = ioutil.ReadAll(os.Stdin)
 		if *write {
 			logger.Fatalln("--write is incompatible with reading from stdin")
 		}
+		data, err = ioutil.ReadAll(os.Stdin)
 	} else {
 		data, err = ioutil.ReadFile(*filename)
 		if err == nil && *write {

--- a/bin/p2-norm/main.go
+++ b/bin/p2-norm/main.go
@@ -21,6 +21,7 @@ var (
 	progName = filepath.Base(os.Args[0])
 	app      = kingpin.New(progName, helpMessage)
 	filename = app.Arg("filename", `Pod manifest file to normalize. Use "-" for stdin.`).String()
+	write    = app.Flag("write", "write result to source file instead of stdout").Short('w').Bool()
 )
 
 func main() {
@@ -29,10 +30,17 @@ func main() {
 
 	var data []byte
 	var err error
+	output := os.Stdout
 	if *filename == "" || *filename == "-" {
 		data, err = ioutil.ReadAll(os.Stdin)
+		if *write {
+			logger.Fatalln("--write is incompatible with reading from stdin")
+		}
 	} else {
 		data, err = ioutil.ReadFile(*filename)
+		if err == nil && *write {
+			output, err = os.OpenFile(*filename, os.O_RDWR, 0)
+		}
 	}
 	if err != nil {
 		logger.Fatalln(err)
@@ -42,7 +50,7 @@ func main() {
 	if err != nil {
 		logger.Fatalln(err)
 	}
-	err = m.GetBuilder().GetManifest().Write(os.Stdout)
+	err = m.GetBuilder().GetManifest().Write(output)
 	if err != nil {
 		logger.Fatalln(err)
 	}


### PR DESCRIPTION
This causes the output to be written to the file it was read from.  An error is
returned if p2-norm is reading from stdin and is passed -w / --write