### PR TITLE
pods: Take/use fetcher in NewHookFactory

### DIFF
--- a/bin/p2-install-hook/main.go
+++ b/bin/p2-install-hook/main.go
@@ -45,7 +45,8 @@ func main() {
 		log.Fatalf("%s", err)
 	}
 
-	hookFactory := pods.NewHookFactory(filepath.Join(*podRoot, "hooks", *hookType), types.NodeName(*nodeName))
+	// TODO: Configure fetcher?
+	hookFactory := pods.NewHookFactory(filepath.Join(*podRoot, "hooks", *hookType), types.NodeName(*nodeName), uri.DefaultFetcher)
 
 	// /data/pods/hooks/<event>/<id>
 	// if the event is the empty string (global hook), then that path segment

--- a/pkg/pods/factory.go
+++ b/pkg/pods/factory.go
@@ -49,6 +49,7 @@ type factory struct {
 type hookFactory struct {
 	hookRoot string
 	node     types.NodeName
+	fetcher  uri.Fetcher
 }
 
 func NewFactory(podRoot string, node types.NodeName, fetcher uri.Fetcher, requireFile string) Factory {
@@ -64,7 +65,7 @@ func NewFactory(podRoot string, node types.NodeName, fetcher uri.Fetcher, requir
 	}
 }
 
-func NewHookFactory(hookRoot string, node types.NodeName) HookFactory {
+func NewHookFactory(hookRoot string, node types.NodeName, fetcher uri.Fetcher) HookFactory {
 	if hookRoot == "" {
 		hookRoot = filepath.Join(DefaultPath, "hooks")
 	}
@@ -72,6 +73,7 @@ func NewHookFactory(hookRoot string, node types.NodeName) HookFactory {
 	return &hookFactory{
 		hookRoot: hookRoot,
 		node:     node,
+		fetcher:  fetcher,
 	}
 }
 
@@ -104,8 +106,7 @@ func (f *hookFactory) NewHookPod(id types.PodID) *Pod {
 	home := filepath.Join(f.hookRoot, id.String())
 
 	// Hooks can't have a UUID
-	// TODO: Shouldn't the Fetcher be configured? but NewHookFactory doesn't take/store a fetcher.
-	return newPodWithHome(id, "", home, f.node, "", nil)
+	return newPodWithHome(id, "", home, f.node, "", f.fetcher)
 }
 
 func newPodWithHome(id types.PodID, uniqueKey types.PodUniqueKey, podHome string, node types.NodeName, requireFile string, fetcher uri.Fetcher) *Pod {

--- a/pkg/preparer/setup_test.go
+++ b/pkg/preparer/setup_test.go
@@ -60,7 +60,7 @@ func TestInstallHooks(t *testing.T) {
 
 	podManifest := builder.GetManifest()
 
-	hookFactory := pods.NewHookFactory(destDir, "testNode")
+	hookFactory := pods.NewHookFactory(destDir, "testNode", uri.DefaultFetcher)
 	hooksPod := hookFactory.NewHookPod(podManifest.ID())
 
 	preparer := Preparer{


### PR DESCRIPTION
pods: Take/use fetcher in NewHookFactory

As in #915, it seems necessary to configure a fetcher, otherwise I predict (but have no hard evidence to support) that we will be unable to install any hooks.

I'm unsure of the necessity of this one but it's here if we need it.