### PR TITLE
turn off fail fast call option for gRPC retries

### DIFF
--- a/pkg/grpc/labelstore/client/client.go
+++ b/pkg/grpc/labelstore/client/client.go
@@ -77,7 +77,7 @@ func (c Client) WatchMatches(selector klabels.Selector, labelType labels.Type, q
 					watchClient, err = c.labelStoreClient.WatchMatches(innerCtx, &label_protos.WatchMatchesRequest{
 						LabelType: labelTypeToProtoLabelType(labelType),
 						Selector:  selector.String(),
-					})
+					}, grpc.FailFast(false))
 					if err != nil {
 						c.logger.WithError(err).Errorln("could not restart WatchMatches RPC, will retry")
 						innerCancel()

--- a/pkg/grpc/podstore/client/client.go
+++ b/pkg/grpc/podstore/client/client.go
@@ -102,7 +102,7 @@ func (c Client) WatchStatus(ctx context.Context, podUniqueKey types.PodUniqueKey
 						PodUniqueKey:    podUniqueKey.String(),
 						StatusNamespace: consul.PreparerPodStatusNamespace.String(),
 						WaitForExists:   waitForExists,
-					})
+					}, grpc.FailFast(false))
 					if err != nil {
 						innerCancel()
 						select {


### PR DESCRIPTION
A common pattern in P2 code is to call a function that returns a channel
of results, the values on which are the result of calls to Consul.
Errors connecting to consul are typically swallowed and retried.

When providing a gRPC implementation of this same interface, a similar
approach was taken where an error making the gRPC call results in
continuous retrying forever. In the event of a broken TCP connection,
these RPC calls would fail immediately, resulting in a lot of log
messages.

This commit disables the "fail fast" call option when retrying an rpc,
which means that the call will wait until a TCP connection is ready
before returning. This will reduce the amount of logging when the TCP
connection breaks, but doesn't simplify the code because there are still
certain errors that could occur, so a retry loop is still necessary.