### PR TITLE
ds: Attempt to acquire unchanged daemon sets

### DIFF
--- a/pkg/store/consul/consulutil/watch.go
+++ b/pkg/store/consul/consulutil/watch.go
@@ -364,6 +364,7 @@ type WatchedChanges struct {
 	Created api.KVPairs
 	Updated api.KVPairs
 	Deleted api.KVPairs
+	Same    api.KVPairs
 }
 
 // WatchDiff watches a Consul prefix for changes and categorizes them
@@ -463,6 +464,7 @@ func WatchDiff(
 					if _, ok := mapCopy[val.Key]; ok {
 						delete(mapCopy, val.Key)
 					}
+					outgoingChanges.Same = append(outgoingChanges.Same, val)
 				}
 			}
 			// If it was not observed, then it was a delete

--- a/pkg/store/consul/dsstore/consul_store.go
+++ b/pkg/store/consul/dsstore/consul_store.go
@@ -256,6 +256,7 @@ type WatchedDaemonSets struct {
 	Created []*fields.DaemonSet
 	Updated []*fields.DaemonSet
 	Deleted []*fields.DaemonSet
+	Same    []*fields.DaemonSet
 	Err     error
 }
 
@@ -311,6 +312,10 @@ func (s *ConsulStore) Watch(quitCh <-chan struct{}) <-chan WatchedDaemonSets {
 			if err != nil {
 				outgoingDSs.Err = util.Errorf("Watch create error: %s; ", err)
 			}
+			sameDSs, err := kvpsToDSs(kvps.Same)
+			if err != nil {
+				outgoingDSs.Err = util.Errorf("%sWatch same error: %s; ", outgoingDSs.Err, err)
+			}
 			updatedDSs, err := kvpsToDSs(kvps.Updated)
 			if err != nil {
 				outgoingDSs.Err = util.Errorf("%sWatch update error: %s; ", outgoingDSs.Err, err)
@@ -335,6 +340,10 @@ func (s *ConsulStore) Watch(quitCh <-chan struct{}) <-chan WatchedDaemonSets {
 				// and should not be used outside of this block
 				dsCopy := ds
 				outgoingDSs.Created = append(outgoingDSs.Created, &dsCopy)
+			}
+			for _, ds := range sameDSs {
+				dsCopy := ds
+				outgoingDSs.Same = append(outgoingDSs.Same, &dsCopy)
 			}
 			for _, ds := range updatedDSs {
 				dsCopy := ds

--- a/pkg/store/consul/dsstore/dsstoretest/fake_dsstore.go
+++ b/pkg/store/consul/dsstore/dsstoretest/fake_dsstore.go
@@ -250,8 +250,10 @@ func (s *FakeDSStore) watchDiffDaemonSets(inCh <-chan []fields.DaemonSet, quitCh
 					// If they are not equal, update them
 					outgoingChanges.Updated = append(outgoingChanges.Updated, &copyDS)
 					oldDSs[id] = copyDS
+				} else {
+					// They're the same.
+					outgoingChanges.Same = append(outgoingChanges.Same, &copyDS)
 				}
-				// Otherwise no changes need to be made
 			}
 
 			for id, ds := range oldDSs {


### PR DESCRIPTION
Without this change, if a farm crashes, no other farm will pick up the
daemon sets managed by the former farm.

This means that if a daemon set gains a new node, nothing will schedule
onto the new node.

Attached test fails without attached code change.

Note that this is a very low-effort way to effect this change. The code
could be restructured to look more like an RC watch and get rid of
WatchDiff, but this requires more time to work with the code.