### PR TITLE
Fix p2-rctl when configured to use http applicator.

### DIFF
--- a/bin/p2-rctl/main.go
+++ b/bin/p2-rctl/main.go
@@ -119,13 +119,10 @@ func main() {
 
 	rcStore := rcstore.NewConsul(client, labeler, 3)
 
-	// This means that p2-rctl can only use direct-consul labelers, not
-	// HTTP applicators (because the rollstore requires transactions and
-	// only direct consul access can accomplish that)
-	rollLabeler, ok := labeler.(rollstore.RollLabeler)
-	if !ok {
-		logger.Fatalf("labeler configured via flags is not valid as a rollstore labeler")
-	}
+	// The roll labeler CANT be an http applicator because it uses consul
+	// transactions, so this might be different from labeler returned by
+	// flags.ParseWithConsulOptions()
+	rollLabeler := labels.NewConsulApplicator(client, 0)
 	rctl := rctlParams{
 		httpClient: httpClient,
 		baseClient: client,


### PR DESCRIPTION
Using an HTTP applicator is allowed by most of our CLIs and generally
desirable over using direct consul access where possible, however
p2-rctl also instantiates a rolling update store which has a hard
dependency on direct consul access for writing labels in order to
perform transactions.

This commit simply instantiates a direct-consul-access applicator for
use in the roll store while still using the labeler according to common
flags for other purposes.