### PR TITLE
gzip: Always extract with --no-same-owner

### DIFF
--- a/pkg/gzip/gzip.go
+++ b/pkg/gzip/gzip.go
@@ -32,7 +32,11 @@ func ExtractTarGz(owner string, filename string, dest string) (err error) {
 		return util.Errorf("error setting ownership of root directory %s: %s", dest, err)
 	}
 
-	cmd := exec.Command("tar", "xpzf", filename, "-C", dest)
+	// Always pass --no-same-owner:
+	// this is default if extracting as non-root, but --same-owner is default if root.
+	// For run_as root apps, we DO want the files to end up owned by root,
+	// instead of an unknown user dictated by the build system that produced the artifact.
+	cmd := exec.Command("tar", "xpzf", filename, "--no-same-owner", "-C", dest)
 	if currentUser.Username != owner {
 		// If we are running as a non-root user (e.g. in tests), don't change user.
 		// Non-root users are understandably not allowed to change to other users...


### PR DESCRIPTION
This preserves the behaviour present before #739 / #821, for apps that
run_as root, since the custom gzip code would explicitly chown those
files to root.

So this can be considered as a fix to a regression caused by #821.

As code comment states: this helps apps that run_as root ensure that
their files are in fact owned by root rather than some unknown user
dictated by the build system.