### PR TITLE
roll farm: only delete old RC if replica count is zero. otherwise page.

### DIFF
--- a/bin/p2-rctl/main.go
+++ b/bin/p2-rctl/main.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 	klabels "k8s.io/kubernetes/pkg/labels"
 
+	"github.com/square/p2/pkg/alerting"
 	"github.com/square/p2/pkg/cli"
 	"github.com/square/p2/pkg/health/checker"
 	"github.com/square/p2/pkg/labels"
@@ -376,6 +377,7 @@ func (r rctlParams) RollingUpdate(oldID, newID string, want, need int) {
 			r.logger,
 			session,
 			watchDelay,
+			alerting.NewNop(),
 		).Run(quit)
 		close(result)
 	}()

--- a/pkg/roll/farm.go
+++ b/pkg/roll/farm.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/rcrowley/go-metrics"
 
+	"github.com/square/p2/pkg/alerting"
 	"github.com/square/p2/pkg/audit"
 	"github.com/square/p2/pkg/health/checker"
 	"github.com/square/p2/pkg/labels"
@@ -39,6 +40,7 @@ type UpdateFactory struct {
 	HealthChecker checker.ConsulHealthChecker
 	Labeler       rc.Labeler
 	WatchDelay    time.Duration
+	Alerter       alerting.Alerter
 }
 
 func NewUpdateFactory(
@@ -48,6 +50,7 @@ func NewUpdateFactory(
 	healthChecker checker.ConsulHealthChecker,
 	labeler rc.Labeler,
 	watchDelay time.Duration,
+	alerter alerting.Alerter,
 ) UpdateFactory {
 	return UpdateFactory{
 		Store:         store,
@@ -56,6 +59,7 @@ func NewUpdateFactory(
 		HealthChecker: healthChecker,
 		Labeler:       labeler,
 		WatchDelay:    watchDelay,
+		Alerter:       alerter,
 	}
 }
 
@@ -70,6 +74,7 @@ func (f UpdateFactory) New(u roll_fields.Update, l logging.Logger, session consu
 		l,
 		session,
 		f.WatchDelay,
+		f.Alerter,
 	)
 }
 

--- a/pkg/roll/integration_test.go
+++ b/pkg/roll/integration_test.go
@@ -1,15 +1,25 @@
+// +build !race
+
 package roll
 
 import (
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/square/p2/pkg/alerting"
 	"github.com/square/p2/pkg/audit"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
+	"github.com/square/p2/pkg/manifest"
+	"github.com/square/p2/pkg/roll/fields"
 	"github.com/square/p2/pkg/store/consul/auditlogstore"
 	"github.com/square/p2/pkg/store/consul/consulutil"
+	"github.com/square/p2/pkg/store/consul/rcstore"
 	"github.com/square/p2/pkg/store/consul/rollstore"
+
+	klabels "k8s.io/kubernetes/pkg/labels"
 )
 
 func TestAuditLogCreation(t *testing.T) {
@@ -54,5 +64,111 @@ func TestAuditLogCreation(t *testing.T) {
 		if val.EventType != audit.RUCompletionEvent {
 			t.Fatalf("expected audit log type to be %s but was %s", audit.RUCompletionEvent, val.EventType)
 		}
+	}
+}
+
+func TestCleanupOldRCHappy(t *testing.T) {
+	fixture := consulutil.NewFixture(t)
+
+	applicator := labels.NewConsulApplicator(fixture.Client, 0)
+	rcStore := rcstore.NewConsul(fixture.Client, applicator, 0)
+
+	builder := manifest.NewBuilder()
+	builder.SetID("whatever")
+
+	rc, err := rcStore.Create(builder.GetManifest(), klabels.Everything(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	update := update{
+		Update:  fields.Update{OldRC: rc.ID},
+		logger:  logging.TestLogger(),
+		rcStore: rcStore,
+	}
+
+	quit := make(chan struct{})
+	defer close(quit)
+	update.cleanupOldRC(quit)
+
+	_, err = rcStore.Get(rc.ID)
+	switch err {
+	case rcstore.NoReplicationController:
+		//good
+	case nil:
+		t.Fatal("expected an error due to missing old RC")
+	default:
+		t.Fatalf("unexpected error when checking that old RC was deleted: %s", err)
+	}
+}
+
+// errorOnceChannelAlerter returns an error the first time you call Alert() and
+// then does not on subsequent calls. This lets us test code that must run
+// until an alert is sent
+type errorOnceChannelAlerter struct {
+	out     chan<- struct{}
+	ranOnce bool
+}
+
+func (c errorOnceChannelAlerter) Alert(alerting.AlertInfo) error {
+	c.out <- struct{}{}
+	if c.ranOnce {
+		return nil
+	}
+	c.ranOnce = true
+	return errors.New("some error")
+}
+
+func TestCleanupOldRCTooManyReplicas(t *testing.T) {
+	fixture := consulutil.NewFixture(t)
+
+	applicator := labels.NewConsulApplicator(fixture.Client, 0)
+	rcStore := rcstore.NewConsul(fixture.Client, applicator, 0)
+
+	builder := manifest.NewBuilder()
+	builder.SetID("whatever")
+
+	rc, err := rcStore.Create(builder.GetManifest(), klabels.Everything(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = rcStore.SetDesiredReplicas(rc.ID, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	alertOut := make(chan struct{})
+	defer close(alertOut)
+
+	update := update{
+		Update:  fields.Update{OldRC: rc.ID},
+		logger:  logging.TestLogger(),
+		rcStore: rcStore,
+		alerter: errorOnceChannelAlerter{out: alertOut},
+	}
+
+	quit := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		update.cleanupOldRC(quit)
+	}()
+
+	// the first attempt will error so make sure there are two attempts
+	<-alertOut
+	<-alertOut
+	close(quit)
+
+	wg.Wait()
+	_, err = rcStore.Get(rc.ID)
+	switch err {
+	case rcstore.NoReplicationController:
+		t.Fatal("rc was deleted even though it had some replicas desired")
+	case nil:
+		// good
+	default:
+		t.Fatalf("unexpected error when checking that old RC was not deleted: %s", err)
 	}
 }

--- a/pkg/roll/update_test.go
+++ b/pkg/roll/update_test.go
@@ -199,6 +199,7 @@ func TestLockRCs(t *testing.T) {
 		logging.DefaultLogger,
 		session,
 		0,
+		nil,
 	).(*update)
 	err = update.lockRCs(make(<-chan struct{}))
 	Assert(t).IsNil(err, "should not have erred locking RCs")


### PR DESCRIPTION
Previously the RU farm would always zero out the old RC's replica count
and then delete it if the "LeaveOld" flag was not set. This can lead to
bad situations if a math error is encountered when creating an RU
because we might delete an RC that was managing pods and then those pods
become orphaned.

This commit causes the RU farm to only delete the old RC if its replica
count is zero. Otherwise it will send an alert so a human user can
correct the situation.