### PR TITLE
Fix RemoveAllLabelsTxn in consul applicator.

### DIFF
--- a/pkg/labels/consul_applicator.go
+++ b/pkg/labels/consul_applicator.go
@@ -322,8 +322,11 @@ func (c *consulApplicator) RemoveAllLabelsTxn(ctx context.Context, labelType Typ
 	if err != nil {
 		return err
 	}
-	_, err = c.kv.Delete(path, nil)
-	return err
+
+	return transaction.Add(ctx, api.KVTxnOp{
+		Verb: api.KVDelete,
+		Key:  path,
+	})
 }
 
 // kvp must be non-nil

--- a/pkg/labels/integration_test.go
+++ b/pkg/labels/integration_test.go
@@ -1,0 +1,54 @@
+// +build !race
+
+package labels
+
+import (
+	"context"
+	"testing"
+
+	"github.com/square/p2/pkg/store/consul/consulutil"
+	"github.com/square/p2/pkg/store/consul/transaction"
+)
+
+func TestRemoveAllLabelsTxn(t *testing.T) {
+	fixture := consulutil.NewFixture(t)
+
+	applicator := NewConsulApplicator(fixture.Client, 0)
+
+	// set some labels
+	err := applicator.SetLabels(RU, "some_id", map[string]string{"foo": "bar"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancelFunc := transaction.New(context.Background())
+	defer cancelFunc()
+
+	err = applicator.RemoveAllLabelsTxn(ctx, RU, "some_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// confirm that nothing was actually removed yet because transaction wasn't committed
+	labels, err := applicator.GetLabels(RU, "some_id")
+	if err != nil {
+		t.Fatalf("shouldn't have errored fetching labels we didn't delete yet: %s", err)
+	}
+	if len(labels.Labels) == 0 {
+		t.Fatal("no labels found when we haven't committed transaction for removal yet")
+	}
+
+	err = transaction.Commit(ctx, cancelFunc, fixture.Client.KV())
+	if err != nil {
+		t.Fatalf("error committing transaction: %s", err)
+	}
+
+	labels, err = applicator.GetLabels(RU, "some_id")
+	if err != nil {
+		t.Fatalf("unexpected error checking for labels: %s", err)
+	}
+
+	if len(labels.Labels) != 0 {
+		t.Errorf("labels were not deleted as expected, found %s", labels.Labels)
+	}
+}


### PR DESCRIPTION
The intention was that that call wouldn't actually remove labels, it
would just add an api.KVTxnOp to the passed transaction within the
passed context to do so, and the actual deletion wouldn't occur until
the transaction was committed. However the code had the exact same
behavior as the synchronous deletion in RemoveAllLabels().

This commit reimplements the function as intended and adds a regression
test.