### PR TITLE
Make all functions take a context.Context instead of transaction.Tx

### DIFF
--- a/pkg/grpc/auditlogstore/audit_log_store_test.go
+++ b/pkg/grpc/auditlogstore/audit_log_store_test.go
@@ -35,11 +35,11 @@ func TestList(t *testing.T) {
 		t.Errorf("expected 0 records to be returned but there were %d", len(resp.GetAuditLogs()))
 	}
 
-	txn := transaction.New()
+	ctx, cancelFunc := transaction.New(context.Background())
 	eventDetails0 := json.RawMessage(`{"bogus_event_details":0}`)
 	eventType := audit.EventType("bogus_event_type")
 	err = alStore.Create(
-		txn,
+		ctx,
 		eventType,
 		eventDetails0,
 	)
@@ -47,7 +47,7 @@ func TestList(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = txn.Commit(f.Client.KV())
+	err = transaction.Commit(ctx, cancelFunc, f.Client.KV())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,9 +71,9 @@ func TestList(t *testing.T) {
 		}
 	}
 
-	txn = transaction.New()
+	ctx, cancelFunc = transaction.New(context.Background())
 	err = alStore.Create(
-		txn,
+		ctx,
 		"bogus_event_type",
 		json.RawMessage(`{"bogus_event_details1":1}`),
 	)
@@ -82,7 +82,7 @@ func TestList(t *testing.T) {
 	}
 
 	err = alStore.Create(
-		txn,
+		ctx,
 		"bogus_event_type",
 		json.RawMessage(`{"bogus_event_details":2}`),
 	)
