### PR TITLE
Increase safety of rolling update loop via TransferReplicaCounts().

### DIFF
--- a/integration/single-node-slug-deploy/check.go
+++ b/integration/single-node-slug-deploy/check.go
@@ -434,7 +434,19 @@ func verifyTransferReplicas(errCh chan<- error, tempdir string, logger logging.L
 		return
 	}
 
-	err = rcStore.TransferReplicaCounts(toRC.ID, 1, fromRC.ID, 2)
+	replicasToAdd := 1
+	replicasToRemove := 2
+	startingFromReplicas := 4
+	startingToReplicas := 0
+	transferReq := rcstore.TransferReplicaCountsRequest{
+		ToRCID:               toRC.ID,
+		ReplicasToAdd:        &replicasToAdd,
+		FromRCID:             fromRC.ID,
+		ReplicasToRemove:     &replicasToRemove,
+		StartingFromReplicas: &startingFromReplicas,
+		StartingToReplicas:   &startingToReplicas,
+	}
+	err = rcStore.TransferReplicaCounts(transferReq)
 	if err != nil {
 		errCh <- util.Errorf("failed to transfer replicas from one RC to another: %s", err)
 		return

--- a/pkg/store/consul/rcstore/fake_store.go
+++ b/pkg/store/consul/rcstore/fake_store.go
@@ -230,13 +230,13 @@ func (s *fakeStore) LockForUpdateCreation(rcID fields.ID, session consul.Session
 	return session.Lock(key)
 }
 
-func (s *fakeStore) TransferReplicaCounts(toRCID fields.ID, replicasToAdd int, fromRCID fields.ID, replicasToRemove int) error {
-	err := s.AddDesiredReplicas(toRCID, replicasToAdd)
+func (s *fakeStore) TransferReplicaCounts(req TransferReplicaCountsRequest) error {
+	err := s.AddDesiredReplicas(req.ToRCID, *req.ReplicasToAdd)
 	if err != nil {
 		return err
 	}
 
-	err = s.AddDesiredReplicas(fromRCID, -replicasToRemove)
+	err = s.AddDesiredReplicas(req.FromRCID, -*req.ReplicasToRemove)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Commit feb411da55cd07df531e9614a92d12cfccaaa30d changed the rolling
update loop to batch its RC count changes into a single consul
transaction. However, there was a regression in safety introduced in
that commit which is addressed by this one.

The old code would make separate calls of CASDesiredReplicas for each
RC. That function fetches the RC, ensures that the replica count matches
one passed to the function call, and only then does a CAS operation on
the RC. This prevents a situation where the rolling update loop computes
a RC count change based on a previous count that might have changed by
the time the change is applied.

This commit makes the TransferReplicaCounts() function take similar
parameters: StartingToReplicas and StartingFromReplicas. The function
will not apply the requested update unless the counts on the ToRC and
FromRC respectively match the passed values.