### PR TITLE
Fix a nil pointer exception in consulutil.WatchKeys()

### DIFF
--- a/pkg/store/consul/consulutil/watch.go
+++ b/pkg/store/consul/consulutil/watch.go
@@ -56,8 +56,6 @@ func WatchKeys(
 				WaitIndex:  currentIndex,
 				AllowStale: true,
 			})
-			consulLatencyHistogram.Update(int64(queryMeta.RequestTime))
-			listLatencyHistogram.Update(int64(time.Since(listStart) / time.Millisecond))
 			// outputPairsHistogram.Update(int64(sizeInBytes(keys)))
 			if err == CanceledError {
 				return
@@ -72,6 +70,8 @@ func WatchKeys(
 				continue
 			}
 
+			consulLatencyHistogram.Update(int64(queryMeta.RequestTime))
+			listLatencyHistogram.Update(int64(time.Since(listStart) / time.Millisecond))
 			// This might happen if a watch expires on a node that was stale for a
 			// long time.  Not likely but good to be careful.
 			if queryMeta.LastIndex < currentIndex {

--- a/pkg/store/consul/statusstore/podstatus/consul_store_test.go
+++ b/pkg/store/consul/statusstore/podstatus/consul_store_test.go
@@ -1,13 +1,10 @@
 package podstatus
 
 import (
-	"context"
 	"testing"
 
-	"github.com/square/p2/pkg/store/consul/consulutil"
 	"github.com/square/p2/pkg/store/consul/statusstore"
 	"github.com/square/p2/pkg/store/consul/statusstore/statusstoretest"
-	"github.com/square/p2/pkg/store/consul/transaction"
 	"github.com/square/p2/pkg/types"
 )
 
@@ -81,88 +78,6 @@ func TestDelete(t *testing.T) {
 
 	if !statusstore.IsNoStatus(err) {
 		t.Errorf("expected error to be NoStatus but was %s", err)
-	}
-}
-
-func TestMutateStatusNewKey(t *testing.T) {
-	fixture := consulutil.NewFixture(t)
-	defer fixture.Stop()
-	consulStore := statusstore.NewConsul(fixture.Client)
-	podStore := NewConsul(consulStore, "test_namespace")
-
-	key := types.NewPodUUID()
-	ctx, cancelFunc := transaction.New(context.Background())
-	defer cancelFunc()
-	err := podStore.MutateStatus(ctx, key, func(p PodStatus) (PodStatus, error) {
-		p.PodStatus = PodLaunched
-		return p, nil
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = transaction.Commit(ctx, cancelFunc, fixture.Client.KV())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Now try to get it and confirm the status was set
-	status, _, err := podStore.Get(key)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if status.PodStatus != PodLaunched {
-		t.Errorf("Expected pod status to be set to '%s' but was '%s'", PodLaunched, status.PodStatus)
-	}
-}
-
-func TestMutateStatusExistingKey(t *testing.T) {
-	fixture := consulutil.NewFixture(t)
-	defer fixture.Stop()
-	consulStore := statusstore.NewConsul(fixture.Client)
-	podStore := NewConsul(consulStore, "test_namespace")
-
-	key := types.NewPodUUID()
-	processStatus := ProcessStatus{
-		EntryPoint:   "echo_service",
-		LaunchableID: "some_launchable",
-		LastExit:     nil,
-	}
-	err := podStore.Set(key, PodStatus{
-		ProcessStatuses: []ProcessStatus{
-			processStatus,
-		},
-	})
-	if err != nil {
-		t.Fatalf("Unable to set up test with an existing key: %s", err)
-	}
-
-	ctx, cancelFunc := transaction.New(context.Background())
-	defer cancelFunc()
-	err = podStore.MutateStatus(ctx, key, func(p PodStatus) (PodStatus, error) {
-		p.PodStatus = PodLaunched
-		return p, nil
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	transaction.Commit(ctx, cancelFunc, fixture.Client.KV())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Now try to get it and confirm the status was set
-	status, _, err := podStore.Get(key)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if status.PodStatus != PodLaunched {
-		t.Errorf("Expected pod status to be set to '%s' but was '%s'", PodLaunched, status.PodStatus)
-	}
-
-	if len(status.ProcessStatuses) != 1 {
-		t.Error("ProcessStatus field didn't go untouched when mutating PodStatus")
 	}
 }
 

--- a/pkg/store/consul/statusstore/podstatus/integration_test.go
+++ b/pkg/store/consul/statusstore/podstatus/integration_test.go
@@ -1,0 +1,95 @@
+// +build !race
+
+package podstatus
+
+import (
+	"context"
+	"testing"
+
+	"github.com/square/p2/pkg/store/consul/consulutil"
+	"github.com/square/p2/pkg/store/consul/statusstore"
+	"github.com/square/p2/pkg/store/consul/transaction"
+	"github.com/square/p2/pkg/types"
+)
+
+func TestMutateStatusNewKey(t *testing.T) {
+	fixture := consulutil.NewFixture(t)
+	defer fixture.Stop()
+	consulStore := statusstore.NewConsul(fixture.Client)
+	podStore := NewConsul(consulStore, "test_namespace")
+
+	key := types.NewPodUUID()
+	ctx, cancelFunc := transaction.New(context.Background())
+	defer cancelFunc()
+	err := podStore.MutateStatus(ctx, key, func(p PodStatus) (PodStatus, error) {
+		p.PodStatus = PodLaunched
+		return p, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = transaction.Commit(ctx, cancelFunc, fixture.Client.KV())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Now try to get it and confirm the status was set
+	status, _, err := podStore.Get(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if status.PodStatus != PodLaunched {
+		t.Errorf("Expected pod status to be set to '%s' but was '%s'", PodLaunched, status.PodStatus)
+	}
+}
+
+func TestMutateStatusExistingKey(t *testing.T) {
+	fixture := consulutil.NewFixture(t)
+	defer fixture.Stop()
+	consulStore := statusstore.NewConsul(fixture.Client)
+	podStore := NewConsul(consulStore, "test_namespace")
+
+	key := types.NewPodUUID()
+	processStatus := ProcessStatus{
+		EntryPoint:   "echo_service",
+		LaunchableID: "some_launchable",
+		LastExit:     nil,
+	}
+	err := podStore.Set(key, PodStatus{
+		ProcessStatuses: []ProcessStatus{
+			processStatus,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Unable to set up test with an existing key: %s", err)
+	}
+
+	ctx, cancelFunc := transaction.New(context.Background())
+	defer cancelFunc()
+	err = podStore.MutateStatus(ctx, key, func(p PodStatus) (PodStatus, error) {
+		p.PodStatus = PodLaunched
+		return p, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	transaction.Commit(ctx, cancelFunc, fixture.Client.KV())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Now try to get it and confirm the status was set
+	status, _, err := podStore.Get(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if status.PodStatus != PodLaunched {
+		t.Errorf("Expected pod status to be set to '%s' but was '%s'", PodLaunched, status.PodStatus)
+	}
+
+	if len(status.ProcessStatuses) != 1 {
+		t.Error("ProcessStatus field didn't go untouched when mutating PodStatus")
+	}
+}


### PR DESCRIPTION
Some metrics histograms are updated to track things like consul latency.
However in the WatchKeys() function, the queryMeta return value from the
consul List() operation was being used to update histograms before
checking that the response came back without an error. If there is an
error then queryMeta will be nil which will cause a server panic.