### PR TITLE
Add constructor for the roll.UpdateFactory type.

### DIFF
--- a/pkg/roll/farm.go
+++ b/pkg/roll/farm.go
@@ -37,6 +37,24 @@ type UpdateFactory struct {
 	WatchDelay    time.Duration
 }
 
+func NewUpdateFactory(
+	store Store,
+	rcLocker ReplicationControllerLocker,
+	rcStore ReplicationControllerStore,
+	healthChecker checker.ConsulHealthChecker,
+	labeler rc.Labeler,
+	watchDelay time.Duration,
+) UpdateFactory {
+	return UpdateFactory{
+		Store:         store,
+		RCLocker:      rcLocker,
+		RCStore:       rcStore,
+		HealthChecker: healthChecker,
+		Labeler:       labeler,
+		WatchDelay:    watchDelay,
+	}
+}
+
 func (f UpdateFactory) New(u roll_fields.Update, l logging.Logger, session consul.Session) Update {
 	return NewUpdate(
 		u,


### PR DESCRIPTION
Using a constructor is preferable in many cases to manually creating
structs because it makes the compiler complain if the constructor adds
or removes a field that is being passed.