### PR TITLE
Exempt p2-preparer itself from hook failure handling.

### DIFF
--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -157,7 +157,10 @@ func (p *Preparer) tryRunHooks(hookType hooks.HookType, pod hooks.Pod, manifest 
 			"hooks": hookType}).Errorln("Encountered a hook error")
 	}
 
-	return err == nil
+	// Ignore hook errors if the preparer itself is being deployed. The preparer
+	// needs to be resilient to hook failures to make it easier to address issues
+	// that come up
+	return err == nil || manifest.ID() == constants.PreparerPodID
 }
 
 // no return value, no output channels. This should do everything it needs to do


### PR DESCRIPTION
Up until recently, p2-preparer would never halt the installation process
of a pod if a hook failure was experienced. This meant that pods could
be installed/updated if a hook was broken but also created situations
where it would appear that everything worked but in fact something that
a hook was supposed to do would be incomplete.

A recent commit made p2-preparer treat hook failures as critical ones,
which would cause the entire pod update to restart.

This created an unintended issue when a hook failure affects the
p2-preparer updating itself, in which the preparer might stop itself but
then fail to start itself again if an error is encountered during the
"before_launch" hook cycle or earlier.

This commit makes it so that hook failures are still ignored when run on
the p2-preparer pod, which should make it easier to recover from issues
with bad hooks in the future.