### PR TITLE
Remove replication controller watchers from roll farm.

### DIFF
--- a/bin/p2-rctl/main.go
+++ b/bin/p2-rctl/main.go
@@ -121,13 +121,10 @@ func main() {
 		baseClient: client,
 		// rcStore copied so many times right now but might not all be
 		// the same implementation of these various interfaces in
-		// the future. Also rcWatcher isn't even used it is simply
-		// used by the roll farm to initialie an RC for a computation
-		// that probably doesn't need to be defined on RC.
+		// the future.
 		rcs:         rcStore,
 		rollRCStore: rcStore,
 		rcLocker:    rcStore,
-		rcWatcher:   rcStore,
 		rls:         rollstore.NewConsul(client, labeler, nil),
 		consuls:     consul.NewConsulStore(client),
 		labeler:     labeler,
@@ -360,7 +357,6 @@ func (r rctlParams) RollingUpdate(oldID, newID string, want, need int) {
 			r.consuls,
 			r.rcLocker,
 			r.rollRCStore,
-			r.rcWatcher,
 			r.hcheck,
 			r.labeler,
 			r.logger,

--- a/pkg/roll/farm.go
+++ b/pkg/roll/farm.go
@@ -32,7 +32,6 @@ type UpdateFactory struct {
 	Store         Store
 	RCLocker      ReplicationControllerLocker
 	RCStore       ReplicationControllerStore
-	RCWatcher     rc.ReplicationControllerWatcher
 	HealthChecker checker.ConsulHealthChecker
 	Labeler       rc.Labeler
 	WatchDelay    time.Duration
@@ -44,7 +43,6 @@ func (f UpdateFactory) New(u roll_fields.Update, l logging.Logger, session consu
 		f.Store,
 		f.RCLocker,
 		f.RCStore,
-		f.RCWatcher,
 		f.HealthChecker,
 		f.Labeler,
 		l,

--- a/pkg/roll/run_update.go
+++ b/pkg/roll/run_update.go
@@ -45,12 +45,11 @@ type ReplicationControllerStore interface {
 type update struct {
 	fields.Update
 
-	consuls   Store
-	rcStore   ReplicationControllerStore
-	rcLocker  ReplicationControllerLocker
-	rcWatcher rc.ReplicationControllerWatcher
-	hcheck    checker.ConsulHealthChecker
-	labeler   rc.Labeler
+	consuls  Store
+	rcStore  ReplicationControllerStore
+	rcLocker ReplicationControllerLocker
+	hcheck   checker.ConsulHealthChecker
+	labeler  rc.Labeler
 
 	logger logging.Logger
 
@@ -75,7 +74,6 @@ func NewUpdate(
 	consuls Store,
 	rcLocker ReplicationControllerLocker,
 	rcStore ReplicationControllerStore,
-	rcWatcher rc.ReplicationControllerWatcher,
 	hcheck checker.ConsulHealthChecker,
 	labeler rc.Labeler,
 	logger logging.Logger,


### PR DESCRIPTION
As a result of splitting up the giant preemptive *.Store interfaces, it
became clear that the rolling update store was passing a store that
watches RCs just to instantiate a ReplicationController struct which
wouldn't even use that parameter.

Now that it is completely unused, we can delete it from the roll farm
completely.