### PR TITLE
prune old hook launchable installs

### DIFF
--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -665,5 +665,8 @@ func (p *Preparer) InstallHooks() error {
 		return err
 	}
 	sub.NoFields().Infoln("Updated hook")
+
+	p.hooksPod.Prune(p.maxLaunchableDiskUsage, p.hooksManifest)
+
 	return nil
 }


### PR DESCRIPTION
Hooks are just a pod, but they're installed in a separate code path when
the preparer boots up since the hook manifest if found within
p2-preparer's config. An unintended consequence of this change is that
old installs of hook launchables were not getting pruned. This commit
prunes old hook launchables after installing the new ones.