### PR TITLE
Add RC Status store

### DIFF
--- a/pkg/store/consul/statusstore/rcstatus/status.go
+++ b/pkg/store/consul/statusstore/rcstatus/status.go
@@ -1,0 +1,38 @@
+package rcstatus
+
+import (
+	"encoding/json"
+
+	"github.com/square/p2/pkg/store/consul/statusstore"
+	"github.com/square/p2/pkg/types"
+	"github.com/square/p2/pkg/util"
+)
+
+type RCStatus struct {
+	NodeTransfer NodeTransfer `json:"node_transfer"`
+}
+
+type NodeTransfer struct {
+	OldNode types.NodeName `json:"old_node"`
+	NewNode types.NodeName `json:"new_node"`
+}
+
+func statusToRCStatus(rawStatus statusstore.Status) (RCStatus, error) {
+	var rcStatus RCStatus
+
+	err := json.Unmarshal(rawStatus.Bytes(), &rcStatus)
+	if err != nil {
+		return RCStatus{}, util.Errorf("Could not unmarshal raw status as rc status: %s", err)
+	}
+
+	return rcStatus, nil
+}
+
+func rcStatusToStatus(rcStatus RCStatus) (statusstore.Status, error) {
+	bytes, err := json.Marshal(rcStatus)
+	if err != nil {
+		return statusstore.Status{}, util.Errorf("Could not marshal rc status as json bytes: %s", err)
+	}
+
+	return statusstore.Status(bytes), nil
+}

--- a/pkg/store/consul/statusstore/rcstatus/store.go
+++ b/pkg/store/consul/statusstore/rcstatus/store.go
@@ -1,0 +1,65 @@
+package rcstatus
+
+import (
+	"github.com/square/p2/pkg/rc/fields"
+	"github.com/square/p2/pkg/store/consul/statusstore"
+	"github.com/square/p2/pkg/util"
+
+	"github.com/hashicorp/consul/api"
+)
+
+type ConsulStore struct {
+	statusStore statusstore.Store
+
+	// The consul implementation statusstore.Store formats keys like
+	// /status/<resource-type>/<resource-id>/<namespace>. The namespace
+	// portion is useful if multiple subsystems need to record their
+	// own view of a resource.
+	namespace statusstore.Namespace
+}
+
+func NewConsul(statusStore statusstore.Store, namespace statusstore.Namespace) ConsulStore {
+	return ConsulStore{
+		statusStore: statusStore,
+		namespace:   namespace,
+	}
+}
+
+func (c ConsulStore) Get(rcID fields.ID) (RCStatus, *api.QueryMeta, error) {
+	if rcID == "" {
+		return RCStatus{}, nil, util.Errorf("Provided replication controller ID was empty")
+	}
+
+	status, queryMeta, err := c.statusStore.GetStatus(statusstore.RC, statusstore.ResourceID(rcID), c.namespace)
+	if err != nil {
+		return RCStatus{}, queryMeta, err
+	}
+
+	rcStatus, err := statusToRCStatus(status)
+	if err != nil {
+		return RCStatus{}, queryMeta, err
+	}
+
+	return rcStatus, queryMeta, nil
+}
+
+func (c ConsulStore) Set(rcID fields.ID, status RCStatus) error {
+	if rcID == "" {
+		return util.Errorf("Provided replication controller ID was empty")
+	}
+
+	rawStatus, err := rcStatusToStatus(status)
+	if err != nil {
+		return err
+	}
+
+	return c.statusStore.SetStatus(statusstore.RC, statusstore.ResourceID(rcID), c.namespace, rawStatus)
+}
+
+func (c ConsulStore) Delete(rcID fields.ID) error {
+	if rcID == "" {
+		return util.Errorf("Provided replication controller ID was empty")
+	}
+
+	return c.statusStore.DeleteStatus(statusstore.RC, statusstore.ResourceID(rcID.String()), c.namespace)
+}

