### PR TITLE
Treat hook failures like normal failures.

### DIFF
--- a/integration/travis.sh
+++ b/integration/travis.sh
@@ -36,4 +36,4 @@ CERTPATH=/var/tmp/certs
 mkdir -p $CERTPATH
 openssl req -x509 -newkey rsa:2048 -keyout $CERTPATH/key.pem -out $CERTPATH/cert.pem -nodes -days 300 -subj "$(echo -n "$subj" | tr "\n" "/")"
 
-sudo env PATH=$PATH GOPATH=$GOPATH GOROOT=$GOROOT go run integration/single-node-slug-deploy/check.go
+sudo env PATH=$PATH GOPATH=$GOPATH GOROOT=$GOROOT go run integration/single-node-slug-deploy/check.go --no-add-user

--- a/pkg/store/consul/consulutil/watch.go
+++ b/pkg/store/consul/consulutil/watch.go
@@ -377,11 +377,6 @@ func WatchDiff(
 	outCh := make(chan *WatchedChanges)
 	outErrors := make(chan error)
 
-	// initialized tracks whether we've done a loop iteration yet. For the first iteration, we don't want to
-	// do a stale query of consul to ensure the caller of WatchDiff() doesn't get a more stale result
-	// than in a previous watch. Once we've initialized state with the last index from a consistent query
-	// we can then rely on stale queries and discard values which have a lower index.
-	initialized := false
 	go func() {
 		defer close(outCh)
 		defer close(outErrors)
@@ -434,7 +429,6 @@ func WatchDiff(
 			}
 			consulLatencyHistogram.Update(int64(queryMeta.RequestTime))
 			currentIndex = queryMeta.LastIndex
-			initialized = true
 			// A copy used to keep track of what was deleted
 			mapCopy := make(map[string]*api.KVPair)
 			for key, val := range keys {


### PR DESCRIPTION
Up until this commit, hook failures woul not stop a pod from being
installed and having reality updated. Hook failures were logged but
otherwise ignored.

This commit changes this by treating a hook failure as a critical
failure which will cause the entire pod installation routine to be
retried (the same way a download failure is treated, for example).

This means that P2 operators will have confidence that if reality is
updated for a pod, that all of its hooks must have succeeded. Previously
this was not the case and the philosophy was that P2 applications should
check for conditions they expect hooks to put in place within their
health checks, which will prevent a rolling update from rendering all
pod instances within a pod cluster to be nonfunctional