### PR TITLE
Refactor rc status store

### DIFF
--- a/pkg/store/consul/statusstore/rcstatus/status.go
+++ b/pkg/store/consul/statusstore/rcstatus/status.go
@@ -8,8 +8,8 @@ import (
 	"github.com/square/p2/pkg/util"
 )
 
-type RCStatus struct {
-	NodeTransfer NodeTransfer `json:"node_transfer"`
+type Status struct {
+	NodeTransfer *NodeTransfer `json:"node_transfer"`
 }
 
 type NodeTransfer struct {
@@ -17,19 +17,19 @@ type NodeTransfer struct {
 	NewNode types.NodeName `json:"new_node"`
 }
 
-func statusToRCStatus(rawStatus statusstore.Status) (RCStatus, error) {
-	var rcStatus RCStatus
+func rawStatusToStatus(rawStatus statusstore.Status) (Status, error) {
+	var status Status
 
-	err := json.Unmarshal(rawStatus.Bytes(), &rcStatus)
+	err := json.Unmarshal(rawStatus.Bytes(), &status)
 	if err != nil {
-		return RCStatus{}, util.Errorf("Could not unmarshal raw status as rc status: %s", err)
+		return Status{}, util.Errorf("Could not unmarshal raw status as rc status: %s", err)
 	}
 
-	return rcStatus, nil
+	return status, nil
 }
 
-func rcStatusToStatus(rcStatus RCStatus) (statusstore.Status, error) {
-	bytes, err := json.Marshal(rcStatus)
+func statusToRawStatus(status Status) (statusstore.Status, error) {
+	bytes, err := json.Marshal(status)
 	if err != nil {
 		return statusstore.Status{}, util.Errorf("Could not marshal rc status as json bytes: %s", err)
 	}

--- a/pkg/store/consul/statusstore/rcstatus/store_test.go
+++ b/pkg/store/consul/statusstore/rcstatus/store_test.go
@@ -1,92 +1,124 @@
 package rcstatus
 
 import (
+	"context"
 	"testing"
 
 	"github.com/square/p2/pkg/rc/fields"
+	"github.com/square/p2/pkg/store/consul/consulutil"
 	"github.com/square/p2/pkg/store/consul/statusstore"
-	"github.com/square/p2/pkg/store/consul/statusstore/statusstoretest"
+	"github.com/square/p2/pkg/store/consul/transaction"
 	"github.com/square/p2/pkg/types"
+
+	"github.com/hashicorp/consul/api"
 )
 
-func TestSetAndGetStatus(t *testing.T) {
-	store := newFixture()
-	testStatus := RCStatus{
-		NodeTransfer: NodeTransfer{
+type testHelper struct {
+	consulFixture consulutil.Fixture
+	store         ConsulStore
+	status        Status
+	id            fields.ID
+}
+
+func (th *testHelper) stop() {
+	th.consulFixture.Stop()
+}
+
+func initTestHelper(t *testing.T) testHelper {
+	consulFixture := consulutil.NewFixture(t)
+	store := NewConsul(statusstore.NewConsul(consulFixture.Client), "test")
+	status := Status{
+		NodeTransfer: &NodeTransfer{
 			OldNode: types.NodeName("old.123"),
 			NewNode: types.NodeName("new.456"),
 		},
 	}
+	id := fields.ID("rc_id")
 
-	rcID := fields.ID("rc_id")
-	err := store.Set(rcID, testStatus)
-	if err != nil {
-		t.Fatalf("Unexpected error setting rc status: %s", err)
-	}
-
-	status, _, err := store.Get(rcID)
-	if err != nil {
-		t.Fatalf("Unexpected error getting status: %s", err)
-	}
-
-	if status.NodeTransfer.OldNode == "" || status.NodeTransfer.NewNode == "" {
-		t.Fatalf("Expected oldNode and newNode to be set but they were not")
-	}
-
-	if status.NodeTransfer.OldNode != testStatus.NodeTransfer.OldNode {
-		t.Fatalf("Expected oldNode to be %s, was %s", testStatus.NodeTransfer.OldNode, status.NodeTransfer.OldNode)
-	}
-
-	if status.NodeTransfer.NewNode != testStatus.NodeTransfer.NewNode {
-		t.Fatalf("Expected newNode to be %s, was %s", testStatus.NodeTransfer.NewNode, status.NodeTransfer.NewNode)
+	return testHelper{
+		consulFixture: consulFixture,
+		store:         store,
+		status:        status,
+		id:            id,
 	}
 }
 
-func TestDelete(t *testing.T) {
-	store := newFixture()
-	testStatus := RCStatus{
-		NodeTransfer: NodeTransfer{
-			OldNode: types.NodeName("old.123"),
-			NewNode: types.NodeName("new.456"),
-		},
+func TestSetAndGetStatus(t *testing.T) {
+	th := initTestHelper(t)
+	defer th.stop()
+
+	_, _, err := th.store.Get(th.id)
+	if !statusstore.IsNoStatus(err) {
+		t.Fatalf("Expected no status error, got: %s", err)
 	}
 
-	// Put a value in the store
-	rcID := fields.ID("rc_id")
-	err := store.Set(rcID, testStatus)
+	err = th.store.Set(th.id, th.status)
 	if err != nil {
 		t.Fatalf("Unexpected error setting status: %s", err)
 	}
 
-	// Get the value out to confirm it's there
-	status, _, err := store.Get(rcID)
+	status, _, err := th.store.Get(th.id)
 	if err != nil {
 		t.Fatalf("Unexpected error getting status: %s", err)
 	}
 
-	if status.NodeTransfer != testStatus.NodeTransfer {
-		t.Fatalf("Expected status.NodeTransfer to be %v, but was %v", testStatus.NodeTransfer, status.NodeTransfer)
-	}
-
-	// Now delete it
-	err = store.Delete(rcID)
-	if err != nil {
-		t.Fatalf("Error deleting rc status: %s", err)
-	}
-
-	_, _, err = store.Get(rcID)
-	if err == nil {
-		t.Fatal("Expected an error fetching a deleted status")
-	}
-
-	if !statusstore.IsNoStatus(err) {
-		t.Errorf("Expected error to be NoStatus but was %s", err)
+	if *(status.NodeTransfer) != *(th.status.NodeTransfer) {
+		t.Fatalf("NodeTransfer was %v, wanted %v", status.NodeTransfer, th.status.NodeTransfer)
 	}
 }
 
-func newFixture() *ConsulStore {
-	return &ConsulStore{
-		statusStore: statusstoretest.NewFake(),
-		namespace:   "test_namespace",
+func TestCASTxn(t *testing.T) {
+	th := initTestHelper(t)
+	defer th.stop()
+
+	// Test check and set new status
+	status, queryMeta, err := testCASTxnHelper(th, 0)
+	if err != nil {
+		t.Fatal(err)
 	}
+
+	if *(status.NodeTransfer) != *(th.status.NodeTransfer) {
+		t.Fatalf("NodeTransfer was %v, wanted %v", status.NodeTransfer, th.status.NodeTransfer)
+	}
+
+	// Test mutate existing status
+	mutatedNode := types.NodeName("new.789")
+	th.status.NodeTransfer.NewNode = mutatedNode
+
+	status, _, err = testCASTxnHelper(th, queryMeta.LastIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if status.NodeTransfer.NewNode != mutatedNode {
+		t.Fatalf("NewNode was %v, wanted %v", status.NodeTransfer.NewNode, mutatedNode)
+	}
+
+	// Test bad modify index
+	_, _, err = testCASTxnHelper(th, 1000)
+	if err == nil {
+		t.Fatalf("Expected error but err was nil")
+	}
+}
+
+func testCASTxnHelper(th testHelper, modifyIndex uint64) (*Status, *api.QueryMeta, error) {
+	writeCtx, writeCancel := transaction.New(context.Background())
+	defer writeCancel()
+
+	err := th.store.CASTxn(writeCtx, th.id, modifyIndex, th.status)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = transaction.MustCommit(writeCtx, th.consulFixture.Client.KV())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	status, queryMeta, err := th.store.Get(th.id)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &status, queryMeta, nil
 }


### PR DESCRIPTION
Add transactional check and set CASTxn(). Also update
names based on go code review guide.

Cleaned up rc status store text, added CASTxn to use in the replication controller, and updated rc status struct name based on https://github.com/golang/go/wiki/CodeReviewComments#package-names. This commit also includes the NodeTransfer as a pointer change. 