--- a/pkg/store/consul/statusstore/rcstatus/store_test.go
+++ b/pkg/store/consul/statusstore/rcstatus/store_test.go
@@ -1,0 +1,92 @@
+package rcstatus
+
+import (
+	"testing"
+
+	"github.com/square/p2/pkg/rc/fields"
+	"github.com/square/p2/pkg/store/consul/statusstore"
+	"github.com/square/p2/pkg/store/consul/statusstore/statusstoretest"
+	"github.com/square/p2/pkg/types"
+)
+
+func TestSetAndGetStatus(t *testing.T) {
+	store := newFixture()
+	testStatus := RCStatus{
+		NodeTransfer: NodeTransfer{
+			OldNode: types.NodeName("old.123"),
+			NewNode: types.NodeName("new.456"),
+		},
+	}
+
+	rcID := fields.ID("rc_id")
+	err := store.Set(rcID, testStatus)
+	if err != nil {
+		t.Fatalf("Unexpected error setting rc status: %s", err)
+	}
+
+	status, _, err := store.Get(rcID)
+	if err != nil {
+		t.Fatalf("Unexpected error getting status: %s", err)
+	}
+
+	if status.NodeTransfer.OldNode == "" || status.NodeTransfer.NewNode == "" {
+		t.Fatalf("Expected oldNode and newNode to be set but they were not")
+	}
+
+	if status.NodeTransfer.OldNode != testStatus.NodeTransfer.OldNode {
+		t.Fatalf("Expected oldNode to be %s, was %s", testStatus.NodeTransfer.OldNode, status.NodeTransfer.OldNode)
+	}
+
+	if status.NodeTransfer.NewNode != testStatus.NodeTransfer.NewNode {
+		t.Fatalf("Expected newNode to be %s, was %s", testStatus.NodeTransfer.NewNode, status.NodeTransfer.NewNode)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	store := newFixture()
+	testStatus := RCStatus{
+		NodeTransfer: NodeTransfer{
+			OldNode: types.NodeName("old.123"),
+			NewNode: types.NodeName("new.456"),
+		},
+	}
+
+	// Put a value in the store
+	rcID := fields.ID("rc_id")
+	err := store.Set(rcID, testStatus)
+	if err != nil {
+		t.Fatalf("Unexpected error setting status: %s", err)
+	}
+
+	// Get the value out to confirm it's there
+	status, _, err := store.Get(rcID)
+	if err != nil {
+		t.Fatalf("Unexpected error getting status: %s", err)
+	}
+
+	if status.NodeTransfer != testStatus.NodeTransfer {
+		t.Fatalf("Expected status.NodeTransfer to be %v, but was %v", testStatus.NodeTransfer, status.NodeTransfer)
+	}
+
+	// Now delete it
+	err = store.Delete(rcID)
+	if err != nil {
+		t.Fatalf("Error deleting rc status: %s", err)
+	}
+
+	_, _, err = store.Get(rcID)
+	if err == nil {
+		t.Fatal("Expected an error fetching a deleted status")
+	}
+
+	if !statusstore.IsNoStatus(err) {
+		t.Errorf("Expected error to be NoStatus but was %s", err)
+	}
+}
+
+func newFixture() *ConsulStore {
+	return &ConsulStore{
+		statusStore: statusstoretest.NewFake(),
+		namespace:   "test_namespace",
+	}
+}

--- a/pkg/store/consul/statusstore/store.go
+++ b/pkg/store/consul/statusstore/store.go
@@ -20,6 +20,7 @@ const (
 	PC  = ResourceType("pod_clusters")
 	POD = ResourceType("pods")
 	DS  = ResourceType("daemon_sets")
+	RC  = ResourceType("replication_controllers")
 )
 
 // Unfortunately each ResourceType will carry along with it a different "ID"


### PR DESCRIPTION
As part of better host idling, RC's will keep track of their status to know when they are performing a node transfer. To do this they will need to Get the status to see if a node transfer is in progress, Set the status when they are performing a node transfer, and Delete the status when they are finished.  Those three behaviors are implemented and tested.