### PR TITLE
ds: spawn child when acquiring lock on updated DS

### DIFF
--- a/pkg/ds/farm_test.go
+++ b/pkg/ds/farm_test.go
@@ -1007,6 +1007,96 @@ func TestRelock(t *testing.T) {
 	assertLabel("node3", "first farm quit")
 }
 
+func TestDieAndUpdate(t *testing.T) {
+	retryInterval = testFarmRetryInterval
+
+	dsStore := dsstoretest.NewFake()
+	consulStore := consultest.NewFakePodStore(make(map[consultest.FakePodStoreKey]manifest.Manifest), make(map[string]consul.WatchResult))
+	applicator := labels.NewFakeApplicator()
+
+	preparer := consultest.NewFakePreparer(consulStore, logging.DefaultLogger)
+	preparer.Enable()
+	defer preparer.Disable()
+
+	session := consultest.NewSession()
+
+	allNodes := []types.NodeName{"node1", "node2", "node3"}
+	happyHealthChecker := fake_checker.HappyHealthChecker(allNodes)
+
+	mkFarm := func(logName string) (chan<- struct{}, <-chan struct{}) {
+		farm := &Farm{
+			dsStore:   dsStore,
+			dsLocker:  dsStore,
+			store:     consulStore,
+			scheduler: scheduler.NewApplicatorScheduler(applicator),
+			labeler:   applicator,
+			watcher:   applicator,
+			children:  make(map[ds_fields.ID]*childDS),
+			session:   session,
+			logger: logging.DefaultLogger.SubLogger(logrus.Fields{
+				"farm": logName,
+			}),
+			alerter:       alerting.NewNop(),
+			healthChecker: &happyHealthChecker,
+		}
+		quitCh := make(chan struct{})
+		farmHasQuit := make(chan struct{})
+		go func() {
+			go farm.cleanupDaemonSetPods(quitCh)
+			farm.mainLoop(quitCh)
+			close(farmHasQuit)
+		}()
+
+		return quitCh, farmHasQuit
+	}
+
+	firstQuitCh, farmHasQuit := mkFarm("firstUpdateCrash")
+
+	mkds := func(zone string) ds_fields.DaemonSet {
+		podID := types.PodID("testPod")
+		minHealth := 0
+		clusterName := ds_fields.ClusterName("some_name")
+
+		manifestBuilder := manifest.NewBuilder()
+		manifestBuilder.SetID(podID)
+		podManifest := manifestBuilder.GetManifest()
+
+		nodeSelector := klabels.Everything().Add(pc_fields.AvailabilityZoneLabel, klabels.EqualsOperator, []string{zone})
+		dsData, err := dsStore.Create(podManifest, minHealth, clusterName, nodeSelector, podID, replicationTimeout)
+		Assert(t).IsNil(err, "Expected no error creating request")
+		return dsData
+	}
+
+	dsData := mkds("az1")
+
+	assertLabel := func(node, desc string) {
+		applicator.SetLabel(labels.NODE, node, pc_fields.AvailabilityZoneLabel, "az1")
+		labeled, err := waitForPodLabel(applicator, true, node+"/testPod")
+		Assert(t).IsNil(err, "Expected pod to have a dsID label when "+desc)
+		dsID := labeled.Labels.Get(DSIDLabel)
+		Assert(t).AreEqual(dsData.ID.String(), dsID, "Unexpected dsID labeled when "+desc)
+	}
+
+	assertLabel("node1", "one farm")
+
+	secondQuitCh, _ := mkFarm("secondUpdateCrash")
+	defer close(secondQuitCh)
+
+	assertLabel("node2", "second farm created, first farm still active")
+
+	close(firstQuitCh)
+	<-farmHasQuit
+
+	_, err := dsStore.MutateDS(dsData.ID, func(ds ds_fields.DaemonSet) (ds_fields.DaemonSet, error) {
+		ds.Name = ds_fields.ClusterName("name_has_changed")
+		return ds, nil
+	})
+	Assert(t).IsNil(err, "Expected no error changing name of daemon set")
+
+	// After the first farm quits, the second farm should take over.
+	assertLabel("node3", "first farm quit")
+}
+
 func waitForPodLabel(applicator labels.Applicator, hasDSIDLabel bool, podPath string) (labels.Labeled, error) {
 	var labeled labels.Labeled
 	var err error


### PR DESCRIPTION
If we have just acquired a lock on a daemon set, necessarily it is not
one of our children. Therefore, any attempt to send on its updated
channel will trigger a nil dereference. This code has never worked.

Attached test demonstrates, though "Attempt to acquire unchanged daemon
sets" of #813 alleviates the problem slightly. With #813, the attached
test only sometimes dereferences nil because sometimes the lock is still
held when the second farm attempts to access and the daemon set moves to
the "unchanged" or "same" category.

A similar mistake was fixed in #753.