### PR TITLE
Fix an inverted for loop exit condition.

### DIFF
--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -420,7 +420,7 @@ func (p *Preparer) installAndLaunchPod(pair ManifestPair, pod Pod, logger loggin
 			}
 		} else {
 			backoff := 100 * time.Millisecond
-			for err := p.writeStatusRecord(pair, logger); err == nil; err = p.writeStatusRecord(pair, logger) {
+			for err := p.writeStatusRecord(pair, logger); err != nil; err = p.writeStatusRecord(pair, logger) {
 				time.Sleep(backoff)
 				backoff = 2 * backoff
 				if backoff > time.Minute {


### PR DESCRIPTION
After the preparer launches a oneoff pod, it writes a status record for
that pod indicating that it has launched. It is intended to retry
forever until the record is written successfully.

However a typo in the for loop condition did the opposite, it will retry
forever if it succeeds and only exit when an error is hit (even if there
was no successful write).