### PR TITLE
Enhance daemon set logging

### DIFF
--- a/pkg/ds/farm.go
+++ b/pkg/ds/farm.go
@@ -343,28 +343,24 @@ func (dsf *Farm) handleDSChanges(ctx context.Context, changes dsstore.WatchedDae
 	dsf.childMu.Lock()
 	defer dsf.childMu.Unlock()
 	if len(changes.Created) > 0 {
-		dsf.logger.Infof("The following %d daemon sets have been created: %s", len(changes.Created), dsIDs(changes.Created))
 		for _, dsFields := range changes.Created {
 			dsf.lockAndSpawn(ctx, *dsFields)
 		}
 	}
 
 	if len(changes.Updated) > 0 {
-		dsf.logger.Infof("The following %d daemon sets have been updated: %s", len(changes.Updated), dsIDs(changes.Updated))
 		for _, dsFields := range changes.Updated {
 			dsf.lockAndSpawn(ctx, *dsFields)
 		}
 	}
 
 	if len(changes.Same) > 0 {
-		dsf.logger.Infof("The following %d daemon sets are the same: %s", len(changes.Same), dsIDs(changes.Same))
 		for _, dsFields := range changes.Same {
 			dsf.lockAndSpawn(ctx, *dsFields)
 		}
 	}
 
 	if len(changes.Deleted) > 0 {
-		dsf.logger.Infof("The following %d daemon sets have been deleted: %s", len(changes.Deleted), dsIDs(changes.Deleted))
 		for _, dsFields := range changes.Deleted {
 			// We have to spawn the daemon set, so that it can act on its deletion.
 			// Otherwise, child is nil when we reach the below select.
@@ -392,6 +388,8 @@ func (dsf *Farm) handleDSChanges(ctx context.Context, changes dsstore.WatchedDae
 			case child.deletedCh <- *dsFields:
 				dsf.closeChild(dsFields.ID)
 			}
+
+			dsf.logger.Infof("Released deleted daemon set %s", dsFields.ID)
 		}
 	}
 }


### PR DESCRIPTION
This commit removes some noisy log messages that aren't very useful at
the farm level, such as the ones that list all of the daemon sets.

It also trades general messages (e.g. "daemon set updated") for specific
ones (e.g. "daemon set disabled").