### PR TITLE
Remove "expected" warn

### DIFF
--- a/pkg/labels/http_applicator.go
+++ b/pkg/labels/http_applicator.go
@@ -278,7 +278,6 @@ func (h *httpApplicator) getMatches(selector labels.Selector, labelType Type, ca
 	if err == nil {
 		return labeled, nil
 	}
-	h.logger.Warnln(err)
 
 	// fallback to a list of IDs
 	matches := []string{}


### PR DESCRIPTION
If this case fails, it's likely that the labels returned follow a different
schema. The error case in which the response is totally invalid JSON already
returns an error.