### PR TITLE
Do not consider a missing implicit entry point an error.

### DIFF
--- a/pkg/hoist/hoist_launchable_test.go
+++ b/pkg/hoist/hoist_launchable_test.go
@@ -84,7 +84,7 @@ func TestMultipleEntryPointsLegacy(t *testing.T) {
 	fakeLaunchable, sb := FakeHoistLaunchableForDirLegacyPod("multiple_script_test_hoist_launchable")
 	defer CleanupFakeLaunchable(fakeLaunchable, sb)
 
-	fakeLaunchable.EntryPoints = append(fakeLaunchable.EntryPoints, "bin/start")
+	fakeLaunchable.EntryPoints.Paths = append(fakeLaunchable.EntryPoints.Paths, "bin/start")
 	executables, err := fakeLaunchable.Executables(runit.DefaultBuilder)
 
 	Assert(t).IsNil(err, "Error occurred when obtaining runit services for launchable")
@@ -105,7 +105,7 @@ func TestMultipleEntryPointsUUIDPod(t *testing.T) {
 	fakeLaunchable, sb := FakeHoistLaunchableForDirUUIDPod("multiple_script_test_hoist_launchable")
 	defer CleanupFakeLaunchable(fakeLaunchable, sb)
 
-	fakeLaunchable.EntryPoints = append(fakeLaunchable.EntryPoints, "bin/start")
+	fakeLaunchable.EntryPoints.Paths = append(fakeLaunchable.EntryPoints.Paths, "bin/start")
 	executables, err := fakeLaunchable.Executables(runit.DefaultBuilder)
 
 	Assert(t).IsNil(err, "Error occurred when obtaining runit services for launchable")
@@ -125,7 +125,7 @@ func TestNonStandardEntryPointLegacy(t *testing.T) {
 	fakeLaunchable, sb := FakeHoistLaunchableForDirLegacyPod("multiple_script_test_hoist_launchable")
 	defer CleanupFakeLaunchable(fakeLaunchable, sb)
 
-	fakeLaunchable.EntryPoints = []string{"bin/start"}
+	fakeLaunchable.EntryPoints.Paths = []string{"bin/start"}
 	executables, err := fakeLaunchable.Executables(runit.DefaultBuilder)
 
 	Assert(t).IsNil(err, "Error occurred when obtaining runit services for launchable")
@@ -143,7 +143,7 @@ func TestNonStandardEntryPointUUIDPod(t *testing.T) {
 	fakeLaunchable, sb := FakeHoistLaunchableForDirUUIDPod("multiple_script_test_hoist_launchable")
 	defer CleanupFakeLaunchable(fakeLaunchable, sb)
 
-	fakeLaunchable.EntryPoints = []string{"bin/start"}
+	fakeLaunchable.EntryPoints.Paths = []string{"bin/start"}
 	executables, err := fakeLaunchable.Executables(runit.DefaultBuilder)
 
 	Assert(t).IsNil(err, "Error occurred when obtaining runit services for launchable")
@@ -156,12 +156,22 @@ func TestNonStandardEntryPointUUIDPod(t *testing.T) {
 	assertExpectedServices(t, expectedServicePaths, executables)
 }
 
+func TestMissingExplicitEntryPointError(t *testing.T) {
+	fakeLaunchable, sb := FakeHoistLaunchableForDirUUIDPod("multiple_script_test_hoist_launchable")
+	defer CleanupFakeLaunchable(fakeLaunchable, sb)
+
+	fakeLaunchable.EntryPoints.Paths = []string{"bin/missing"}
+	fakeLaunchable.EntryPoints.Implicit = false
+	_, err := fakeLaunchable.Executables(runit.DefaultBuilder)
+	Assert(t).IsNotNil(err, "expected an error if an explicitly enumerated entry point is missing")
+}
+
 func TestErrorIfConflictingServiceNames(t *testing.T) {
 	// This test's behavior is not dependent on whether the pod is a legacy or uuid pod
 	fakeLaunchable, sb := FakeHoistLaunchableForDirLegacyPod("multiple_script_test_hoist_launchable")
 	defer CleanupFakeLaunchable(fakeLaunchable, sb)
 
-	fakeLaunchable.EntryPoints = []string{"bin/start", "bin/start2"}
+	fakeLaunchable.EntryPoints.Paths = []string{"bin/start", "bin/start2"}
 	executables, err := fakeLaunchable.Executables(runit.DefaultBuilder)
 
 	Assert(t).IsNotNil(err, "Expected naming collision error calling Executables()")

--- a/pkg/hoist/test_helper.go
+++ b/pkg/hoist/test_helper.go
@@ -23,15 +23,18 @@ func fakeHoistLaunchableForDir(dirName string, isUUIDPod bool) (*Launchable, *ru
 	launchableInstallDir := util.From(runtime.Caller(0)).ExpandPath(dirName)
 
 	launchable := &Launchable{
-		Id:          "testLaunchable",
-		ServiceId:   "testPod__testLaunchable",
-		RunAs:       "testPod",
-		PodEnvDir:   tempDir,
-		RootDir:     launchableInstallDir,
-		P2Exec:      util.From(runtime.Caller(0)).ExpandPath("fake_p2-exec"),
-		Version:     "abc123",
-		EntryPoints: []string{"bin/launch"},
-		IsUUIDPod:   isUUIDPod,
+		Id:        "testLaunchable",
+		ServiceId: "testPod__testLaunchable",
+		RunAs:     "testPod",
+		PodEnvDir: tempDir,
+		RootDir:   launchableInstallDir,
+		P2Exec:    util.From(runtime.Caller(0)).ExpandPath("fake_p2-exec"),
+		Version:   "abc123",
+		EntryPoints: EntryPoints{
+			Paths:    []string{"bin/launch"},
+			Implicit: true,
+		},
+		IsUUIDPod: isUUIDPod,
 	}
 
 	curUser, err := user.Current()

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -709,9 +709,11 @@ func (pod *Pod) getLaunchable(launchableID launch.LaunchableID, launchableStanza
 	}
 
 	if launchableStanza.LaunchableType == "hoist" {
-		entryPoints := launchableStanza.EntryPoints
-		if len(entryPoints) == 0 {
-			entryPoints = append(entryPoints, path.Join("bin", "launch"))
+		entryPointPaths := launchableStanza.EntryPoints
+		implicitEntryPoints := false
+		if len(entryPointPaths) == 0 {
+			implicitEntryPoints = true
+			entryPointPaths = append(entryPointPaths, path.Join("bin", "launch"))
 		}
 		cgroupName := serviceId
 		if *NestedCgroups {
@@ -721,6 +723,11 @@ func (pod *Pod) getLaunchable(launchableID launch.LaunchableID, launchableStanza
 				pod.UniqueName(),
 				launchableID.String(),
 			)
+		}
+
+		entryPoints := hoist.EntryPoints{
+			Paths:    entryPointPaths,
+			Implicit: implicitEntryPoints,
 		}
 
 		ret := &hoist.Launchable{


### PR DESCRIPTION
This change is intended to cut down on error noise in p2-preparer. The
hoist artifact spec historically required all "entry points" for an
artifact to be located at bin/launch whether it's a directory of entry
points or a file. At a later point in time the pod manifest spec was
extended to allow specifying alternate entry points, at which point it
was considered an error if an entry point is missing.

However it is not uncommon for an artifact to have no entry points, for
instance when the intention is just to deploy some scripts to a server
and not run any processes. These cases now generate errors which pollute
preparer logs and exception systems.

This commit tries to take the best of both worlds by considering a
missing entry point to be an error only if it was explicitly enumerated
in the pod manifest. If the implicit default one is missing, it is no
longer an error.