### PR TITLE
pods: Pass fetcher from factory to pods

### DIFF
--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -262,7 +262,7 @@ func TestWriteManifestWillReturnOldManifestTempPath(t *testing.T) {
 
 	poddir, err := ioutil.TempDir("", "poddir")
 	Assert(t).IsNil(err, "couldn't create tempdir")
-	pod := newPodWithHome("testPod", "", poddir, "testNode", "")
+	pod := newPodWithHome("testPod", "", poddir, "testNode", "", nil)
 
 	// set the RunAs user to the user running the test, because when we
 	// write files we need an owner.


### PR DESCRIPTION
NewFactory was taking a fetcher and then not using it, instead using a
defaultFetcher.

This is inappropriate for situations where we must configure specific
settings on the fetcher in order to be able to download artifacts (for
example, CA file)

`newPodWithHome` must accept a fetcher and then use it, and `NewUUIDPod`
and `NewLegacyPod` must pass the fetcher given from `NewFactory`.

Recall that the certificates we issue require that we be able to
configure specific CAs.

This was partially done in #826, but it was not made to apply to Pods,
which internally contain Fetchers as well.