### PR TITLE
daemon set farm: add configurable pod blacklist and whitelist

### DIFF
--- a/bin/p2-ds-farm/main.go
+++ b/bin/p2-ds-farm/main.go
@@ -70,6 +70,7 @@ func main() {
 		*useCachePodMatches,
 		1*time.Second,
 		ds_farm.DefaultRetryInterval,
+		ds_farm.DSFarmConfig{},
 	)
 
 	go func() {

--- a/pkg/ds/farm_test.go
+++ b/pkg/ds/farm_test.go
@@ -1238,6 +1238,60 @@ func TestDieAndUpdate(t *testing.T) {
 	assertLabel("node3", "first farm quit")
 }
 
+func TestBlacklistAndWhitelist(t *testing.T) {
+	type testCase struct {
+		blacklist    []types.PodID
+		whitelist    []types.PodID
+		podID        types.PodID
+		shouldWorkOn bool
+	}
+
+	testCases := []testCase{
+		// nothing in black or whitelist
+		{
+			podID:        "foo",
+			shouldWorkOn: true,
+		},
+		// pod is blacklisted
+		{
+			podID:        "foo",
+			blacklist:    []types.PodID{"foo"},
+			shouldWorkOn: false,
+		},
+		// pod is whitelisted
+		{
+			podID:        "foo",
+			whitelist:    []types.PodID{"foo"},
+			shouldWorkOn: true,
+		},
+		// pod is whitelisted along with another
+		{
+			podID:        "foo",
+			whitelist:    []types.PodID{"foo", "bar"},
+			shouldWorkOn: true,
+		},
+		// another pod is whitelisted
+		{
+			podID:        "foo",
+			whitelist:    []types.PodID{"bar"},
+			shouldWorkOn: false,
+		},
+	}
+
+	for i, testCase := range testCases {
+		farm := &Farm{
+			config: DSFarmConfig{
+				PodWhitelist: testCase.whitelist,
+				PodBlacklist: testCase.blacklist,
+			},
+		}
+
+		if farm.shouldWorkOn(testCase.podID) != testCase.shouldWorkOn {
+			t.Errorf("case %d: expected %t got %t: %+v", i, testCase.shouldWorkOn, farm.shouldWorkOn(testCase.podID), testCase)
+		}
+	}
+}
+
 func waitForPodLabel(applicator labels.Applicator, hasDSIDLabel bool, podPath string) (labels.Labeled, error) {
 	var labeled labels.Labeled
 	var err error

--- a/pkg/ds/farm_test.go
+++ b/pkg/ds/farm_test.go
@@ -553,7 +553,7 @@ func TestFarmSchedule(t *testing.T) {
 		dsToUpdate.NodeSelector = someSelector
 		return dsToUpdate, nil
 	}
-	_, err = dsStore.MutateDS(anotherDSData.ID, mutator)
+	anotherDSData, err = dsStore.MutateDS(anotherDSData.ID, mutator)
 	Assert(t).IsNil(err, "Expected no error mutating daemon set")
 	err = waitForMutateSelector(dsf, anotherDSData)
 	Assert(t).IsNil(err, "Expected daemon set to be mutated in farm")


### PR DESCRIPTION
This will allow farms to be configured such that they only handle
certain pod IDs. This is useful for creating staging environments where
only a certain pod ID is serviced and can be excluded from the
production environments.