### PR TITLE
Add random jitter to consul watch requests after an error.

### DIFF
--- a/bin/grpc/servers/label-store-server/main.go
+++ b/bin/grpc/servers/label-store-server/main.go
@@ -41,7 +41,7 @@ func main() {
 		logrusLogger.Logger.Level = logrus.DebugLevel
 	}
 	client := consul.NewConsulClient(opts)
-	applicator := labels.NewConsulApplicator(client, 1)
+	applicator := labels.NewConsulApplicator(client, 1, 0)
 
 	port := getPort()
 

--- a/bin/p2-ds-farm/main.go
+++ b/bin/p2-ds-farm/main.go
@@ -66,7 +66,7 @@ func main() {
 		dsStore,
 		statusStore,
 		labeler,
-		labels.NewConsulApplicator(client, 0),
+		labels.NewConsulApplicator(client, 0, 1*time.Minute),
 		sessions,
 		logger,
 		nil,

--- a/bin/p2-pcctl/main.go
+++ b/bin/p2-pcctl/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/user"
+	"time"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 
@@ -98,7 +99,7 @@ func main() {
 	client := consul.NewConsulClient(consulOpts)
 	kv := consul.NewConsulStore(client)
 	logger := logging.NewLogger(logrus.Fields{})
-	applicator := labels.NewConsulApplicator(client, 0)
+	applicator := labels.NewConsulApplicator(client, 0, 1*time.Minute)
 	pcstore := pcstore.NewConsul(client, labeler, labels.DefaultAggregationRate, applicator, &logger)
 
 	switch cmd {

--- a/bin/p2-rctl/main.go
+++ b/bin/p2-rctl/main.go
@@ -130,14 +130,14 @@ func main() {
 	// flags.ParseWithConsulOptions() gives you because that interface
 	// doesn't support transactions which is required by the rc store. so
 	// we just set up a labeler that directly accesses consul
-	labeler := labels.NewConsulApplicator(client, 0)
+	labeler := labels.NewConsulApplicator(client, 0, 0)
 
 	rcStore := rcstore.NewConsul(client, labeler, 3)
 
 	// The roll labeler CANT be an http applicator because it uses consul
 	// transactions, so this might be different from labeler returned by
 	// flags.ParseWithConsulOptions()
-	rollLabeler := labels.NewConsulApplicator(client, 0)
+	rollLabeler := labels.NewConsulApplicator(client, 0, 0)
 	rctl := rctlParams{
 		httpClient: httpClient,
 		baseClient: client,

--- a/bin/p2-rm/main.go
+++ b/bin/p2-rm/main.go
@@ -34,7 +34,7 @@ func main() {
 	// we ignore the labels.ApplicatorWithoutWatches that
 	// ParseWithConsulOptions() gives us because the RC store now requires
 	// transactions which that interface does not provide
-	labeler := labels.NewConsulApplicator(consulClient, 0)
+	labeler := labels.NewConsulApplicator(consulClient, 0, 0)
 
 	err := handlePodRemoval(consulClient, labeler)
 	if err != nil {

--- a/bin/p2-watch/main.go
+++ b/bin/p2-watch/main.go
@@ -122,7 +122,7 @@ func watchPodClusters(client consulutil.ConsulClient, applicator labels.Applicat
 	logger := &logging.DefaultLogger
 	logger.Infoln("Beginning pod cluster watch")
 
-	pcStore := pcstore.NewConsul(client, applicator, labels.DefaultAggregationRate, labels.NewConsulApplicator(client, 0), logger)
+	pcStore := pcstore.NewConsul(client, applicator, labels.DefaultAggregationRate, labels.NewConsulApplicator(client, 0, 0), logger)
 	quitCh := make(chan struct{})
 	go func() {
 		signalCh := make(chan os.Signal, 2)

--- a/integration/single-node-slug-deploy/check.go
+++ b/integration/single-node-slug-deploy/check.go
@@ -434,7 +434,7 @@ func verifyProcessExit(errCh chan error, tempDir string, logger logging.Logger) 
 func verifyTransferReplicas(errCh chan<- error, tempdir string, logger logging.Logger, consulClient consulutil.ConsulClient) {
 	defer close(errCh)
 
-	applicator := labels.NewConsulApplicator(consulClient, 1)
+	applicator := labels.NewConsulApplicator(consulClient, 1, 0)
 	rcStore := rcstore.NewConsul(consulClient, applicator, 2)
 
 	builder := manifest.NewBuilder()
@@ -935,7 +935,7 @@ func waitForPodLabeledWithRC(selector klabels.Selector, rcID fields.ID) error {
 	}
 
 	client := consul.NewConsulClient(consul.Options{})
-	applicator := labels.NewConsulApplicator(client, 1)
+	applicator := labels.NewConsulApplicator(client, 1, 0)
 
 	err = applicator.SetLabel(labels.NODE, host, "test", "yes")
 	if err != nil {

--- a/pkg/ds/daemon_set_test.go
+++ b/pkg/ds/daemon_set_test.go
@@ -186,7 +186,7 @@ func TestSchedule(t *testing.T) {
 	Assert(t).IsNil(err, "Expected no error committing transaction")
 
 	consulStore := consul.NewConsulStore(fixture.Client)
-	applicator := labels.NewConsulApplicator(fixture.Client, 0)
+	applicator := labels.NewConsulApplicator(fixture.Client, 0, 0)
 
 	// seed the applicator so the "no labels" failsafe isn't triggered
 	err = applicator.SetLabel(labels.POD, "some_untouched_pod", "foo", "bar")
@@ -448,7 +448,7 @@ func TestPublishToReplication(t *testing.T) {
 	Assert(t).IsNil(err, "Expected no error committing transaction")
 
 	consulStore := consul.NewConsulStore(fixture.Client)
-	applicator := labels.NewConsulApplicator(fixture.Client, 0)
+	applicator := labels.NewConsulApplicator(fixture.Client, 0, 0)
 
 	// seed applicator with unrelated labels so we don't trigger "no labels" failsave
 	err = applicator.SetLabel(labels.POD, "some_unrelated_pod", "foo", "bar")

--- a/pkg/ds/farm_test.go
+++ b/pkg/ds/farm_test.go
@@ -1473,7 +1473,7 @@ func waitForMutateSelectorFarms(firstFarm *Farm, secondFarm *Farm, ds ds_fields.
 }
 
 func createAndSeedApplicator(client consulutil.ConsulClient, t *testing.T) *labels.ConsulApplicator {
-	applicator := labels.NewConsulApplicator(client, 0)
+	applicator := labels.NewConsulApplicator(client, 0, 0)
 	// seed the label trees that daemon set farm uses
 	err := applicator.SetLabel(labels.NODE, "key", "whatever", "whatever")
 	if err != nil {

--- a/pkg/health/checker/test/fake_checker.go
+++ b/pkg/health/checker/test/fake_checker.go
@@ -33,7 +33,7 @@ func (s singleServiceChecker) WatchService(serviceID string, resultCh chan<- map
 
 }
 
-func (s singleServiceChecker) WatchHealth(_ chan []*health.Result, errCh chan<- error, quitCh <-chan struct{}) {
+func (s singleServiceChecker) WatchHealth(_ chan []*health.Result, errCh chan<- error, quitCh <-chan struct{}, jitterWindow time.Duration) {
 	panic("WatchHealth not implemented")
 }
 
@@ -108,8 +108,11 @@ func (h AlwaysHappyHealthChecker) WatchService(
 	}
 }
 
-func (h AlwaysHappyHealthChecker) WatchHealth(_ chan []*health.Result,
+func (h AlwaysHappyHealthChecker) WatchHealth(
+	_ chan []*health.Result,
 	errCh chan<- error,
-	quitCh <-chan struct{}) {
+	quitCh <-chan struct{},
+	jitterWindow time.Duration,
+) {
 	panic("not implemented")
 }

--- a/pkg/health/store/store_test.go
+++ b/pkg/health/store/store_test.go
@@ -31,7 +31,7 @@ func (hc *FakeHealthChecker) Service(serviceID string) (map[types.NodeName]healt
 	panic("not implemented")
 }
 
-func (hc *FakeHealthChecker) WatchHealth(resultCh chan []*health.Result, errCh chan<- error, quitCh <-chan struct{}) {
+func (hc *FakeHealthChecker) WatchHealth(resultCh chan []*health.Result, errCh chan<- error, quitCh <-chan struct{}, _ time.Duration) {
 	hc.results = resultCh
 	close(hc.ready)
 	<-quitCh
@@ -56,7 +56,7 @@ func TestStartWatchBasic(t *testing.T) {
 	quitCh := make(chan struct{})
 	defer close(quitCh)
 	hs, checker := NewFakeHealthStore()
-	go hs.StartWatch(quitCh)
+	go hs.StartWatch(quitCh, 0)
 
 	node := types.NodeName("abc01.sjc1")
 	podID1 := types.PodID("podID1")

--- a/pkg/labels/consul_aggregator.go
+++ b/pkg/labels/consul_aggregator.go
@@ -174,11 +174,11 @@ func (c *consulAggregator) Quit() {
 // watcher's output channel respectively.
 // Aggregate will loop forever, constantly sending matches to each watcher
 // until Quit() has been invoked.
-func (c *consulAggregator) Aggregate() {
+func (c *consulAggregator) Aggregate(jitterWindow time.Duration) {
 	outPairs := make(chan api.KVPairs)
 	done := make(chan struct{})
 	outErrors := make(chan error)
-	go consulutil.WatchPrefix(c.path+"/", c.kv, outPairs, done, outErrors, 0)
+	go consulutil.WatchPrefix(c.path+"/", c.kv, outPairs, done, outErrors, 0, jitterWindow)
 	for {
 		missedSends := 0
 		loopTime := time.After(c.aggregationRate)

--- a/pkg/labels/consul_aggregator_test.go
+++ b/pkg/labels/consul_aggregator_test.go
@@ -33,7 +33,7 @@ func TestTwoClients(t *testing.T) {
 		watchTrigger: nil,
 	}
 	aggreg := NewConsulAggregator(POD, fakeKV, logging.DefaultLogger, metrics.NewRegistry(), 0)
-	go aggreg.Aggregate()
+	go aggreg.Aggregate(0)
 	defer aggreg.Quit()
 
 	quitCh := make(chan struct{})
@@ -75,7 +75,7 @@ func TestQuitAggregateAfterResults(t *testing.T) {
 		watchTrigger: nil,
 	}
 	aggreg := NewConsulAggregator(POD, fakeKV, logging.DefaultLogger, metrics.NewRegistry(), 0)
-	go aggreg.Aggregate()
+	go aggreg.Aggregate(0)
 
 	quitCh := make(chan struct{})
 	res := aggreg.Watch(labels.Everything().Add("color", labels.EqualsOperator, []string{"green"}), quitCh)
@@ -107,7 +107,7 @@ func TestQuitAggregateBeforeResults(t *testing.T) {
 		watchTrigger: trigger,
 	}
 	aggreg := NewConsulAggregator(POD, fakeKV, logging.DefaultLogger, metrics.NewRegistry(), 0)
-	go aggreg.Aggregate()
+	go aggreg.Aggregate(0)
 
 	quitCh := make(chan struct{})
 	res := aggreg.Watch(labels.Everything().Add("color", labels.EqualsOperator, []string{"green"}), quitCh)
@@ -132,7 +132,7 @@ func TestQuitIndividualWatch(t *testing.T) {
 		watchTrigger: nil,
 	}
 	aggreg := NewConsulAggregator(POD, fakeKV, logging.DefaultLogger, metrics.NewRegistry(), 0)
-	go aggreg.Aggregate()
+	go aggreg.Aggregate(0)
 
 	quitCh1 := make(chan struct{})
 	labeledChannel1 := aggreg.Watch(labels.Everything().Add("color", labels.EqualsOperator, []string{"green"}), quitCh1)
@@ -184,7 +184,7 @@ func TestIgnoreIndividualWatch(t *testing.T) {
 		watchTrigger: nil,
 	}
 	aggreg := NewConsulAggregator(POD, fakeKV, logging.DefaultLogger, metrics.NewRegistry(), 0)
-	go aggreg.Aggregate()
+	go aggreg.Aggregate(0)
 	defer aggreg.Quit()
 
 	quitCh1 := make(chan struct{})
@@ -240,7 +240,7 @@ func TestCachedValueImmediatelySent(t *testing.T) {
 	defer close(quitCh)
 	watch := aggreg.Watch(selector, quitCh)
 
-	// even though we have not called Aggregate() on the aggregator, we expect
+	// even though we have not called Aggregate(0) on the aggregator, we expect
 	// that the cached value we have added will be present on the result channel.
 
 	select {
@@ -278,7 +278,7 @@ func TestIdenticalSelectors(t *testing.T) {
 		watchTrigger: nil,
 	}
 	aggreg := NewConsulAggregator(POD, fakeKV, logging.DefaultLogger, metrics.NewRegistry(), 0)
-	go aggreg.Aggregate()
+	go aggreg.Aggregate(0)
 	defer aggreg.Quit()
 
 	quitCh := make(chan struct{})

--- a/pkg/labels/integration_test.go
+++ b/pkg/labels/integration_test.go
@@ -20,7 +20,7 @@ func TestRemoveAllLabelsTxn(t *testing.T) {
 	fixture := consulutil.NewFixture(t)
 	defer fixture.Stop()
 
-	applicator := NewConsulApplicator(fixture.Client, 0)
+	applicator := NewConsulApplicator(fixture.Client, 0, 0)
 
 	// set some labels
 	err := applicator.SetLabels(RU, "some_id", map[string]string{"foo": "bar"})
@@ -64,7 +64,7 @@ func TestSetLabelTxn(t *testing.T) {
 	fixture := consulutil.NewFixture(t)
 	defer fixture.Stop()
 
-	applicator := NewConsulApplicator(fixture.Client, 0)
+	applicator := NewConsulApplicator(fixture.Client, 0, 0)
 
 	ctx, cancelFunc := transaction.New(context.Background())
 	defer cancelFunc()
@@ -103,7 +103,7 @@ func TestSetLabelTxnFailsIfLabelsChange(t *testing.T) {
 	fixture := consulutil.NewFixture(t)
 	defer fixture.Stop()
 
-	applicator := NewConsulApplicator(fixture.Client, 0)
+	applicator := NewConsulApplicator(fixture.Client, 0, 0)
 
 	ctx, cancelFunc := transaction.New(context.Background())
 	defer cancelFunc()
@@ -134,7 +134,7 @@ func TestRemoveLabelTxn(t *testing.T) {
 	fixture := consulutil.NewFixture(t)
 	defer fixture.Stop()
 
-	applicator := NewConsulApplicator(fixture.Client, 0)
+	applicator := NewConsulApplicator(fixture.Client, 0, 0)
 
 	// set some labels
 	err := applicator.SetLabel(RU, "some_id", "some_key", "some_value")
@@ -179,7 +179,7 @@ func TestRemoveLabelTxnFailsIfLabelsChange(t *testing.T) {
 	fixture := consulutil.NewFixture(t)
 	defer fixture.Stop()
 
-	applicator := NewConsulApplicator(fixture.Client, 0)
+	applicator := NewConsulApplicator(fixture.Client, 0, 0)
 
 	// set some labels
 	err := applicator.SetLabel(RU, "some_id", "some_key", "some_value")
@@ -215,7 +215,7 @@ func TestSetLabelsTxn(t *testing.T) {
 	fixture := consulutil.NewFixture(t)
 	defer fixture.Stop()
 
-	applicator := NewConsulApplicator(fixture.Client, 0)
+	applicator := NewConsulApplicator(fixture.Client, 0, 0)
 
 	ctx, cancelFunc := transaction.New(context.Background())
 	defer cancelFunc()
@@ -254,7 +254,7 @@ func TestSetLabelsTxnFailsIfLabelsChange(t *testing.T) {
 	fixture := consulutil.NewFixture(t)
 	defer fixture.Stop()
 
-	applicator := NewConsulApplicator(fixture.Client, 0)
+	applicator := NewConsulApplicator(fixture.Client, 0, 0)
 
 	ctx, cancelFunc := transaction.New(context.Background())
 	defer cancelFunc()
@@ -284,7 +284,7 @@ func TestRemoveLabelsTxn(t *testing.T) {
 	fixture := consulutil.NewFixture(t)
 	defer fixture.Stop()
 
-	applicator := NewConsulApplicator(fixture.Client, 0)
+	applicator := NewConsulApplicator(fixture.Client, 0, 0)
 
 	// set some labels
 	err := applicator.SetLabel(RU, "some_id", "some_key", "some_value")
@@ -329,7 +329,7 @@ func TestRemoveLabelsTxnFailsIfLabelsChange(t *testing.T) {
 	fixture := consulutil.NewFixture(t)
 	defer fixture.Stop()
 
-	applicator := NewConsulApplicator(fixture.Client, 0)
+	applicator := NewConsulApplicator(fixture.Client, 0, 0)
 
 	// set some labels
 	err := applicator.SetLabel(RU, "some_id", "some_key", "some_value")
@@ -365,7 +365,7 @@ func TestRemoveLabelsTxnFailsIfLabelsChange(t *testing.T) {
 func TestMutateAndSelectHTTPApplicator(t *testing.T) {
 	fixture := consulutil.NewFixture(t)
 	defer fixture.Stop()
-	labelServer := NewHTTPLabelServer(NewConsulApplicator(fixture.Client, 0), 0, logging.TestLogger())
+	labelServer := NewHTTPLabelServer(NewConsulApplicator(fixture.Client, 0, 0), 0, logging.TestLogger())
 	server := httptest.NewServer(labelServer.Handler())
 	defer server.Close()
 	url, err := url.Parse(server.URL)
@@ -429,7 +429,7 @@ func TestMutateAndSelectHTTPApplicator(t *testing.T) {
 func TestRemoveLabelTxnHTTPApplicator(t *testing.T) {
 	fixture := consulutil.NewFixture(t)
 	defer fixture.Stop()
-	labelServer := NewHTTPLabelServer(NewConsulApplicator(fixture.Client, 0), 0, logging.TestLogger())
+	labelServer := NewHTTPLabelServer(NewConsulApplicator(fixture.Client, 0, 0), 0, logging.TestLogger())
 	server := httptest.NewServer(labelServer.Handler())
 	defer server.Close()
 

--- a/pkg/labels/label_http_server_test.go
+++ b/pkg/labels/label_http_server_test.go
@@ -18,7 +18,7 @@ import (
 func TestGetLabels(t *testing.T) {
 	fixture := consulutil.NewFixture(t)
 
-	applicator := NewConsulApplicator(fixture.Client, 0)
+	applicator := NewConsulApplicator(fixture.Client, 0, 0)
 	server := NewHTTPLabelServer(applicator, 0, logging.TestLogger())
 	router := mux.NewRouter()
 	server.AddRoutes(router)

--- a/pkg/rc/replication_controller_test.go
+++ b/pkg/rc/replication_controller_test.go
@@ -73,7 +73,7 @@ func setup(t *testing.T) (
 ) {
 	fixture := consulutil.NewFixture(t)
 	closeFn = fixture.Stop
-	applicator = labels.NewConsulApplicator(fixture.Client, 0)
+	applicator = labels.NewConsulApplicator(fixture.Client, 0, 0)
 
 	// set a bogus label so we don't get "no labels" errors
 	err := applicator.SetLabel(labels.POD, "some_id", "some_key", "some_value")

--- a/pkg/replication/common_setup_test.go
+++ b/pkg/replication/common_setup_test.go
@@ -39,7 +39,7 @@ func testReplicatorAndServer(t *testing.T) (Replicator, Store, consulutil.Fixtur
 		active,
 		store,
 		f.Client.KV(),
-		labels.NewConsulApplicator(f.Client, 1),
+		labels.NewConsulApplicator(f.Client, 1, 0),
 		healthChecker,
 		threshold,
 		testLockMessage,
@@ -127,7 +127,9 @@ func (h channelBasedHealthChecker) WatchService(
 func (h channelBasedHealthChecker) WatchHealth(
 	resultCh chan []*health.Result,
 	errCh chan<- error,
-	quitCh <-chan struct{}) {
+	quitCh <-chan struct{},
+	_ time.Duration,
+) {
 	panic("not implemented")
 }
 

--- a/pkg/replication/replication_test.go
+++ b/pkg/replication/replication_test.go
@@ -46,7 +46,7 @@ func TestEnactHappyPath(t *testing.T) {
 		t.Errorf("Expected to have 2 reality records scheduled but got %d.\n%v", len(reality), reality)
 	}
 
-	allLabels, err := labels.NewConsulApplicator(fixture.Client, 0).ListLabels(labels.POD)
+	allLabels, err := labels.NewConsulApplicator(fixture.Client, 0, 0).ListLabels(labels.POD)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +133,7 @@ func newTestReplication(t *testing.T, errCh chan error) (*replication, consuluti
 		nodes:       nodes,
 		store:       podStore,
 		txner:       fixture.Client.KV(),
-		labeler:     labels.NewConsulApplicator(fixture.Client, 0),
+		labeler:     labels.NewConsulApplicator(fixture.Client, 0, 0),
 		manifest:    mb.GetManifest(),
 		health:      test.HappyHealthChecker(nodes),
 		threshold:   health.Passing,

--- a/pkg/replication/replicator_test.go
+++ b/pkg/replication/replicator_test.go
@@ -193,7 +193,7 @@ func TestInitializeReplicationWithManaged(t *testing.T) {
 	setupPreparers(f)
 
 	// Make one node appear to be managed by a replication controller
-	err := labels.NewConsulApplicator(f.Client, 1).SetLabel(
+	err := labels.NewConsulApplicator(f.Client, 1, 0).SetLabel(
 		labels.POD,
 		path.Join(testNodes[0].String(), testPodId),
 		rc.RCIDLabel,

--- a/pkg/roll/farm.go
+++ b/pkg/roll/farm.go
@@ -88,7 +88,7 @@ type RCGetter interface {
 }
 
 type RollingUpdateStore interface {
-	Watch(quit <-chan struct{}) (<-chan []roll_fields.Update, <-chan error)
+	Watch(quit <-chan struct{}, jitterWindow time.Duration) (<-chan []roll_fields.Update, <-chan error)
 	Delete(ctx context.Context, id roll_fields.ID) error
 }
 
@@ -184,7 +184,7 @@ func (rlf *Farm) Start(quit <-chan struct{}) {
 func (rlf *Farm) mainLoop(quit <-chan struct{}) {
 	subQuit := make(chan struct{})
 	defer close(subQuit)
-	rlWatch, rlErr := rlf.rls.Watch(subQuit)
+	rlWatch, rlErr := rlf.rls.Watch(subQuit, 1*time.Minute)
 
 START_LOOP:
 	for {

--- a/pkg/roll/integration_test.go
+++ b/pkg/roll/integration_test.go
@@ -26,7 +26,7 @@ func TestAuditLogCreation(t *testing.T) {
 	fixture := consulutil.NewFixture(t)
 	defer fixture.Stop()
 
-	applicator := labels.NewConsulApplicator(fixture.Client, 0)
+	applicator := labels.NewConsulApplicator(fixture.Client, 0, 0)
 	logger := logging.TestLogger()
 	rollStore := rollstore.NewConsul(fixture.Client, applicator, &logger)
 
@@ -72,7 +72,7 @@ func TestCleanupOldRCHappy(t *testing.T) {
 	fixture := consulutil.NewFixture(t)
 	defer fixture.Stop()
 
-	applicator := labels.NewConsulApplicator(fixture.Client, 0)
+	applicator := labels.NewConsulApplicator(fixture.Client, 0, 0)
 	rcStore := rcstore.NewConsul(fixture.Client, applicator, 0)
 
 	builder := manifest.NewBuilder()
@@ -125,7 +125,7 @@ func TestCleanupOldRCTooManyReplicas(t *testing.T) {
 	fixture := consulutil.NewFixture(t)
 	defer fixture.Stop()
 
-	applicator := labels.NewConsulApplicator(fixture.Client, 0)
+	applicator := labels.NewConsulApplicator(fixture.Client, 0, 0)
 	rcStore := rcstore.NewConsul(fixture.Client, applicator, 0)
 
 	builder := manifest.NewBuilder()

--- a/pkg/store/consul/consulutil/watch_test.go
+++ b/pkg/store/consul/consulutil/watch_test.go
@@ -167,7 +167,7 @@ func TestWatchPrefix(t *testing.T) {
 
 	// Process existing data
 	f.Client.KV().Put(kv1a, nil)
-	go WatchPrefix("prefix/", f.Client.KV(), pairsChan, done, testLogger(t), 0)
+	go WatchPrefix("prefix/", f.Client.KV(), pairsChan, done, testLogger(t), 0, 0)
 	pairs := kvToMap(<-pairsChan)
 	if !kvMatch(pairs, kv1a) {
 		t.Error("existing data not recognized")

--- a/pkg/store/consul/dsstore/consul_store.go
+++ b/pkg/store/consul/dsstore/consul_store.go
@@ -471,7 +471,7 @@ func (s *ConsulStore) WatchAll(quitCh <-chan struct{}, pauseTime time.Duration) 
 	errCh := make(chan error, 1)
 
 	// Watch for changes in the dsTree and deletedDSTree
-	go consulutil.WatchPrefix(dsTree, s.kv, inCh, quitCh, errCh, pauseTime)
+	go consulutil.WatchPrefix(dsTree, s.kv, inCh, quitCh, errCh, pauseTime, 1*time.Minute)
 
 	go func() {
 		defer close(outCh)

--- a/pkg/store/consul/flags/kingpin.go
+++ b/pkg/store/consul/flags/kingpin.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/store/consul"
@@ -72,7 +73,8 @@ func ParseWithConsulOptions() (string, consul.Options, labels.ApplicatorWithoutW
 			log.Fatalln(err)
 		}
 	} else {
-		applicator = labels.NewConsulApplicator(consul.NewConsulClient(consulOpts), 0)
+		jitterWindow := 0 * time.Second // we don't initiate watches in CLIs so this doesn't matter
+		applicator = labels.NewConsulApplicator(consul.NewConsulClient(consulOpts), 0, jitterWindow)
 	}
 	return cmd, consulOpts, applicator
 }

--- a/pkg/store/consul/kv.go
+++ b/pkg/store/consul/kv.go
@@ -443,7 +443,7 @@ func (c consulStore) WatchPods(
 	}
 
 	kvPairsChan := make(chan api.KVPairs)
-	go consulutil.WatchPrefix(keyPrefix, c.client.KV(), kvPairsChan, quitChan, errChan, 0)
+	go consulutil.WatchPrefix(keyPrefix, c.client.KV(), kvPairsChan, quitChan, errChan, 0, 1*time.Minute)
 	for kvPairs := range kvPairsChan {
 		manifests := make([]ManifestResult, 0, len(kvPairs))
 		for _, pair := range kvPairs {
@@ -477,7 +477,7 @@ func (c consulStore) WatchAllPods(
 	defer close(podChan)
 
 	kvPairsChan := make(chan api.KVPairs)
-	go consulutil.WatchPrefix(string(podPrefix), c.client.KV(), kvPairsChan, quitChan, errChan, pauseTime)
+	go consulutil.WatchPrefix(string(podPrefix), c.client.KV(), kvPairsChan, quitChan, errChan, pauseTime, 1*time.Minute)
 	for kvPairs := range kvPairsChan {
 		manifests := make([]ManifestResult, 0, len(kvPairs))
 		for _, pair := range kvPairs {

--- a/pkg/store/consul/pcstore/consul_store.go
+++ b/pkg/store/consul/pcstore/consul_store.go
@@ -369,7 +369,7 @@ func (s *ConsulStore) Watch(quit <-chan struct{}) <-chan WatchedPodClusters {
 	outCh := make(chan WatchedPodClusters)
 	errChan := make(chan error, 1)
 
-	go consulutil.WatchPrefix(podClusterTree, s.kv, inCh, quit, errChan, 5*time.Second)
+	go consulutil.WatchPrefix(podClusterTree, s.kv, inCh, quit, errChan, 5*time.Second, 1*time.Minute)
 
 	go func() {
 		var kvp api.KVPairs

--- a/pkg/store/consul/rcstore/consul_store.go
+++ b/pkg/store/consul/rcstore/consul_store.go
@@ -301,7 +301,7 @@ func (s *ConsulStore) WatchNew(quit <-chan struct{}) (<-chan []fields.RC, <-chan
 	inCh := make(chan api.KVPairs)
 
 	outCh, errCh := publishLatestRCs(inCh, quit)
-	go consulutil.WatchPrefix(rcTree+"/", s.kv, inCh, quit, errCh, 1*time.Second)
+	go consulutil.WatchPrefix(rcTree+"/", s.kv, inCh, quit, errCh, 1*time.Second, 1*time.Minute)
 
 	return outCh, errCh
 }

--- a/pkg/store/consul/rcstore/integration_test.go
+++ b/pkg/store/consul/rcstore/integration_test.go
@@ -18,7 +18,7 @@ func TestCreateTxn(t *testing.T) {
 	fixture := consulutil.NewFixture(t)
 	defer fixture.Stop()
 
-	applicator := labels.NewConsulApplicator(fixture.Client, 0)
+	applicator := labels.NewConsulApplicator(fixture.Client, 0, 0)
 	store := NewConsul(fixture.Client, applicator, 0)
 
 	rcLabelsToSet := klabels.Set{

--- a/pkg/store/consul/rollstore/consul_store.go
+++ b/pkg/store/consul/rollstore/consul_store.go
@@ -527,11 +527,11 @@ func (s ConsulStore) Lock(id roll_fields.ID, session string) (bool, error) {
 
 // Watch wtches for changes to the store and generate a list of Updates for each
 // change. This function does not block.
-func (s ConsulStore) Watch(quit <-chan struct{}) (<-chan []roll_fields.Update, <-chan error) {
+func (s ConsulStore) Watch(quit <-chan struct{}, jitterWindow time.Duration) (<-chan []roll_fields.Update, <-chan error) {
 	inCh := make(chan api.KVPairs)
 
 	outCh, errCh := publishLatestRolls(inCh, quit)
-	go consulutil.WatchPrefix(rollTree+"/", s.kv, inCh, quit, errCh, 0)
+	go consulutil.WatchPrefix(rollTree+"/", s.kv, inCh, quit, errCh, 0, jitterWindow)
 
 	return outCh, errCh
 }

--- a/pkg/store/consul/rollstore/integration_test.go
+++ b/pkg/store/consul/rollstore/integration_test.go
@@ -521,7 +521,7 @@ func newRollStoreWithRealConsul(t *testing.T, fixture consulutil.Fixture, entrie
 			t.Fatalf("could not seed consul with RC: %s", err)
 		}
 	}
-	applicator := labels.NewConsulApplicator(fixture.Client, 0)
+	applicator := labels.NewConsulApplicator(fixture.Client, 0, 0)
 	rcStore := rcstore.NewConsul(fixture.Client, applicator, 0)
 	return &ConsulStore{
 		kv:      fixture.Client.KV(),


### PR DESCRIPTION
Many places in p2 initiate "watches" on the consul database, meaning
they will have many long-lived HTTP connections that are re-initiated as
soon as the response is received.

This causes a lot of synchronized load on consul whenever a node becomes
unavailable (whether due to hardware failure or a graceful restart). The
watches that that node is handling will all be broken at the same time
and then re-attempted all at the same time, and often the retries will
sync up as well since the same wait time on consul is used (usually 5
minutes).

This commit adds the ability to specify a jitter window from which a
random value between 0 and the jitter window will be chosen and slept
before intiating another request after an error. This should smooth out
the load on consul after a server is rebooted.