### PR TITLE
replication: Stop health watch when done

### DIFF
--- a/pkg/replication/replication.go
+++ b/pkg/replication/replication.go
@@ -239,6 +239,7 @@ func (r *replication) Enact() {
 	nodeQueue := make(chan types.NodeName)
 
 	aggregateHealth := AggregateHealth(r.manifest.ID(), r.health, r.healthWatchDelay)
+	defer aggregateHealth.Stop()
 	// this loop multiplexes the node queue across some goroutines
 
 	var updatePool sync.WaitGroup


### PR DESCRIPTION
The AggregateHealth was never being stopped. Luckily, since nobody reads
off the channel, it blocks sending on the channel. So we leak
goroutines, but at least it's not as bad as continually hammering
Consul.

This is safe: The only use of aggregateHealth is as an argument to
updateOne, and updatePool will stop the function from returning (and
Stopping the aggregateHealth) until all updateOne have finished.

First discovered in:
https://github.com/square/p2/pull/738#discussion_r98260867