@@ -90,7 +90,7 @@ func TestList(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = txn.Commit(f.Client.KV())
+	err = transaction.Commit(ctx, cancelFunc, f.Client.KV())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,11 +116,11 @@ func TestDelete(t *testing.T) {
 		f.Client.KV(),
 	)
 
-	txn := transaction.New()
+	ctx, cancelFunc := transaction.New(context.Background())
 	eventDetails0 := json.RawMessage(`{"bogus_event_details":0}`)
 	eventType := audit.EventType("bogus_event_type")
 	err := alStore.Create(
-		txn,
+		ctx,
 		eventType,
 		eventDetails0,
 	)
@@ -128,7 +128,7 @@ func TestDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = txn.Commit(f.Client.KV())
+	err = transaction.Commit(ctx, cancelFunc, f.Client.KV())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/labels/fake_applicator.go
+++ b/pkg/labels/fake_applicator.go
@@ -1,10 +1,10 @@
 package labels
 
 import (
+	"context"
 	"sync"
 
 	"github.com/square/p2/pkg/logging"
-	"github.com/square/p2/pkg/store/consul/transaction"
 
 	"k8s.io/kubernetes/pkg/labels"
 )
@@ -56,7 +56,7 @@ func (app *fakeApplicator) SetLabels(labelType Type, id string, labels map[strin
 	return nil
 }
 
-func (app *fakeApplicator) SetLabelsTxn(txn *transaction.Tx, labelType Type, id string, labels map[string]string) error {
+func (app *fakeApplicator) SetLabelsTxn(ctx context.Context, labelType Type, id string, labels map[string]string) error {
 	panic("not implemented")
 }
 

--- a/pkg/store/consul/auditlogstore/consul_store.go
+++ b/pkg/store/consul/auditlogstore/consul_store.go
@@ -1,6 +1,7 @@
 package auditlogstore
 
 import (
+	"context"
 	"encoding/json"
 	"path"
 	"strings"
@@ -37,7 +38,7 @@ func NewConsulStore(consulKV ConsulKV) ConsulStore {
 }
 
 func (ConsulStore) Create(
-	txn *transaction.Tx,
+	ctx context.Context,
 	eventType audit.EventType,
 	eventDetails json.RawMessage,
 ) error {
@@ -51,21 +52,21 @@ func (ConsulStore) Create(
 		return util.Errorf("could not create audit log record: %s", err)
 	}
 
-	return txn.Add(api.KVTxnOp{
+	return transaction.Add(ctx, api.KVTxnOp{
 		Verb:  string(api.KVSet),
 		Key:   computeKey(audit.ID(uuid.New())),
 		Value: auditLogBytes,
 	})
 }
 func (ConsulStore) Delete(
-	txn *transaction.Tx,
+	ctx context.Context,
 	id audit.ID,
 ) error {
 	if uuid.Parse(id.String()) == nil {
 		return util.Errorf("%s is not a valid audit log ID", id)
 	}
 
-	return txn.Add(api.KVTxnOp{
+	return transaction.Add(ctx, api.KVTxnOp{
 		Verb: api.KVDelete,
 		Key:  computeKey(id),
 	})

--- a/pkg/store/consul/rcstore/fake_store.go
+++ b/pkg/store/consul/rcstore/fake_store.go
@@ -1,6 +1,7 @@
 package rcstore
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"sync"
@@ -12,7 +13,6 @@ import (
 	"github.com/square/p2/pkg/rc/fields"
 	"github.com/square/p2/pkg/store/consul"
 	"github.com/square/p2/pkg/store/consul/consulutil"
-	"github.com/square/p2/pkg/store/consul/transaction"
 	"github.com/square/p2/pkg/util"
 )
 
@@ -66,7 +66,7 @@ func (s *fakeStore) Create(manifest manifest.Manifest, nodeSelector labels.Selec
 // If a test needs to use transactions, it should be using a real consul e.g.
 // via consulutil.NewFixture(). We won't be implementing transactions ourselves
 // in these fake storage structs
-func (s *fakeStore) CreateTxn(txn *transaction.Tx, manifest manifest.Manifest, nodeSelector labels.Selector, podLabels labels.Set) (fields.RC, error) {
+func (s *fakeStore) CreateTxn(ctx context.Context, manifest manifest.Manifest, nodeSelector labels.Selector, podLabels labels.Set) (fields.RC, error) {
 	panic("transactions not implemented in fake rc store")
 }
 

--- a/pkg/store/consul/rollstore/consul_store_test.go
+++ b/pkg/store/consul/rollstore/consul_store_test.go
@@ -1,6 +1,7 @@
 package rollstore
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -186,7 +187,8 @@ func TestCreateExistingRCsMutualExclusion(t *testing.T) {
 		OldRC: oldRCID,
 	}
 
-	_, err := rollstore.CreateRollingUpdateFromExistingRCs(transaction.New(), update, nil, nil)
+	ctx, _ := transaction.New(context.Background())
+	_, err := rollstore.CreateRollingUpdateFromExistingRCs(ctx, update, nil, nil)
 	if err == nil {
 		t.Fatal("Expected update creation to fail due to conflict")
 	}
@@ -233,7 +235,8 @@ func TestCreateFailsIfCantAcquireLock(t *testing.T) {
 		t.Fatalf("Unable to acquire conflicting lock on old rc: %s", err)
 	}
 
-	_, err = rollstore.CreateRollingUpdateFromExistingRCs(transaction.New(), update, nil, nil)
+	ctx, _ := transaction.New(context.Background())
+	_, err = rollstore.CreateRollingUpdateFromExistingRCs(ctx, update, nil, nil)
 	if err == nil {
 		t.Fatal("Expected update creation to fail due to lock conflict")
 	}
@@ -262,8 +265,9 @@ func TestCreateRollingUpdateFromOneExistingRCWithIDFailsIfCantAcquireLock(t *tes
 		t.Fatalf("Unable to acquire conflicting lock on old rc: %s", err)
 	}
 
+	ctx, _ := transaction.New(context.Background())
 	newUpdate, err := rollstore.CreateRollingUpdateFromOneExistingRCWithID(
-		transaction.New(),
+		ctx,
 		oldRCID,
 		1,
 		0,
@@ -334,8 +338,9 @@ func TestCreateRollingUpdateFromOneMaybeExistingWithLabelSelectorFailsWhenTwoMat
 	oldRCSelector := klabels.Everything().
 		Add("is_test_rc", klabels.EqualsOperator, []string{"true"})
 
+	ctx, _ := transaction.New(context.Background())
 	u, err := rollstore.CreateRollingUpdateFromOneMaybeExistingWithLabelSelector(
-		transaction.New(),
+		ctx,
 		oldRCSelector,
 		1,
 		0,
@@ -391,8 +396,9 @@ func TestCreateRollingUpdateFromOneMaybeExistingWithLabelSelectorFailsWhenExisti
 	oldRCSelector := klabels.Everything().
 		Add("is_test_rc", klabels.EqualsOperator, []string{"true"})
 
+	ctx, _ := transaction.New(context.Background())
 	u, err := rollstore.CreateRollingUpdateFromOneMaybeExistingWithLabelSelector(
-		transaction.New(),
+		ctx,
 		oldRCSelector,
 		1,
 		0,
@@ -421,8 +427,9 @@ func TestLeaveOldInvalidIfNoOldRC(t *testing.T) {
 	oldRCSelector := klabels.Everything().
 		Add("is_test_rc", klabels.EqualsOperator, []string{"true"})
 
+	ctx, _ := transaction.New(context.Background())
 	_, err := rollstore.CreateRollingUpdateFromOneMaybeExistingWithLabelSelector(
-		transaction.New(),
+		ctx,
 		oldRCSelector,
 		1,
 		0,

--- a/pkg/store/consul/transaction/transaction.go
+++ b/pkg/store/consul/transaction/transaction.go
@@ -3,6 +3,7 @@
 package transaction
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -11,36 +12,45 @@ import (
 	"github.com/hashicorp/consul/api"
 )
 
+// contextKeyType is only used as a key into a context's value
+// map[interface{}]interface{}. It's a private type to guarantee no key
+// collisions in the map.
+type contextKeyType struct{}
+
 // Per https://www.consul.io/api/txn.html
 const maxAllowedOperations = 64
 
 var (
 	ErrTooManyOperations = errors.New("consul transactions cannot have more than 64 operations")
 	ErrAlreadyCommitted  = errors.New("this transaction has already been committed")
+
+	contextKey = contextKeyType{}
 )
 
 type Tx struct {
-	kvOps            *api.KVTxnOps
-	alreadyCommitted bool
+	kvOps *api.KVTxnOps
 
 	commitHooks []func()
 }
 
-func New() *Tx {
-	return &Tx{
+func New(ctx context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancelFunc := context.WithCancel(ctx)
+	ctx = context.WithValue(ctx, contextKey, &Tx{
 		kvOps: new(api.KVTxnOps),
-	}
+	})
+	return ctx, cancelFunc
 }
 
-func (c *Tx) Add(op api.KVTxnOp) error {
-	if c.alreadyCommitted {
-		return ErrAlreadyCommitted
+func Add(ctx context.Context, op api.KVTxnOp) error {
+	txn, err := getTxnFromContext(ctx)
+	if err != nil {
+		return err
 	}
 
-	if len(*c.kvOps) == maxAllowedOperations {
+	if len(*txn.kvOps) == maxAllowedOperations {
 		return ErrTooManyOperations
 	}
-	*c.kvOps = append(*c.kvOps, &op)
+	*txn.kvOps = append(*txn.kvOps, &op)
 
 	return nil
 }
@@ -48,32 +58,13 @@ func (c *Tx) Add(op api.KVTxnOp) error {
 // AddCommitHook adds a function that should be run when the transaction is
 // committed.  This is useful for cleaning up resources, e.g. consul sessions
 // that had to be opened as part of transaction setup.
-func (c *Tx) AddCommitHook(f func()) error {
-	if c.alreadyCommitted {
-		return ErrAlreadyCommitted
+func AddCommitHook(ctx context.Context, f func()) error {
+	txn, err := getTxnFromContext(ctx)
+	if err != nil {
+		return err
 	}
 
-	c.commitHooks = append(c.commitHooks, f)
-	return nil
-}
-
-func (c *Tx) Append(newTxn *Tx) error {
-	if c.alreadyCommitted {
-		return ErrAlreadyCommitted
-	}
-
-	if newTxn.alreadyCommitted {
-		return ErrAlreadyCommitted
-	}
-
-	if len(*c.kvOps)+len(*newTxn.kvOps) > 64 {
-		return ErrTooManyOperations
-	}
-
-	for _, op := range *newTxn.kvOps {
-		*c.kvOps = append(*c.kvOps, op)
-	}
-
+	txn.commitHooks = append(txn.commitHooks, f)
 	return nil
 }
 
@@ -81,20 +72,29 @@ type Txner interface {
 	Txn(txn api.KVTxnOps, q *api.QueryOptions) (bool, *api.KVTxnResponse, *api.QueryMeta, error)
 }
 
-func (c *Tx) Commit(txner Txner) error {
-	if c.alreadyCommitted {
-		return ErrAlreadyCommitted
+// Commit attempts to run all of the kv operations in the context's
+// transaction. The cancel function with which the context was created must
+// also be passed to guarantee that the transaction won't be applied twice
+func Commit(ctx context.Context, cancel context.CancelFunc, txner Txner) error {
+	txn, err := getTxnFromContext(ctx)
+	if err != nil {
+		return err
 	}
 
-	ok, resp, _, err := txner.Txn(*c.kvOps, nil)
+	ok, resp, _, err := txner.Txn(*txn.kvOps, nil)
 	if err != nil {
 		return util.Errorf("transaction failed: %s", err)
 	}
 
-	c.runCommitHooks()
-	// Set this after we know err == nil because otherwise it could have
-	// been a retry-able TCP error for example
-	c.alreadyCommitted = true
+	txn.runCommitHooks()
+
+	// we call cancel() here to mark the transaction as completed. Any
+	// further function calls using this context will now error via
+	// getTxnFromContext() since the transaction is already applied.  we do
+	// NOT call cancel() if there was an error applying the transaction
+	// because the caller may wish to retry temporary failures without
+	// rebuilding the whole transaction
+	cancel()
 
 	if len(resp.Errors) != 0 {
 		return util.Errorf("some errors occurred when committing the transaction: %s", txnErrorsToString(resp.Errors))
@@ -122,4 +122,24 @@ func txnErrorsToString(errors api.TxnErrors) string {
 	}
 
 	return str
+}
+
+func getTxnFromContext(ctx context.Context) (*Tx, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ErrAlreadyCommitted
+	default:
+	}
+
+	txnValue := ctx.Value(contextKey)
+	if txnValue == nil {
+		return nil, util.Errorf("no transaction was opened on the passed Context")
+	}
+
+	txn, ok := txnValue.(*Tx)
+	if !ok {
+		return nil, util.Errorf("the transaction value on the context had the wrong type!")
+	}
+
+	return txn, nil
 }

--- a/pkg/store/consul/transaction/transaction.go
+++ b/pkg/store/consul/transaction/transaction.go
@@ -27,13 +27,13 @@ var (
 	contextKey = contextKeyType{}
 )
 
-type Tx struct {
+type tx struct {
 	kvOps *api.KVTxnOps
 }
 
 func New(ctx context.Context) (context.Context, context.CancelFunc) {
 	ctx, cancelFunc := context.WithCancel(ctx)
-	ctx = context.WithValue(ctx, contextKey, &Tx{
+	ctx = context.WithValue(ctx, contextKey, &tx{
 		kvOps: new(api.KVTxnOps),
 	})
 	return ctx, cancelFunc
@@ -101,7 +101,7 @@ func txnErrorsToString(errors api.TxnErrors) string {
 	return str
 }
 
-func getTxnFromContext(ctx context.Context) (*Tx, error) {
+func getTxnFromContext(ctx context.Context) (*tx, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ErrAlreadyCommitted
@@ -113,7 +113,7 @@ func getTxnFromContext(ctx context.Context) (*Tx, error) {
 		return nil, util.Errorf("no transaction was opened on the passed Context")
 	}
 
-	txn, ok := txnValue.(*Tx)
+	txn, ok := txnValue.(*tx)
 	if !ok {
 		return nil, util.Errorf("the transaction value on the context had the wrong type!")
 	}

--- a/pkg/store/consul/transaction/transaction_test.go
+++ b/pkg/store/consul/transaction/transaction_test.go
@@ -119,25 +119,6 @@ func TesetErrAlreadyCommitted(t *testing.T) {
 	}
 }
 
-func TestCommitHooks(t *testing.T) {
-	hookRan := false
-	hook := func() {
-		hookRan = true
-	}
-
-	ctx, cancelFunc := New(context.Background())
-	AddCommitHook(ctx, hook)
-
-	err := Commit(ctx, cancelFunc, &testTxner{shouldOK: true})
-	if err != nil {
-		t.Fatalf("could not commit transaction: %s", err)
-	}
-
-	if !hookRan {
-		t.Error("hook function did not run when committing")
-	}
-}
-
 func TestCommitErrNoTransaction(t *testing.T) {
 	err := Commit(context.Background(), func() {}, &testTxner{})
 	if err == nil {


### PR DESCRIPTION
This commit changes function signatures for consul store operations to
take a context.Context instead of a *transaction.Tx. This means we're
providing a more standard interface and additionally callers can specify
deadlines or cancellation signals for applying a transaction.