### PR TITLE
Env var for restart timeout

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -499,3 +499,7 @@ func (hl *Launchable) EnvVars() map[string]string {
 func (hl *Launchable) RestartPolicy() runit.RestartPolicy {
 	return hl.RestartPolicy_
 }
+
+func (hl *Launchable) GetRestartTimeout() time.Duration {
+	return hl.RestartTimeout
+}

--- a/pkg/launch/launchable.go
+++ b/pkg/launch/launchable.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/square/p2/pkg/cgroups"
 	"github.com/square/p2/pkg/runit"
@@ -156,6 +157,9 @@ type Launchable interface {
 	// be necessary. The provided argument is guidance for how many bytes on disk a particular
 	// launchable should consume
 	Prune(size.ByteCount) error
+
+	// RestartTimeout returns the RestartTimeout
+	GetRestartTimeout() time.Duration
 
 	// Env vars that will be exported to the launchable for its launch script and other hooks.
 	EnvVars() map[string]string

--- a/pkg/opencontainer/containers.go
+++ b/pkg/opencontainer/containers.go
@@ -312,3 +312,7 @@ func (l *Launchable) Prune(max size.ByteCount) error {
 func (l *Launchable) RestartPolicy() runit.RestartPolicy {
 	return l.RestartPolicy_
 }
+
+func (l *Launchable) GetRestartTimeout() time.Duration {
+	return l.RestartTimeout
+}

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -42,13 +42,14 @@ var (
 )
 
 const (
-	ConfigPathEnvVar         = "CONFIG_PATH"
-	LaunchableIDEnvVar       = "LAUNCHABLE_ID"
-	LaunchableRootEnvVar     = "LAUNCHABLE_ROOT"
-	PodIDEnvVar              = "POD_ID"
-	PodHomeEnvVar            = "POD_HOME"
-	PodUniqueKeyEnvVar       = "POD_UNIQUE_KEY"
-	PlatformConfigPathEnvVar = "PLATFORM_CONFIG_PATH"
+	ConfigPathEnvVar               = "CONFIG_PATH"
+	LaunchableIDEnvVar             = "LAUNCHABLE_ID"
+	LaunchableRootEnvVar           = "LAUNCHABLE_ROOT"
+	PodIDEnvVar                    = "POD_ID"
+	PodHomeEnvVar                  = "POD_HOME"
+	PodUniqueKeyEnvVar             = "POD_UNIQUE_KEY"
+	PlatformConfigPathEnvVar       = "PLATFORM_CONFIG_PATH"
+	LaunchableRestartTimeoutEnvVar = "RESTART_TIMEOUT"
 )
 
 type Pod struct {
@@ -602,7 +603,11 @@ func (pod *Pod) setupConfig(manifest manifest.Manifest, launchables []launch.Lau
 		if err != nil {
 			return err
 		}
-		err = writeEnvFile(launchable.EnvDir(), "LAUNCHABLE_ROOT", launchable.InstallDir(), uid, gid)
+		err = writeEnvFile(launchable.EnvDir(), LaunchableRootEnvVar, launchable.InstallDir(), uid, gid)
+		if err != nil {
+			return err
+		}
+		err = writeEnvFile(launchable.EnvDir(), LaunchableRestartTimeoutEnvVar, fmt.Sprintf("%d", int64(launchable.GetRestartTimeout().Seconds())), uid, gid)
 		if err != nil {
 			return err
 		}

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -195,6 +195,10 @@ config:
 		Assert(t).IsNil(err, "should not have erred reading the launchable root env file")
 		Assert(t).AreEqual(launchable.InstallDir(), string(launchableRootEnv), "The launchable root path did not match expected")
 
+		launchableRestartTimeout, err := ioutil.ReadFile(filepath.Join(launchable.EnvDir(), "RESTART_TIMEOUT"))
+		Assert(t).IsNil(err, "should not have erred reading the launchable root env file")
+		Assert(t).AreEqual("60", string(launchableRestartTimeout), "The restart timeout did not match expected")
+
 		enableBlamSetting, err := ioutil.ReadFile(filepath.Join(launchable.EnvDir(), "ENABLED_BLAMS"))
 		Assert(t).IsNil(err, "should not have erred reading custom env var")
 		Assert(t).AreEqual("5", string(enableBlamSetting), "The user-supplied custom env var was wrong")


### PR DESCRIPTION
An internal request for exposing the restart_timeout has prompted this change. The alternative is having the customer parse the manifest (bad) & copy the knowledge of the default timeout (very bad!)