### PR TITLE
change config's type to string -> interface{}

### DIFF
--- a/pkg/store/consul/configstore/store.go
+++ b/pkg/store/consul/configstore/store.go
@@ -25,7 +25,7 @@ func (v *Version) uint64() uint64 {
 }
 
 type Fields struct {
-	Config map[interface{}]interface{}
+	Config map[string]interface{}
 	ID     ID
 }
 
@@ -75,7 +75,7 @@ func (cs *ConsulStore) FetchConfig(id ID) (Fields, *Version, error) {
 	if err != nil {
 		return Fields{}, nil, nil
 	}
-	parsedConfig := make(map[interface{}]interface{})
+	parsedConfig := make(map[string]interface{})
 	err = yaml.Unmarshal([]byte(env.Config), &parsedConfig)
 	if err != nil {
 		return Fields{}, nil, util.Errorf("Config did not unmarshal as YAML! %v", err)

--- a/pkg/store/consul/configstore/store_test.go
+++ b/pkg/store/consul/configstore/store_test.go
@@ -17,7 +17,7 @@ type FakeConsulKV struct {
 	config map[ID][]byte
 }
 
-func (kv *FakeConsulKV) insertConfig(id ID, m map[interface{}]interface{}) {
+func (kv *FakeConsulKV) insertConfig(id ID, m map[string]interface{}) {
 	if kv.config == nil {
 		kv.config = make(map[ID][]byte)
 	}
@@ -54,7 +54,7 @@ func (kv *FakeConsulKV) DeleteCAS(p *api.KVPair, q *api.WriteOptions) (bool, *ap
 	return true, nil, nil
 }
 
-func yamlMarshal(m map[interface{}]interface{}) string {
+func yamlMarshal(m map[string]interface{}) string {
 	bs, err := yaml.Marshal(m)
 	if err != nil {
 		panic(fmt.Sprintf("I need better YAML, y'all: %v", err))
@@ -75,7 +75,7 @@ func TestFetchConfig(t *testing.T) {
 	fakeConsulKV := FakeConsulKV{}
 	consulStore := NewConsulStore(&fakeConsulKV, labels.NewFakeApplicator())
 
-	m := make(map[interface{}]interface{})
+	m := make(map[string]interface{})
 	m["configuration"] = "hell yeah"
 	id := ID("foo")
 	fakeConsulKV.insertConfig(id, m)
@@ -110,7 +110,7 @@ func TestPutConfig(t *testing.T) {
 	consulStore := NewConsulStore(&fakeConsulKV, labels.NewFakeApplicator())
 
 	id := ID("foo")
-	m := make(map[interface{}]interface{})
+	m := make(map[string]interface{})
 	m["configuration"] = "hell yeah"
 	f := Fields{
 		ID:     id,
@@ -144,7 +144,7 @@ func TestDeleteConfig(t *testing.T) {
 	consulStore := NewConsulStore(&fakeConsulKV, labels.NewFakeApplicator())
 
 	id := ID("foo")
-	m := make(map[interface{}]interface{})
+	m := make(map[string]interface{})
 	m["configuration"] = "hell yeah"
 	f := Fields{
 		ID:     id,
@@ -169,7 +169,7 @@ func TestLabels(t *testing.T) {
 	consulStore := NewConsulStore(&fakeConsulKV, labels.NewFakeApplicator())
 
 	id := ID("foo")
-	m := make(map[interface{}]interface{})
+	m := make(map[string]interface{})
 	m["configuration"] = "hell yeah"
 	f := Fields{
 		ID:     id,


### PR DESCRIPTION
Golang's JSON marshal doesn't support arbitrary types as keys, probably because
JSON itself does not support this.