### PR TITLE
pc/control: Only accept/use session in Create; p2-pcctl: Only create session when creating a PC

### DIFF
--- a/bin/p2-pcctl/main.go
+++ b/bin/p2-pcctl/main.go
@@ -111,7 +111,7 @@ func main() {
 		cn := fields.ClusterName(*createName)
 		podID := types.PodID(*createPodID)
 		selector := defaultSelector(az, cn, podID)
-		pccontrol := control.NewPodCluster(az, cn, podID, pcstore, selector, session)
+		pccontrol := control.NewPodCluster(az, cn, podID, pcstore, selector)
 
 		annotations := *createAnnotations
 		var parsedAnnotations map[string]interface{}
@@ -119,7 +119,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("could not parse json: %v", err)
 		}
-		_, err = pccontrol.Create(parsedAnnotations)
+		_, err = pccontrol.Create(parsedAnnotations, session)
 		if err != nil {
 			log.Fatalf("err: %v", err)
 		}
@@ -131,10 +131,10 @@ func main() {
 
 		var pccontrol *control.PodCluster
 		if pcID != "" {
-			pccontrol = control.NewPodClusterFromID(pcID, session, pcstore)
+			pccontrol = control.NewPodClusterFromID(pcID, pcstore)
 		} else if az != "" && cn != "" && podID != "" {
 			selector := defaultSelector(az, cn, podID)
-			pccontrol = control.NewPodCluster(az, cn, podID, pcstore, selector, session)
+			pccontrol = control.NewPodCluster(az, cn, podID, pcstore, selector)
 		} else {
 			log.Fatalf("Expected one of: pcID or (pod,az,name)")
 		}
@@ -157,10 +157,10 @@ func main() {
 
 		var pccontrol *control.PodCluster
 		if pcID != "" {
-			pccontrol = control.NewPodClusterFromID(pcID, session, pcstore)
+			pccontrol = control.NewPodClusterFromID(pcID, pcstore)
 		} else if az != "" && cn != "" && podID != "" {
 			selector := defaultSelector(az, cn, podID)
-			pccontrol = control.NewPodCluster(az, cn, podID, pcstore, selector, session)
+			pccontrol = control.NewPodCluster(az, cn, podID, pcstore, selector)
 		} else {
 			log.Fatalf("Expected one of: pcID or (pod,az,name)")
 		}
@@ -180,10 +180,10 @@ func main() {
 
 		var pccontrol *control.PodCluster
 		if pcID != "" {
-			pccontrol = control.NewPodClusterFromID(pcID, session, pcstore)
+			pccontrol = control.NewPodClusterFromID(pcID, pcstore)
 		} else if az != "" && cn != "" && podID != "" {
 			selector := defaultSelector(az, cn, podID)
-			pccontrol = control.NewPodCluster(az, cn, podID, pcstore, selector, session)
+			pccontrol = control.NewPodCluster(az, cn, podID, pcstore, selector)
 		} else {
 			log.Fatalf("Expected one of: pcID or (pod,az,name)")
 		}

--- a/bin/p2-pcctl/main.go
+++ b/bin/p2-pcctl/main.go
@@ -100,10 +100,6 @@ func main() {
 	logger := logging.NewLogger(logrus.Fields{})
 	applicator := labels.NewConsulApplicator(client, 0)
 	pcstore := pcstore.NewConsul(client, labeler, applicator, &logger)
-	session, _, err := kv.NewSession(fmt.Sprintf("pcctl-%s", currentUserName()), nil)
-	if err != nil {
-		log.Fatalf("Could not create session: %s", err)
-	}
 
 	switch cmd {
 	case cmdCreateText:
@@ -119,6 +115,12 @@ func main() {
 		if err != nil {
 			log.Fatalf("could not parse json: %v", err)
 		}
+
+		session, _, err := kv.NewSession(fmt.Sprintf("pcctl-%s", currentUserName()), nil)
+		if err != nil {
+			log.Fatalf("Could not create session: %s", err)
+		}
+
 		_, err = pccontrol.Create(parsedAnnotations, session)
 		if err != nil {
 			log.Fatalf("err: %v", err)

--- a/pkg/pc/control/control.go
+++ b/pkg/pc/control/control.go
@@ -5,7 +5,6 @@ package control
 
 import (
 	"github.com/square/p2/pkg/pc/fields"
-	"github.com/square/p2/pkg/store/consul"
 	"github.com/square/p2/pkg/store/consul/pcstore"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
@@ -36,7 +35,6 @@ type PodClusterStore interface {
 
 type PodCluster struct {
 	pcStore PodClusterStore
-	session consul.Session
 
 	ID fields.ID
 
@@ -52,7 +50,6 @@ func NewPodCluster(
 	podID types.PodID,
 	pcstore PodClusterStore,
 	selector labels.Selector,
-	session consul.Session,
 ) *PodCluster {
 
 	pc := &PodCluster{}
@@ -61,18 +58,15 @@ func NewPodCluster(
 	pc.podID = podID
 	pc.pcStore = pcstore
 	pc.selector = selector
-	pc.session = session
 
 	return pc
 }
 
 func NewPodClusterFromID(
 	id fields.ID,
-	session consul.Session,
 	pcStore PodClusterStore,
 ) *PodCluster {
 	pc := &PodCluster{}
-	pc.session = session
 	pc.pcStore = pcStore
 	pc.ID = id
 	return pc
@@ -105,8 +99,8 @@ func (pccontrol *PodCluster) Delete() (errors []error) {
 	return errors
 }
 
-func (pccontrol *PodCluster) Create(annotations fields.Annotations) (fields.PodCluster, error) {
-	return pccontrol.pcStore.Create(pccontrol.podID, pccontrol.az, pccontrol.cn, pccontrol.selector, annotations, pccontrol.session)
+func (pccontrol *PodCluster) Create(annotations fields.Annotations, session pcstore.Session) (fields.PodCluster, error) {
+	return pccontrol.pcStore.Create(pccontrol.podID, pccontrol.az, pccontrol.cn, pccontrol.selector, annotations, session)
 }
 
 func (pccontrol *PodCluster) Get() (fields.PodCluster, error) {

--- a/pkg/pc/control/control_test.go
+++ b/pkg/pc/control/control_test.go
@@ -23,7 +23,7 @@ func TestCreate(t *testing.T) {
 	session := consultest.NewSession()
 	pcstore := pcstoretest.NewFake()
 
-	pcController := NewPodCluster(testAZ, testCN, testPodID, pcstore, selector, session)
+	pcController := NewPodCluster(testAZ, testCN, testPodID, pcstore, selector)
 
 	annotations := map[string]string{
 		"load_balancer_info": "totally",
@@ -40,7 +40,7 @@ func TestCreate(t *testing.T) {
 		t.Errorf("json unmarshal error: %v", err)
 	}
 
-	pc, err := pcController.Create(fields.Annotations(testAnnotations))
+	pc, err := pcController.Create(fields.Annotations(testAnnotations), session)
 	if err != nil {
 		t.Errorf("got error during creation: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestUpdateAnnotations(t *testing.T) {
 	session := consultest.NewSession()
 	pcstore := pcstoretest.NewFake()
 
-	pcController := NewPodCluster(testAZ, testCN, testPodID, pcstore, selector, session)
+	pcController := NewPodCluster(testAZ, testCN, testPodID, pcstore, selector)
 
 	var annotations = map[string]string{
 		"load_balancer_info": "totally",
@@ -101,7 +101,7 @@ func TestUpdateAnnotations(t *testing.T) {
 		t.Errorf("json unmarshal error: %v", err)
 	}
 
-	pc, err := pcController.Create(fields.Annotations(testAnnotations))
+	pc, err := pcController.Create(fields.Annotations(testAnnotations), session)
 	if err != nil {
 		t.Fatalf("Unable to create pod cluster due to: %v", err)
 	}
@@ -150,14 +150,14 @@ func TestPodClusterFromID(t *testing.T) {
 	session := consultest.NewSession()
 	fakePCStore := pcstoretest.NewFake()
 
-	pcControllerFromLabels := NewPodCluster(testAZ, testCN, testPodID, fakePCStore, selector, session)
-	pc, err := pcControllerFromLabels.Create(fields.Annotations{})
+	pcControllerFromLabels := NewPodCluster(testAZ, testCN, testPodID, fakePCStore, selector)
+	pc, err := pcControllerFromLabels.Create(fields.Annotations{}, session)
 	if err != nil {
 		t.Fatal(err)
 	}
 	pcControllerFromLabels = nil
 
-	pcControllerFromID := NewPodClusterFromID(pc.ID, session, fakePCStore)
+	pcControllerFromID := NewPodClusterFromID(pc.ID, fakePCStore)
 	retrievedPC, err := pcControllerFromID.Get()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
pc/control: Only accept/use session in Create

The constructors were all taking a session but only using them in
Create. Might as well only take in Create.

History: The session argument used to be used in Mutate as well, but
that was removed in #524. After this point, Create is the only user of a
session, so it can be the only function that takes one.

---

p2-pcctl: Only create session when creating a PC

Thus, if someone does not have permission to create a session but can
still read from the PC store, they will still be able to use all
non-Create operations, which seems desirable.