### PR TITLE
Parallelize sending updates to each watcher in consul aggregator.

### DIFF
--- a/pkg/labels/consul_aggregator_test.go
+++ b/pkg/labels/consul_aggregator_test.go
@@ -28,7 +28,10 @@ func fakeLabeledPods() map[string][]byte {
 func TestTwoClients(t *testing.T) {
 	alterAggregationTime(100 * time.Millisecond)
 
-	fakeKV := &fakeLabelStore{fakeLabeledPods(), nil}
+	fakeKV := &fakeLabelStore{
+		data:         fakeLabeledPods(),
+		watchTrigger: nil,
+	}
 	aggreg := NewConsulAggregator(POD, fakeKV, logging.DefaultLogger, metrics.NewRegistry())
 	go aggreg.Aggregate()
 	defer aggreg.Quit()
@@ -67,7 +70,10 @@ func TestTwoClients(t *testing.T) {
 func TestQuitAggregateAfterResults(t *testing.T) {
 	alterAggregationTime(100 * time.Millisecond)
 
-	fakeKV := &fakeLabelStore{fakeLabeledPods(), nil}
+	fakeKV := &fakeLabelStore{
+		data:         fakeLabeledPods(),
+		watchTrigger: nil,
+	}
 	aggreg := NewConsulAggregator(POD, fakeKV, logging.DefaultLogger, metrics.NewRegistry())
 	go aggreg.Aggregate()
 
@@ -96,7 +102,10 @@ func TestQuitAggregateBeforeResults(t *testing.T) {
 	// this channel prevents the List from returning, so the aggregator
 	// must quit prior to entering the loop
 	trigger := make(chan struct{})
-	fakeKV := &fakeLabelStore{fakeLabeledPods(), trigger}
+	fakeKV := &fakeLabelStore{
+		data:         fakeLabeledPods(),
+		watchTrigger: trigger,
+	}
 	aggreg := NewConsulAggregator(POD, fakeKV, logging.DefaultLogger, metrics.NewRegistry())
 	go aggreg.Aggregate()
 
@@ -118,7 +127,10 @@ func TestQuitAggregateBeforeResults(t *testing.T) {
 func TestQuitIndividualWatch(t *testing.T) {
 	alterAggregationTime(time.Millisecond)
 
-	fakeKV := &fakeLabelStore{fakeLabeledPods(), nil}
+	fakeKV := &fakeLabelStore{
+		data:         fakeLabeledPods(),
+		watchTrigger: nil,
+	}
 	aggreg := NewConsulAggregator(POD, fakeKV, logging.DefaultLogger, metrics.NewRegistry())
 	go aggreg.Aggregate()
 
@@ -167,7 +179,10 @@ func TestQuitIndividualWatch(t *testing.T) {
 func TestIgnoreIndividualWatch(t *testing.T) {
 	alterAggregationTime(time.Millisecond)
 
-	fakeKV := &fakeLabelStore{fakeLabeledPods(), nil}
+	fakeKV := &fakeLabelStore{
+		data:         fakeLabeledPods(),
+		watchTrigger: nil,
+	}
 	aggreg := NewConsulAggregator(POD, fakeKV, logging.DefaultLogger, metrics.NewRegistry())
 	go aggreg.Aggregate()
 	defer aggreg.Quit()
@@ -205,7 +220,10 @@ func TestIgnoreIndividualWatch(t *testing.T) {
 }
 
 func TestCachedValueImmediatelySent(t *testing.T) {
-	fakeKV := &fakeLabelStore{fakeLabeledPods(), nil}
+	fakeKV := &fakeLabelStore{
+		data:         fakeLabeledPods(),
+		watchTrigger: nil,
+	}
 	aggreg := NewConsulAggregator(POD, fakeKV, logging.DefaultLogger, metrics.NewRegistry())
 	aggreg.labeledCache = []Labeled{
 		{


### PR DESCRIPTION
The ConsulAggregator is designed to allow performing "watches" on a
label selector for a certain label type, while only actually performing
one watch routine per process. The aggregator maintains a linked list of
"watchers" which represent a particular selector, and every time the
overall label watch returns new values, the list is iterated and each
watcher's selector is applied to the full dataset, with the results
being sent to the watcher's channel.

In practice, if the dataset is large (e.g. ~1.6Mb) and the number of
watchers is high (e.g. ~1700), it can take a noticeable amount of CPU
time in order to process a watch value. This is bad because a mutex
guarding access to the aggregator's linked list is held while these
computations are being performed.

This mutex must also be acquired when registering or deregistering
watchers. It's been observed in production that registering and
deregistering 1700 watchers all at the same time under the workload
described above can take several minutes due to this mutex contention.

This commit aims to mitigate the problem by parallelizing the selector
computations for each watcher. It does not attempt to make any
architectural changes to the aggregator, although there certainly are
some that could be made, for instance using a map instead of a linked
list for faster deregistration which requires a full scan of the linked
list in the worst case.

One test had to be slightly modified because it depended on the lack of
parallelism, but the intent of the test to make sure a bad client cannot
block others was preserved.