### PR TITLE
Effectively revert a change made in #890

### DIFF
--- a/pkg/store/consul/configstore/store.go
+++ b/pkg/store/consul/configstore/store.go
@@ -25,7 +25,7 @@ func (v *Version) uint64() uint64 {
 }
 
 type Fields struct {
-	Config map[string]interface{}
+	Config map[interface{}]interface{}
 	ID     ID
 }
 
@@ -73,7 +73,7 @@ func (cs *ConsulStore) FetchConfig(id ID) (Fields, *Version, error) {
 	if err != nil {
 		return Fields{}, nil, nil
 	}
-	parsedConfig := make(map[string]interface{})
+	parsedConfig := make(map[interface{}]interface{})
 	err = yaml.Unmarshal([]byte(env.Config), &parsedConfig)
 	if err != nil {
 		return Fields{}, nil, util.Errorf("Config did not unmarshal as YAML! %v", err)

--- a/pkg/store/consul/configstore/store_test.go
+++ b/pkg/store/consul/configstore/store_test.go
@@ -20,7 +20,7 @@ type FakeConsulKV struct {
 	config map[ID][]byte
 }
 
-func (kv *FakeConsulKV) insertConfig(id ID, m map[string]interface{}) {
+func (kv *FakeConsulKV) insertConfig(id ID, m map[interface{}]interface{}) {
 	if kv.config == nil {
 		kv.config = make(map[ID][]byte)
 	}
@@ -57,7 +57,7 @@ func (kv *FakeConsulKV) DeleteCAS(p *api.KVPair, q *api.WriteOptions) (bool, *ap
 	return true, nil, nil
 }
 
-func yamlMarshal(m map[string]interface{}) string {
+func yamlMarshal(m map[interface{}]interface{}) string {
 	bs, err := yaml.Marshal(m)
 	if err != nil {
 		panic(fmt.Sprintf("I need better YAML, y'all: %v", err))
@@ -78,7 +78,7 @@ func TestFetchConfig(t *testing.T) {
 	fakeConsulKV := FakeConsulKV{}
 	consulStore := NewConsulStore(&fakeConsulKV, labels.NewFakeApplicator())
 
-	m := make(map[string]interface{})
+	m := make(map[interface{}]interface{})
 	m["configuration"] = "hell yeah"
 	id := ID("foo")
 	fakeConsulKV.insertConfig(id, m)
@@ -113,7 +113,7 @@ func TestPutConfig(t *testing.T) {
 	consulStore := NewConsulStore(&fakeConsulKV, labels.NewFakeApplicator())
 
 	id := ID("foo")
-	m := make(map[string]interface{})
+	m := make(map[interface{}]interface{})
 	m["configuration"] = "hell yeah"
 	f := Fields{
 		ID:     id,
@@ -147,7 +147,7 @@ func TestDeleteConfig(t *testing.T) {
 	consulStore := NewConsulStore(&fakeConsulKV, labels.NewFakeApplicator())
 
 	id := ID("foo")
-	m := make(map[string]interface{})
+	m := make(map[interface{}]interface{})
 	m["configuration"] = "hell yeah"
 	f := Fields{
 		ID:     id,
@@ -172,7 +172,7 @@ func TestLabels(t *testing.T) {
 	consulStore := NewConsulStore(&fakeConsulKV, labels.NewFakeApplicator())
 
 	id := ID("foo")
-	m := make(map[string]interface{})
+	m := make(map[interface{}]interface{})
 	m["configuration"] = "hell yeah"
 	f := Fields{
 		ID:     id,
@@ -208,7 +208,7 @@ func TestPutConfigTxn(t *testing.T) {
 	consulStore := NewConsulStore(fixture.Client.KV(), labels.NewFakeApplicator())
 
 	id := ID("foo")
-	m := make(map[string]interface{})
+	m := make(map[interface{}]interface{})
 	m["configuration"] = "hell yeah"
 	f := Fields{
 		ID:     id,
@@ -249,7 +249,7 @@ func TestDeleteConfigTxn(t *testing.T) {
 	consulStore := NewConsulStore(fixture.Client.KV(), labels.NewFakeApplicator())
 
 	id := ID("foo")
-	m := make(map[string]interface{})
+	m := make(map[interface{}]interface{})
 	m["configuration"] = "hell yeah"
 	f := Fields{
 		ID:     id,


### PR DESCRIPTION
The type of map used by pkg/manifest is map[interface{}]interface{} so it
behooves us to match that. The map[string]interface{} change was to support JSON
marshalling of config stanzas, which seems less important now than it once did.