### PR TITLE
flags: strip spaces out of token read from token file

### DIFF
--- a/pkg/store/consul/flags/kingpin.go
+++ b/pkg/store/consul/flags/kingpin.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strings"
 
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/store/consul"
@@ -33,7 +34,7 @@ func ParseWithConsulOptions() (string, consul.Options, labels.ApplicatorWithoutW
 		if err != nil {
 			log.Fatalln(err)
 		}
-		*token = string(tokenBytes)
+		*token = strings.TrimSpace(string(tokenBytes))
 	}
 	var transport http.RoundTripper
 	if *caFile != "" || *keyFile != "" || *certFile != "" {


### PR DESCRIPTION
As is traditional, our token file ends with a newline. Reading from the
file preserves the newline, but this causes an error when trying to send
a request:

    net/http: invalid header field value "CENSORED\n" for key X-Consul-Token

Thus we should trim the spaces.