### PR TITLE
Fix a panic case in WatchPodStatus() grpc handler.

### DIFF
--- a/pkg/grpc/podstore/podstore.go
+++ b/pkg/grpc/podstore/podstore.go
@@ -147,6 +147,7 @@ func (s store) WatchPodStatus(req *podstore_protos.WatchPodStatusRequest, stream
 
 	podStatusResultCh := make(chan podStatusResult)
 	innerQuit := make(chan struct{})
+	defer close(innerQuit)
 	go func() {
 		defer close(podStatusResultCh)
 		for {
@@ -180,7 +181,6 @@ func (s store) WatchPodStatus(req *podstore_protos.WatchPodStatusRequest, stream
 	for {
 		select {
 		case <-clientCancel:
-			close(innerQuit)
 			return nil
 		case result := <-podStatusResultCh:
 			if result.err != nil {

--- a/pkg/grpc/podstore/podstore.go
+++ b/pkg/grpc/podstore/podstore.go
@@ -147,8 +147,8 @@ func (s store) WatchPodStatus(req *podstore_protos.WatchPodStatusRequest, stream
 
 	podStatusResultCh := make(chan podStatusResult)
 	innerQuit := make(chan struct{})
-	defer close(podStatusResultCh)
 	go func() {
+		defer close(podStatusResultCh)
 		for {
 			status, queryMeta, err := s.podStatusStore.WaitForStatus(podUniqueKey, waitIndex)
 


### PR DESCRIPTION
There was a race where a goroutine might panic sending on a closed
channel. This commit gives responsibility of closing the channel
to the goroutine writing to it.