### PR TITLE
Use consistent rather than stale queries in watches.

### DIFF
--- a/pkg/store/consul/consulutil/watch.go
+++ b/pkg/store/consul/consulutil/watch.go
@@ -53,8 +53,7 @@ func WatchKeys(
 			timer.Reset(pause)
 			listStart = time.Now()
 			keys, queryMeta, err := SafeKeys(clientKV, done, prefix, &api.QueryOptions{
-				WaitIndex:  currentIndex,
-				AllowStale: true,
+				WaitIndex: currentIndex,
 			})
 			// outputPairsHistogram.Update(int64(sizeInBytes(keys)))
 			if err == CanceledError {
@@ -153,8 +152,7 @@ func WatchPrefix(
 		timer.Reset(pause) // upper bound on request rate
 		safeListStart = time.Now()
 		pairs, queryMeta, err := List(clientKV, done, prefix, &api.QueryOptions{
-			WaitIndex:  currentIndex,
-			AllowStale: true,
+			WaitIndex: currentIndex,
 		})
 		listLatencyHistogram.Update(int64(time.Since(safeListStart) / time.Millisecond))
 		switch err {
@@ -410,8 +408,7 @@ func WatchDiff(
 
 			safeListStart = time.Now()
 			pairs, queryMeta, err := List(clientKV, quitCh, prefix, &api.QueryOptions{
-				WaitIndex:  currentIndex,
-				AllowStale: initialized, // do a consistent fetch on the first list so that subsequent WatchDiff calls don't travel backward in time
+				WaitIndex: currentIndex,
 			})
 			listLatencyHistogram.Update(int64(time.Since(safeListStart) / time.Millisecond))
 


### PR DESCRIPTION
As P2 was scaling, it was thought that we could spread load across
consul servers better by using stale queries within "watch" loops since
a stale query can be answered by whichever consul node receives the
request rather than requiring another round trip to the consul leader
node.

This was thought to be completely safe since using an index along with
the query guarantees that successive queries can't "time travel"
backwards.

However, some scalability wins in other areas (mainly the query-batching
capabilities within the labels HTTP server) have made this an
unnecessary complexity of the system. Additionally, after restarting
consul nodes we have occasionally seen a stale query return a 404
response which can have bad consequences if the proper failsafes are not
in place. We believe that using a consistent query will eliminate this
possibility since the leader node should always be "caught up" by
definition.