### PR TITLE
travis: Run once with the race detector and once without

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: go
 go:
   - 1.7.4
 
+env:
+  - RACE=-race
+  - RACE=
+
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y runit

--- a/Rakefile
+++ b/Rakefile
@@ -32,8 +32,9 @@ end
 
 desc 'Test all projects'
 task :test_all => [:build] do
-  e "go test -ldflags -s -timeout 120s -race ./..."
-  e "go test -ldflags -s -timeout 120s github.com/square/p2/pkg/store/consul" # these have build flags that exclude them from race detector due to https://github.com/square/p2/issues/832
+  # due to https://github.com/square/p2/issues/832, some tests are excluded from -race
+  # So, we run once with the race detector and one without. See .travis.yml for setting ENV['RACE']
+  e "go test -ldflags -s -timeout 120s #{ENV['RACE']} ./..."
 end
 
 desc 'Update all dependencies'


### PR DESCRIPTION
We're working around https://github.com/square/p2/issues/832

We're refining the method used in https://github.com/square/p2/pull/831
It becomes harder to maintain the list of packages that will get
excluded from the race detector (and thus must be rerun without it), so
we will just run all tests without and all tests with.

Since we desire not to slow down the tests by running them twice, we
hope to mitigate the slowdown by running the two in parallel.