### PR TITLE
WIP: DON'T MERGE

### DIFF
--- a/pkg/roll/run_update.go
+++ b/pkg/roll/run_update.go
@@ -182,9 +182,6 @@ func (u *update) Run(quit <-chan struct{}) (ret bool) {
 	// rollout complete, clean up old RC if told to do so
 	if !u.LeaveOld {
 		u.logger.NoFields().Infoln("Cleaning up old RC")
-		if !RetryOrQuit(func() error { return u.rcStore.SetDesiredReplicas(u.OldRC, 0) }, quit, u.logger, "Could not zero old replica count") {
-			return
-		}
 		if !RetryOrQuit(func() error { return u.rcStore.Delete(u.OldRC, false) }, quit, u.logger, "Could not delete old RC") {
 			return
 		}


### PR DESCRIPTION
This code is dangerous, we shouldn't zero out the old RC in the cleanup section
of the roll loop. That is the job of the main loop. If we get here and old rc
desired is non-zero, we should page.