### PR TITLE
Add client library wrapper for audit log store grpc operations.

### DIFF
--- a/pkg/grpc/auditlogstore/client/client.go
+++ b/pkg/grpc/auditlogstore/client/client.go
@@ -1,0 +1,52 @@
+package client
+
+import (
+	"context"
+
+	"github.com/square/p2/pkg/audit"
+	"github.com/square/p2/pkg/grpc/auditlogstore"
+	auditlogstore_protos "github.com/square/p2/pkg/grpc/auditlogstore/protos"
+
+	"google.golang.org/grpc"
+)
+
+type Client struct {
+	client auditlogstore_protos.P2AuditLogStoreClient
+}
+
+func New(conn *grpc.ClientConn) Client {
+	return Client{
+		client: auditlogstore_protos.NewP2AuditLogStoreClient(conn),
+	}
+}
+
+func (c Client) List(ctx context.Context) (map[audit.ID]audit.AuditLog, error) {
+	resp, err := c.client.List(ctx, new(auditlogstore_protos.ListRequest))
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make(map[audit.ID]audit.AuditLog)
+	for id, al := range resp.GetAuditLogs() {
+		ret[audit.ID(id)], err = auditlogstore.ProtoAuditLogToRawAuditLog(*al)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ret, nil
+}
+
+func (c Client) Delete(ctx context.Context, idsToDelete []audit.ID) error {
+	req := &auditlogstore_protos.DeleteRequest{}
+	for _, id := range idsToDelete {
+		req.AuditLogIds = append(req.AuditLogIds, id.String())
+	}
+
+	_, err := c.client.Delete(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/store/consul/rcstore/consul_store_test.go
+++ b/pkg/store/consul/rcstore/consul_store_test.go
@@ -350,7 +350,13 @@ func TestPublishLatestRCsWithLockInfoNoLocks(t *testing.T) {
 	select {
 	case inCh <- unlockedCase.InputRCs:
 	case <-time.After(1 * time.Second):
-		t.Fatalf("Timed out writing to input channel")
+		t.Fatal("Timed out writing to input channel")
+	}
+
+	select {
+	case <-lockResultCh:
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out reading from output channel")
 	}
 
 	// create a new case


### PR DESCRIPTION
This will allow clients to operate using the "raw" audit log types
rather than the primitive types that are ncessarily used by generated
protobuf code.