### PR TITLE
Fixes for installation and running tests

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/square/p2",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v79",
+	"GodepVersion": "v77",
 	"Packages": [
 		"./..."
 	],
@@ -662,6 +662,16 @@
 			"Rev": "708a7f9f3283aa2d4f6132d287d78683babe55c8"
 		},
 		{
+			"ImportPath": "google.golang.org/grpc/stats",
+			"Comment": "v1.0.5",
+			"Rev": "708a7f9f3283aa2d4f6132d287d78683babe55c8"
+		},
+		{
+			"ImportPath": "google.golang.org/grpc/tap",
+			"Comment": "v1.0.5",
+			"Rev": "708a7f9f3283aa2d4f6132d287d78683babe55c8"
+		},
+		{
 			"ImportPath": "google.golang.org/grpc/transport",
 			"Comment": "v1.0.5",
 			"Rev": "708a7f9f3283aa2d4f6132d287d78683babe55c8"
@@ -694,16 +704,6 @@
 			"ImportPath": "k8s.io/kubernetes/pkg/util/validation",
 			"Comment": "v1.2.0-alpha.4",
 			"Rev": "4a9b0fc7153c733832d70c9f6d0796db177643a6"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc/stats",
-			"Comment": "v1.0.5",
-			"Rev": "708a7f9f3283aa2d4f6132d287d78683babe55c8"
-		},
-		{
-			"ImportPath": "google.golang.org/grpc/tap",
-			"Comment": "v1.0.5",
-			"Rev": "708a7f9f3283aa2d4f6132d287d78683babe55c8"
 		}
 	]
 }

--- a/Rakefile
+++ b/Rakefile
@@ -22,18 +22,18 @@ end
 
 desc 'Build all projects'
 task :build do
-  e "go build -v ./..."
+  e "go build -ldflags -s -v ./..."
 end
 
 desc 'Test all projects (short only)'
 task :test => [:build] do
-  e "go test -short -timeout 10s ./..."
+  e "go test -ldflags -s -short -timeout 10s ./..."
 end
 
 desc 'Test all projects'
 task :test_all => [:build] do
-  e "go test -timeout 120s -race ./..."
-  e "go test -timeout 120s github.com/square/p2/pkg/store/consul" # these have build flags that exclude them from race detector due to https://github.com/square/p2/issues/832
+  e "go test -ldflags -s -timeout 120s -race ./..."
+  e "go test -ldflags -s -timeout 120s github.com/square/p2/pkg/store/consul" # these have build flags that exclude them from race detector due to https://github.com/square/p2/issues/832
 end
 
 desc 'Update all dependencies'

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/user"
 	"path"
 	"path/filepath"
 	"strings"
@@ -427,7 +428,12 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 	// We don't chmod if the directory is already 755.
 	// Normally there is no harm in doing so,
 	// but on Travis we don't have permission to do so (we don't run as root).
-	if mode&0755 != 0755 {
+
+	currUser, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+	if mode&0755 != 0755 && currUser.Uid == "0" {
 		// keep whatever upper bit is there.
 		err = os.Chmod(os.TempDir(), (mode&07000)|0755)
 		if err != nil {


### PR DESCRIPTION
 - change godep back to v77
 - add temp fix for Rakefile (Go version < 1.8.1 and Command Line Tools 8.3)
 - prevent chmod'ing in preparer setup when not root (no permissions - fail when testing on local machines)