### PR TITLE
ds farm: check if daemon set should be worked on before locking

### DIFF
--- a/pkg/ds/farm.go
+++ b/pkg/ds/farm.go
@@ -636,6 +636,10 @@ func (dsf *Farm) lockAndSpawn(ctx context.Context, dsFields ds_fields.DaemonSet)
 	var err error
 	dsLogger := dsf.makeDSLogger(dsFields)
 
+	if !dsf.shouldWorkOn(dsFields.Manifest.ID()) {
+		return false
+	}
+
 	// If it is not in our map, then try to acquire the lock
 	child, ok := dsf.children[dsFields.ID]
 	if !ok {
@@ -683,10 +687,6 @@ func (dsf *Farm) lockAndSpawn(ctx context.Context, dsFields ds_fields.DaemonSet)
 	if ok {
 		child.updatedCh <- dsFields
 	} else {
-		if !dsf.shouldWorkOn(dsFields.Manifest.ID()) {
-			return false
-		}
-
 		dsf.children[dsFields.ID] = dsf.spawnDaemonSet(ctx, dsFields, dsUnlocker, dsLogger)
 	}
 


### PR DESCRIPTION
This fixes a bug where a daemon set whose pod ID is in the farms'
blacklist will have its lock held forever since the lock is never
released.

It makes more sense to check the blacklist before even acquiring the
lock to avoid the issue.