### PR TITLE
Use contexts for cancellation in daemon set farm.

### DIFF
--- a/bin/p2-dsctl/main.go
+++ b/bin/p2-dsctl/main.go
@@ -143,7 +143,7 @@ func main() {
 
 		fmt.Fprintf(os.Stderr, "checking that that the given selector doesn't overlap nodes with other %s daemon sets\n", manifest.ID())
 
-		conflictingDS, isContending, err := ds.DSContends(&newDS, scheduler.NewApplicatorScheduler(applicator), dsstore)
+		conflictingDS, isContending, err := ds.DSContends(newDS, scheduler.NewApplicatorScheduler(applicator), dsstore)
 		if err != nil {
 			log.Fatalf("failed to check for daemon set overlap: %s", err)
 		}

--- a/pkg/ds/daemon_set.go
+++ b/pkg/ds/daemon_set.go
@@ -63,7 +63,7 @@ type DaemonSet interface {
 	//
 	// The caller is responsible for sending signals when something has been changed
 	WatchDesires(
-		quitCh <-chan struct{},
+		ctx context.Context,
 		updatedCh <-chan *fields.DaemonSet,
 		deletedCh <-chan *fields.DaemonSet,
 	) <-chan error
@@ -244,12 +244,19 @@ func (ds *daemonSet) MetricNames(suffix string) []string {
 }
 
 func (ds *daemonSet) WatchDesires(
-	quitCh <-chan struct{},
+	ctx context.Context,
 	updatedCh <-chan *fields.DaemonSet,
 	deletedCh <-chan *fields.DaemonSet,
 ) <-chan error {
 	errCh := make(chan error)
-	nodesChangedCh := ds.watcher.WatchMatchDiff(ds.NodeSelector, labels.NODE, ds.labelsAggregationRate, quitCh)
+	// TODO: make WatchMatchDiff take a context instead of a quit channel
+	watchMatchQuitCh := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		close(watchMatchQuitCh)
+	}()
+
+	nodesChangedCh := ds.watcher.WatchMatchDiff(ds.NodeSelector, labels.NODE, ds.labelsAggregationRate, watchMatchQuitCh)
 	// Do something whenever something is changed
 	go func() {
 		var err error
@@ -280,7 +287,7 @@ func (ds *daemonSet) WatchDesires(
 					// This is required in case the user disables the daemon set
 					// so that the timer would be stopped after
 					err = nil
-				case <-quitCh:
+				case <-ctx.Done():
 					return
 				}
 			} else {
@@ -371,7 +378,7 @@ func (ds *daemonSet) WatchDesires(
 					continue
 				}
 
-			case <-quitCh:
+			case <-ctx.Done():
 				return
 			}
 		}

--- a/pkg/ds/daemon_set_test.go
+++ b/pkg/ds/daemon_set_test.go
@@ -98,8 +98,8 @@ func watchDSChanges(
 	ctx context.Context,
 	ds *daemonSet,
 	dsStore DaemonSetStore,
-	updatedCh chan<- *ds_fields.DaemonSet,
-	deletedCh chan<- *ds_fields.DaemonSet,
+	updatedCh chan<- ds_fields.DaemonSet,
+	deletedCh chan<- ds_fields.DaemonSet,
 ) <-chan error {
 	errCh := make(chan error)
 	quitCh := make(chan struct{})
@@ -131,14 +131,14 @@ func watchDSChanges(
 			// creations are handled when WatchDesires is called, so ignore them here
 			for _, changedDS := range watched.Updated {
 				if dsID == changedDS.ID {
-					ds.logger.NoFields().Infof("Watched daemon set was updated: %v", *changedDS)
-					updatedCh <- changedDS
+					ds.logger.NoFields().Infof("Watched daemon set was updated: %v", changedDS)
+					updatedCh <- *changedDS
 				}
 			}
 			for _, changedDS := range watched.Deleted {
 				if dsID == changedDS.ID {
-					ds.logger.NoFields().Infof("Watched daemon set was deleted: %v", *changedDS)
-					deletedCh <- changedDS
+					ds.logger.NoFields().Infof("Watched daemon set was deleted: %v", changedDS)
+					deletedCh <- *changedDS
 				}
 			}
 		}
@@ -238,8 +238,8 @@ func TestSchedule(t *testing.T) {
 	// Adds a watch that will automatically send a signal when a change was made
 	// to the daemon set
 	//
-	updatedCh := make(chan *ds_fields.DaemonSet)
-	deletedCh := make(chan *ds_fields.DaemonSet)
+	updatedCh := make(chan ds_fields.DaemonSet)
+	deletedCh := make(chan ds_fields.DaemonSet)
 	desiresErrCh := ds.WatchDesires(ctx, updatedCh, deletedCh)
 	dsChangesErrCh := watchDSChanges(ctx, ds, dsStore, updatedCh, deletedCh)
 
@@ -490,8 +490,8 @@ func TestPublishToReplication(t *testing.T) {
 	// Adds a watch that will automatically send a signal when a change was made
 	// to the daemon set
 	//
-	updatedCh := make(chan *ds_fields.DaemonSet)
-	deletedCh := make(chan *ds_fields.DaemonSet)
+	updatedCh := make(chan ds_fields.DaemonSet)
+	deletedCh := make(chan ds_fields.DaemonSet)
 	desiresErrCh := ds.WatchDesires(ctx, updatedCh, deletedCh)
 	dsChangesErrCh := watchDSChanges(ctx, ds, dsStore, updatedCh, deletedCh)
 

--- a/pkg/ds/daemon_set_test.go
+++ b/pkg/ds/daemon_set_test.go
@@ -95,13 +95,18 @@ func waitForNodes(
 // since these are unit tests and have little daemon sets, we will watch
 // the entire tree for each daemon set for now
 func watchDSChanges(
+	ctx context.Context,
 	ds *daemonSet,
 	dsStore DaemonSetStore,
-	quitCh <-chan struct{},
 	updatedCh chan<- *ds_fields.DaemonSet,
 	deletedCh chan<- *ds_fields.DaemonSet,
 ) <-chan error {
 	errCh := make(chan error)
+	quitCh := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		close(quitCh)
+	}()
 	changesCh := dsStore.Watch(quitCh)
 
 	go func() {
@@ -113,7 +118,7 @@ func watchDSChanges(
 			// Get some changes
 			select {
 			case watched = <-changesCh:
-			case <-quitCh:
+			case <-ctx.Done():
 				return
 			}
 
@@ -233,11 +238,10 @@ func TestSchedule(t *testing.T) {
 	// Adds a watch that will automatically send a signal when a change was made
 	// to the daemon set
 	//
-	quitCh := make(chan struct{})
 	updatedCh := make(chan *ds_fields.DaemonSet)
 	deletedCh := make(chan *ds_fields.DaemonSet)
-	desiresErrCh := ds.WatchDesires(quitCh, updatedCh, deletedCh)
-	dsChangesErrCh := watchDSChanges(ds, dsStore, quitCh, updatedCh, deletedCh)
+	desiresErrCh := ds.WatchDesires(ctx, updatedCh, deletedCh)
+	dsChangesErrCh := watchDSChanges(ctx, ds, dsStore, updatedCh, deletedCh)
 
 	// We need to be careful when shutting down in order to avoid data
 	// races, since updatedCh and deletedCh are shared between two
@@ -246,7 +250,7 @@ func TestSchedule(t *testing.T) {
 	// respective output channels have closed which indicates that they
 	// won't try to send any more values
 	defer func() {
-		close(quitCh)
+		cancel()
 		desiresErrChClosed := false
 		dsChangesErrChClosed := false
 		for !dsChangesErrChClosed || !desiresErrChClosed {
@@ -486,11 +490,10 @@ func TestPublishToReplication(t *testing.T) {
 	// Adds a watch that will automatically send a signal when a change was made
 	// to the daemon set
 	//
-	quitCh := make(chan struct{})
 	updatedCh := make(chan *ds_fields.DaemonSet)
 	deletedCh := make(chan *ds_fields.DaemonSet)
-	desiresErrCh := ds.WatchDesires(quitCh, updatedCh, deletedCh)
-	dsChangesErrCh := watchDSChanges(ds, dsStore, quitCh, updatedCh, deletedCh)
+	desiresErrCh := ds.WatchDesires(ctx, updatedCh, deletedCh)
+	dsChangesErrCh := watchDSChanges(ctx, ds, dsStore, updatedCh, deletedCh)
 
 	// We need to be careful when shutting down in order to avoid data
 	// races, since updatedCh and deletedCh are shared between two
@@ -499,7 +502,7 @@ func TestPublishToReplication(t *testing.T) {
 	// respective output channels have closed which indicates that they
 	// won't try to send any more values
 	defer func() {
-		close(quitCh)
+		cancel()
 		desiresErrChClosed := false
 		dsChangesErrChClosed := false
 		for !dsChangesErrChClosed || !desiresErrChClosed {
@@ -515,7 +518,7 @@ func TestPublishToReplication(t *testing.T) {
 			case <-deletedCh:
 			case <-updatedCh:
 			case <-time.After(1 * time.Second):
-				t.Fatal("watchDSChanges or WatchDesires did not exit promptly after closing quitCh")
+				t.Fatal("watchDSChanges or WatchDesires did not exit promptly after canceling context")
 			}
 		}
 		close(updatedCh)


### PR DESCRIPTION
This will be useful in order to pass a context containing a partial
consul transaction that ensures that the daemon set farm still holds the
lock that it's supposed to be when it performs consul operations. This
will be useful to protect against multiple daemon set farms writing the
same daemon set status entry with conflicting information.