### PR TITLE
Fix function signature of WatchMatches() on grpc label client.

### DIFF
--- a/bin/grpc/clients/label-store-client/main.go
+++ b/bin/grpc/clients/label-store-client/main.go
@@ -63,7 +63,7 @@ func main() {
 }
 
 type matchWatcher interface {
-	WatchMatches(selector klabels.Selector, labelType labels.Type, quitCh <-chan struct{}) (chan []labels.Labeled, error)
+	WatchMatches(selector klabels.Selector, labelType labels.Type, aggregationRate time.Duration, quitCh <-chan struct{}) (chan []labels.Labeled, error)
 }
 
 func watchMatches(watcher matchWatcher) {
@@ -78,7 +78,7 @@ func watchMatches(watcher matchWatcher) {
 	}
 
 	quitCh := make(chan struct{})
-	outCh, err := watcher.WatchMatches(sel, lType, quitCh)
+	outCh, err := watcher.WatchMatches(sel, lType, 0, quitCh)
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/integration/single-node-slug-deploy/check.go
+++ b/integration/single-node-slug-deploy/check.go
@@ -910,7 +910,7 @@ func waitForPodLabeledWithRC(selector klabels.Selector, rcID fields.ID) error {
 	quitCh := make(chan struct{})
 	defer close(quitCh)
 
-	watchCh, err := grpcClient.WatchMatches(selector, labels.POD, quitCh)
+	watchCh, err := grpcClient.WatchMatches(selector, labels.POD, 0, quitCh)
 	if err != nil {
 		return fmt.Errorf("Could not initialize labels grpc client: %s", err)
 	}

--- a/pkg/grpc/labelstore/client/client.go
+++ b/pkg/grpc/labelstore/client/client.go
@@ -29,6 +29,16 @@ func NewClient(conn *grpc.ClientConn, logger logging.Logger) Client {
 	}
 }
 
+// this interface is just to make the compiler assert that our functions match
+// those in the direct consul applicator
+type client interface {
+	WatchMatches(selector klabels.Selector, labelType labels.Type, _ time.Duration, quitCh <-chan struct{}) (chan []labels.Labeled, error)
+}
+
+// assert that the labels applicator functions match the ones exposed here
+var _ client = labels.Applicator(nil)
+var _ client = Client{}
+
 // WatchMatches uses streaming gRPC to subscribe to updates to a label selector
 // and passes each update on the output channel. Returns an error if the
 // initial gRPC call fails. Any further connection breakages will attempt to be

--- a/pkg/grpc/labelstore/client/client.go
+++ b/pkg/grpc/labelstore/client/client.go
@@ -33,7 +33,9 @@ func NewClient(conn *grpc.ClientConn, logger logging.Logger) Client {
 // and passes each update on the output channel. Returns an error if the
 // initial gRPC call fails. Any further connection breakages will attempt to be
 // re-established in a loop.
-func (c Client) WatchMatches(selector klabels.Selector, labelType labels.Type, quitCh <-chan struct{}) (chan []labels.Labeled, error) {
+//
+// aggregationRate is unused because aggregation is handled by the server
+func (c Client) WatchMatches(selector klabels.Selector, labelType labels.Type, _ time.Duration, quitCh <-chan struct{}) (chan []labels.Labeled, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 
 	go func() {


### PR DESCRIPTION
The grpc label client is intended to implement some functions from the
labels.Applicator interface which benefit from centralizing queries on a
server. Recently WatchMatches() had its function signature change to
make the aggregation rate of queries configurable, however the grpc
client did not have a similar change made to its function signature.

This commit brings them into lockstep.