### PR TITLE
Close quit channels on shutdown rather than send a value

### DIFF
--- a/bin/p2-preparer/main.go
+++ b/bin/p2-preparer/main.go
@@ -113,7 +113,7 @@ func waitForTermination(logger logging.Logger, quitMainUpdate chan struct{}, qui
 	received := <-signalCh
 	logger.WithField("signal", received.String()).Infoln("Stopping work")
 	for _, quitCh := range quitChans {
-		quitCh <- struct{}{}
+		close(quitCh)
 	}
 	quitMainUpdate <- struct{}{}
 	<-quitMainUpdate // acknowledgement


### PR DESCRIPTION
The preparer captures TERM signals to buy time to get the work it's
doing into a logical stopping place before exiting. It does this by
creating a bunch of quit channels, one for each function the preparer
performs and then signalling exit via the quit channels.

Prior to this commit it would send a value on the quit channels to
signal that an exit should happen, however if a preparer function shared
the quit channel across goroutines this would cause only one of them to
quit.

This commit instead closes the channel which will cause any watcher on
the quit channel to fire and exit.