### PR TITLE
Improve transactional locking API

### DIFF
--- a/pkg/ds/farm_test.go
+++ b/pkg/ds/farm_test.go
@@ -553,7 +553,7 @@ func TestFarmSchedule(t *testing.T) {
 		dsToUpdate.NodeSelector = someSelector
 		return dsToUpdate, nil
 	}
-	_, err = dsStore.MutateDS(anotherDSData.ID, mutator)
+	anotherDSData, err = dsStore.MutateDS(anotherDSData.ID, mutator)
 	Assert(t).IsNil(err, "Expected no error mutating daemon set")
 	err = waitForMutateSelector(dsf, anotherDSData)
 	Assert(t).IsNil(err, "Expected daemon set to be mutated in farm")

--- a/pkg/store/consul/consultest/fake_session.go
+++ b/pkg/store/consul/consultest/fake_session.go
@@ -84,8 +84,8 @@ func (f *fakeSession) Lock(key string) (consul.Unlocker, error) {
 	}, nil
 }
 
-func (f *fakeSession) LockTxn(context.Context, context.Context, context.Context, string) error {
-	return util.Errorf("LockTxn not implemented in fakeSession. Use a real consul store with a real sesion via consulutil.NewFixture() if this functionality is desired")
+func (f *fakeSession) LockTxn(context.Context, string) (consul.TxnUnlocker, error) {
+	return nil, util.Errorf("LockTxn not implemented in fakeSession. Use a real consul store with a real sesion via consulutil.NewFixture() if this functionality is desired")
 }
 
 // Not currently implemented


### PR DESCRIPTION
This commit reworks the way LockTxn() works on a consul session. Prior
to this commit you had to pass in 3 different context.Context values
each with an inner consul transaction, and LockTxn() would load each of
them up with the respective consul operations that enable locking,
unlocking, and checking that the lock is held within consul
transactions.

In practice this is very cumbersome since callers acquiring locks must
prepare all of the contexts ahead of time, and preserve the contexts and
their cancellations everywhere where they are needed.

This commit changes the LockTxn() function to only take a single context
intended for locking the key and returns an interface which can be used
to load up contexts with unlocking and check-locking operations
respectively.

This will means callers can simply pass around a reference to that
interface and then create contexts on the fly when needed for unlocking
or checking that a lock is held within a transaction.