### PR TITLE
Spenceral/implement new states

### DIFF
--- a/bin/p2-rctl-server/main.go
+++ b/bin/p2-rctl-server/main.go
@@ -26,6 +26,8 @@ import (
 	"github.com/square/p2/pkg/store/consul/flags"
 	"github.com/square/p2/pkg/store/consul/rcstore"
 	"github.com/square/p2/pkg/store/consul/rollstore"
+	"github.com/square/p2/pkg/store/consul/statusstore"
+	"github.com/square/p2/pkg/store/consul/statusstore/rcstatus"
 	"github.com/square/p2/pkg/util/stream"
 	"github.com/square/p2/pkg/version"
 )
@@ -71,8 +73,10 @@ func main() {
 	// Initialize the myriad of different storage components
 	httpClient := cleanhttp.DefaultClient()
 	client := consul.NewConsulClient(opts)
+	statusStoreClient := statusstore.NewConsul(client)
 	consulStore := consul.NewConsulStore(client)
 	rcStore := rcstore.NewConsul(client, labeler, RetryCount)
+	rcStatusStore := rcstatus.NewConsul(statusStoreClient, consul.RCStatusNamespace)
 
 	rollStore := rollstore.NewConsul(client, labeler, nil)
 	healthChecker := checker.NewConsulHealthChecker(client)
@@ -104,6 +108,7 @@ func main() {
 	// Run the farms!
 	go rc.NewFarm(
 		consulStore,
+		rcStatusStore,
 		auditLogStore,
 		rcStore,
 		rcStore,

--- a/pkg/rc/farm.go
+++ b/pkg/rc/farm.go
@@ -19,6 +19,7 @@ import (
 	"github.com/square/p2/pkg/store/consul"
 	"github.com/square/p2/pkg/store/consul/consulutil"
 	"github.com/square/p2/pkg/store/consul/rcstore"
+	"github.com/square/p2/pkg/store/consul/statusstore/rcstatus"
 	"github.com/square/p2/pkg/store/consul/transaction"
 	"github.com/square/p2/pkg/util"
 
@@ -70,6 +71,7 @@ type AuditLogStore interface {
 type Farm struct {
 	// constructor arguments for rcs created by this farm
 	store         consulStore
+	rcStatusStore rcstatus.ConsulStore
 	auditLogStore AuditLogStore
 	rcStore       ReplicationControllerStore
 	rcLocker      ReplicationControllerLocker
@@ -104,6 +106,7 @@ type childRC struct {
 
 func NewFarm(
 	store consulStore,
+	rcStatusStore rcstatus.ConsulStore,
 	auditLogStore AuditLogStore,
 	rcs ReplicationControllerStore,
 	rcLocker ReplicationControllerLocker,
@@ -123,6 +126,7 @@ func NewFarm(
 
 	return &Farm{
 		store:            store,
+		rcStatusStore:    rcStatusStore,
 		auditLogStore:    auditLogStore,
 		rcStore:          rcs,
 		rcLocker:         rcLocker,
@@ -271,6 +275,7 @@ START_LOOP:
 				newChild := New(
 					rc,
 					rcf.store,
+					rcf.rcStatusStore,
 					rcf.auditLogStore,
 					rcf.txner,
 					rcf.rcWatcher,

--- a/pkg/rc/replication_controller_test.go
+++ b/pkg/rc/replication_controller_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/square/p2/pkg/store/consul/statusstore"
 	"github.com/square/p2/pkg/store/consul/statusstore/rcstatus"
 	"github.com/square/p2/pkg/types"
+	"github.com/square/p2/pkg/util"
 
 	. "github.com/anthonybishopric/gotcha"
 	klabels "k8s.io/kubernetes/pkg/labels"
@@ -63,6 +64,28 @@ type testApplicator interface {
 type testAuditLogStore interface {
 	AuditLogStore
 	List() (map[audit.ID]audit.AuditLog, error)
+}
+
+func (s testScheduler) EligibleNodes(manifest manifest.Manifest, nodeSelector klabels.Selector) ([]types.NodeName, error) {
+	as := scheduler.NewApplicatorScheduler(s.applicator)
+	return as.EligibleNodes(manifest, nodeSelector)
+}
+
+func (s testScheduler) AllocateNodes(manifest manifest.Manifest, nodeSelector klabels.Selector, allocationCount int) ([]types.NodeName, error) {
+	if s.shouldErr {
+		return nil, util.Errorf("Intentional error allocating nodes.")
+	}
+
+	return []types.NodeName{types.NodeName("new.789")}, nil
+}
+
+func (s testScheduler) DeallocateNodes(nodeSelector klabels.Selector, nodes []types.NodeName) error {
+	return util.Errorf("DeallocateNodes() is not yet implemented")
+}
+
+type testScheduler struct {
+	applicator testApplicator
+	shouldErr  bool
 }
 
 func setup(t *testing.T) (
@@ -113,7 +136,7 @@ func setup(t *testing.T) (
 		auditLogStore,
 		fixture.Client.KV(),
 		rcStore,
-		scheduler.NewApplicatorScheduler(applicator),
+		testScheduler{applicator, false},
 		applicator,
 		logging.DefaultLogger,
 		alerter,
@@ -687,14 +710,98 @@ func TestUnscheduleMoreThan5(t *testing.T) {
 	wg.Wait()
 }
 
-func TestAlertIfNodeBecomesIneligible(t *testing.T) {
+func TestAlertIfNodeBecomesIneligibleIfNotCattleStrategy(t *testing.T) {
 	_, _, applicator, rc, alerter, _, closeFn := setup(t)
 	defer closeFn()
 
+	err := testIneligibleNodesCommon(applicator, rc, alerter)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(alerter.Alerts) != 1 {
+		t.Fatalf("the RC should have alerted since replicas desired is greater than the number of eligible nodes, but there were %d alerts", len(alerter.Alerts))
+	}
+}
+
+func TestAllocateOnIneligibleIfCattleStrategy(t *testing.T) {
+	_, _, applicator, rc, alerter, _, closeFn := setup(t)
+	defer closeFn()
+
+	rc.AllocationStrategy = fields.CattleStrategy
+
+	err := testIneligibleNodesCommon(applicator, rc, alerter)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(alerter.Alerts) != 0 {
+		t.Fatalf("the RC should not have alerted since it allocated cattle nodes, but there were %d alerts", len(alerter.Alerts))
+	}
+
+	if _, _, err := rc.rcStatusStore.Get(rc.ID()); !statusstore.IsNoStatus(err) {
+		t.Fatalf("the rc should not have written a status but it did")
+	}
+}
+
+func TestNoOpIfNodeTransferInProgress(t *testing.T) {
+	_, _, applicator, rc, alerter, _, closeFn := setup(t)
+	defer closeFn()
+
+	rc.AllocationStrategy = fields.CattleStrategy
+
+	// Simulate node transfer in progress with non-nil node transfer
+	testStatus := rcstatus.Status{
+		NodeTransfer: &rcstatus.NodeTransfer{
+			OldNode: types.NodeName("old.123"),
+			NewNode: types.NodeName("new.456"),
+		},
+	}
+	err := rc.rcStatusStore.Set(rc.ID(), testStatus)
+	if err != nil {
+		t.Fatalf("Unexpected error putting in fake node transfer status")
+	}
+
+	err = testIneligibleNodesCommon(applicator, rc, alerter)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(alerter.Alerts) != 0 {
+		t.Fatalf("the RC should not have alerted since a transfer was in progress, but there were %d alerts", len(alerter.Alerts))
+	}
+}
+
+func TestAlertIfCannotAllocateNodes(t *testing.T) {
+	_, _, applicator, rc, alerter, _, closeFn := setup(t)
+	defer closeFn()
+
+	rc.AllocationStrategy = fields.CattleStrategy
+
+	// Force an allocate nodes failure
+	fixture := consulutil.NewFixture(t)
+	closeFn = fixture.Stop
+	applicator = labels.NewConsulApplicator(fixture.Client, 0)
+	rc.scheduler = testScheduler{applicator, true}
+
+	err := testIneligibleNodesCommon(applicator, rc, alerter)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(alerter.Alerts) != 1 {
+		t.Fatalf("the RC should have alerted since the scheduler could not allocate nodes, but there were %d alerts", len(alerter.Alerts))
+	}
+}
+
+// testIneligibleNodesCommmon labels nodes and meets desires, then marks one as
+// bad and meets desires again. It is the shared to code the establish
+// the ineligible node state and cause the RC to act on it
+func testIneligibleNodesCommon(applicator testApplicator, rc *replicationController, alerter *alertingtest.AlertRecorder) error {
 	for i := 0; i < 7; i++ {
 		err := applicator.SetLabel(labels.NODE, fmt.Sprintf("node%d", i), "nodeQuality", "good")
 		if err != nil {
-			t.Fatal(err)
+			return err
 		}
 	}
 
@@ -702,20 +809,20 @@ func TestAlertIfNodeBecomesIneligible(t *testing.T) {
 
 	err := rc.meetDesires()
 	if err != nil {
-		t.Fatal(err)
+		return err
 	}
 
 	current, err := rc.CurrentPods()
 	if err != nil {
-		t.Fatal(err)
+		return err
 	}
 
 	if len(current) != 7 {
-		t.Fatalf("rc should have scheduled 7 pods but found %d", len(current))
+		return util.Errorf("rc should have scheduled 7 pods but found %d", len(current))
 	}
 
 	if len(alerter.Alerts) != 0 {
-		t.Fatalf("there shouldn't have been any alerts yet but there were %d", len(alerter.Alerts))
+		return util.Errorf("there shouldn't have been any alerts yet but there were %d", len(alerter.Alerts))
 	}
 
 	// now make one of the nodes ineligible, creating a situation where the
@@ -723,29 +830,20 @@ func TestAlertIfNodeBecomesIneligible(t *testing.T) {
 	// those nodes meet the node selector's criteria
 	err = applicator.SetLabel(labels.NODE, "node3", "nodeQuality", "bad")
 	if err != nil {
-		t.Fatal(err)
+		return err
 	}
 
 	err = rc.meetDesires()
 	if err != nil {
-		t.Fatal(err)
+		return err
 	}
 
 	current, err = rc.CurrentPods()
 	if err != nil {
-		t.Fatal(err)
+		return err
 	}
 
-	// There should still be 7 pods by design, we want to be paranoid about
-	// unscheduling. The operator should decrease the replica count if they
-	// want an unschedule to happen
-	if len(current) != 7 {
-		t.Fatalf("rc should still have 7 pods (even though only 6 are eligible) but found %d", len(current))
-	}
-
-	if len(alerter.Alerts) != 1 {
-		t.Fatalf("the RC should have alerted since replicas desired is greater than the number of eligible nodes, but there were %d alerts", len(alerter.Alerts))
-	}
+	return nil
 }
 
 // Tests that an RC will not do any scheduling/unscheduling if the only thing

--- a/pkg/rc/replication_controller_test.go
+++ b/pkg/rc/replication_controller_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/square/p2/pkg/store/consul/auditlogstore"
 	"github.com/square/p2/pkg/store/consul/consulutil"
 	"github.com/square/p2/pkg/store/consul/rcstore"
+	"github.com/square/p2/pkg/store/consul/statusstore"
+	"github.com/square/p2/pkg/store/consul/statusstore/rcstatus"
 	"github.com/square/p2/pkg/types"
 
 	. "github.com/anthonybishopric/gotcha"
@@ -88,6 +90,9 @@ func setup(t *testing.T) (
 	rcStore = rcstore.NewConsul(fixture.Client, applicator, 0)
 	consulStore = consul.NewConsulStore(fixture.Client)
 
+	statusStore := statusstore.NewConsul(fixture.Client)
+	rcStatusStore := rcstatus.NewConsul(statusStore, consul.RCStatusNamespace)
+
 	manifestBuilder := manifest.NewBuilder()
 	manifestBuilder.SetID("testPod")
 	podManifest := manifestBuilder.GetManifest()
@@ -104,6 +109,7 @@ func setup(t *testing.T) (
 	rc = New(
 		rcData,
 		consulStore,
+		rcStatusStore,
 		auditLogStore,
 		fixture.Client.KV(),
 		rcStore,

--- a/pkg/store/consul/kv.go
+++ b/pkg/store/consul/kv.go
@@ -28,8 +28,9 @@ import (
 const (
 	TTL = 60 * time.Second
 
-	// Don't change this, it affects where pod status keys are read and written from
+	// Don't change this, it affects where status keys are read and written from
 	PreparerPodStatusNamespace statusstore.Namespace = "preparer"
+	RCStatusNamespace          statusstore.Namespace = "replication_controller"
 )
 
 type ManifestResult struct {


### PR DESCRIPTION
When RCs discovers they are scheduled to ineligible nodes, those with the cattle strategy make a call to `scheduler.AllocateNodes()` and write a node transfer status. Those with the old strategy (pet strategy) will alert. 

There are currently no tests. Thorough integration tests will be written once the the entire new replication controller behavior has finished being implemented. 