### PR TITLE
Pick a private IP for consul to bind to.

### DIFF
--- a/integration/single-node-slug-deploy/check.go
+++ b/integration/single-node-slug-deploy/check.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"log"
 	"math/rand"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -722,10 +723,21 @@ func getConsulManifest(dir string) (string, error) {
 		}
 	}
 
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return "", util.Errorf("could not list host interfaces to find which to bind consul to: %s", err)
+	}
+	addrs, err := interfaces[0].Addrs()
+	if err != nil {
+		return "", util.Errorf("could not list addresses to find one to bind consul to: %s", err)
+	}
+	ip := strings.Split(addrs[0].String(), "/")[0]
+
 	rubyBin := filepath.Join(dir, "launch")
 	cmds := `#!/usr/bin/env ruby
 
-exec "/usr/bin/consul agent -server -bootstrap-expect 1 -data-dir /tmp/consul"`
+exec "/usr/bin/consul agent -server -bootstrap-expect 1 -data-dir /tmp/consul -bind %%%%"`
+	cmds = strings.Replace(cmds, "%%%%", ip, -1)
 	err = ioutil.WriteFile(rubyBin, []byte(cmds), 0777)
 	if err != nil {
 		return "", util.Errorf("could not write consul exec script: %s", err)

--- a/integration/single-node-slug-deploy/check.go
+++ b/integration/single-node-slug-deploy/check.go
@@ -355,9 +355,9 @@ func verifyProcessExit(errCh chan error, tempDir string, logger logging.Logger) 
 		select {
 		case <-timeout:
 			// Try to manually run the finish script in order to make debugging the test failure easier
-			output, err := exec.Command("sudo", fmt.Sprintf("/var/service/hello-%s__hello__launch/finish", podUniqueKey), "1", "2").CombinedOutput()
+			output, debugErr := exec.Command("sudo", fmt.Sprintf("/var/service/hello-%s__hello__launch/finish", podUniqueKey), "1", "2").CombinedOutput()
 			if err != nil {
-				logger.WithError(err).Infoln("DEBUG: Debug attempt to run finish script failed")
+				logger.WithError(debugErr).Infoln("DEBUG: Debug attempt to run finish script failed")
 			}
 
 			logger.Infof("DEBUG: Output of direct execution of finish script: %s", string(output))

--- a/integration/single-node-slug-deploy/check.go
+++ b/integration/single-node-slug-deploy/check.go
@@ -355,7 +355,7 @@ func verifyProcessExit(errCh chan error, tempDir string, logger logging.Logger) 
 		select {
 		case <-timeout:
 			// Try to manually run the finish script in order to make debugging the test failure easier
-			output, debugErr := exec.Command("sudo", fmt.Sprintf("/var/service/hello-%s__hello__launch/finish", podUniqueKey), "1", "2").CombinedOutput()
+			output, debugErr := exec.Command("sudo", fmt.Sprintf("/var/service/hello-%s__hello__bin__launch/finish", podUniqueKey), "1", "2").CombinedOutput()
 			if err != nil {
 				logger.WithError(debugErr).Infoln("DEBUG: Debug attempt to run finish script failed")
 			}

--- a/integration/travis.sh
+++ b/integration/travis.sh
@@ -15,6 +15,13 @@ sudo mkdir -p /etc/servicebuilder.d /var/service-stage /var/service
 sudo cp $GOPATH/bin/p2-exec /usr/local/bin
 PATH=$PATH:$GOPATH/bin
 
+# At some point travis changed so that directories have 750 permissions, but we
+# need +x so we can traverse to the files underneath
+sudo chmod 755 /home
+sudo chmod 755 /home/travis
+sudo chmod 755 $GOPATH
+sudo chmod 755 $GOPATH/bin
+
 # make ssl certs
 subj="
 C=US


### PR DESCRIPTION
This addresses travis errors where consul won't start with the following
error:

2017-07-20_18:14:35.22743 ==> Error starting agent: Failed to get
advertise address: Multiple private IPs found. Please configure one.