### PR TITLE
Spenceral/delete rcstatus

### DIFF
--- a/pkg/rc/replication_controller_test.go
+++ b/pkg/rc/replication_controller_test.go
@@ -787,7 +787,7 @@ func TestAlertIfCannotAllocateNodes(t *testing.T) {
 	// Force an allocate nodes failure
 	fixture := consulutil.NewFixture(t)
 	closeFn = fixture.Stop
-	applicator = labels.NewConsulApplicator(fixture.Client, 0)
+	applicator = labels.NewConsulApplicator(fixture.Client, 0, 0)
 	rc.scheduler = testScheduler{applicator, true}
 
 	err := testIneligibleNodesCommon(applicator, rc, alerter)

--- a/pkg/store/consul/statusstore/rcstatus/store.go
+++ b/pkg/store/consul/statusstore/rcstatus/store.go
@@ -70,3 +70,11 @@ func (c ConsulStore) CASTxn(ctx context.Context, rcID fields.ID, modifyIndex uin
 
 	return c.statusStore.CASStatus(ctx, statusstore.RC, statusstore.ResourceID(rcID), c.namespace, rawStatus, modifyIndex)
 }
+
+func (c ConsulStore) Delete(rcID fields.ID) error {
+	if rcID == "" {
+		return util.Errorf("Provided replication controller ID was empty")
+	}
+
+	return c.statusStore.DeleteStatus(statusstore.RC, statusstore.ResourceID(rcID.String()), c.namespace)
+}

--- a/pkg/store/consul/statusstore/rcstatus/store_test.go
+++ b/pkg/store/consul/statusstore/rcstatus/store_test.go
@@ -101,6 +101,42 @@ func TestCASTxn(t *testing.T) {
 	}
 }
 
+func TestDelete(t *testing.T) {
+	th := initTestHelper(t)
+	defer th.stop()
+
+	// Put a value in the store
+	err := th.store.Set(th.id, th.status)
+	if err != nil {
+		t.Fatalf("Unexpected error setting status: %s", err)
+	}
+
+	// Get the value out to confirm it's there
+	status, _, err := th.store.Get(th.id)
+	if err != nil {
+		t.Fatalf("Unexpected error getting status: %s", err)
+	}
+
+	if *(status.NodeTransfer) != *(th.status.NodeTransfer) {
+		t.Fatalf("Expected status.NodeTransfer to be %v, but was %v", th.status.NodeTransfer, status.NodeTransfer)
+	}
+
+	// Now delete it
+	err = th.store.Delete(th.id)
+	if err != nil {
+		t.Fatalf("Error deleting rc status: %s", err)
+	}
+
+	_, _, err = th.store.Get(th.id)
+	if err == nil {
+		t.Fatal("Expected an error fetching a deleted status")
+	}
+
+	if !statusstore.IsNoStatus(err) {
+		t.Errorf("Expected error to be NoStatus but was %s", err)
+	}
+}
+
 func testCASTxnHelper(th testHelper, modifyIndex uint64) (*Status, *api.QueryMeta, error) {
 	writeCtx, writeCancel := transaction.New(context.Background())
 	defer writeCancel()


### PR DESCRIPTION
In hindsight this is a confusing branch name. I'm adding a Delete() function to the rcstatus store, not deleting the store.