### PR TITLE
pkg/alerting: support different pagerduty urgency levels in alerts

### DIFF
--- a/bin/p2-rctl-server/main.go
+++ b/bin/p2-rctl-server/main.go
@@ -95,7 +95,9 @@ func main() {
 	alerter := alerting.NewNop()
 	if *pagerdutyServiceKey != "" {
 		var err error
-		alerter, err = alerting.NewPagerduty(*pagerdutyServiceKey, httpClient)
+		// just use the same key for high and low urgency
+		// TODO: support both high and low urgency keys
+		alerter, err = alerting.NewPagerduty(*pagerdutyServiceKey, *pagerdutyServiceKey, httpClient)
 		if err != nil {
 			logger.WithError(err).Fatalln(
 				"Unable to initialize pagerduty alerter",

--- a/pkg/alerting/alerter.go
+++ b/pkg/alerting/alerter.go
@@ -18,12 +18,16 @@ type AlertInfo struct {
 }
 
 type Alerter interface {
-	Alert(alertInfo AlertInfo) error
+	Alert(alertInfo AlertInfo, urgency Urgency) error
 }
 
-func NewPagerduty(serviceKey string, client *http.Client) (Alerter, error) {
-	if serviceKey == "" {
-		return nil, util.Errorf("serviceKey must be provided for pagerduty alerters")
+func NewPagerduty(highUrgencyServiceKey string, lowUrgencyServiceKey string, client *http.Client) (Alerter, error) {
+	if highUrgencyServiceKey == "" {
+		return nil, util.Errorf("high urgency service key must be provided for pagerduty alerters")
+	}
+
+	if lowUrgencyServiceKey == "" {
+		return nil, util.Errorf("low urgency service key must be provided for pagerduty alerters")
 	}
 
 	if client == nil {
@@ -31,8 +35,9 @@ func NewPagerduty(serviceKey string, client *http.Client) (Alerter, error) {
 	}
 
 	return &pagerdutyAlerter{
-		ServiceKey: serviceKey,
-		Client:     client,
+		HighUrgencyServiceKey: highUrgencyServiceKey,
+		LowUrgencyServiceKey:  lowUrgencyServiceKey,
+		Client:                client,
 	}, nil
 }
 

--- a/pkg/alerting/alertingtest/alerter.go
+++ b/pkg/alerting/alertingtest/alerter.go
@@ -4,8 +4,13 @@ import (
 	"github.com/square/p2/pkg/alerting"
 )
 
+type alertCall struct {
+	alertInfo alerting.AlertInfo
+	urgency   alerting.Urgency
+}
+
 type AlertRecorder struct {
-	Alerts []alerting.AlertInfo
+	Alerts []alertCall
 }
 
 var _ alerting.Alerter = &AlertRecorder{}
@@ -14,7 +19,10 @@ func NewRecorder() *AlertRecorder {
 	return &AlertRecorder{}
 }
 
-func (f *AlertRecorder) Alert(alertInfo alerting.AlertInfo) error {
-	f.Alerts = append(f.Alerts, alertInfo)
+func (f *AlertRecorder) Alert(alertInfo alerting.AlertInfo, urgency alerting.Urgency) error {
+	f.Alerts = append(f.Alerts, alertCall{
+		alertInfo: alertInfo,
+		urgency:   urgency,
+	})
 	return nil
 }

--- a/pkg/alerting/nop_alerter.go
+++ b/pkg/alerting/nop_alerter.go
@@ -4,6 +4,6 @@ type nopAlerter struct{}
 
 var _ Alerter = &nopAlerter{}
 
-func (*nopAlerter) Alert(alertInfo AlertInfo) error {
+func (*nopAlerter) Alert(alertInfo AlertInfo, urgency Urgency) error {
 	return nil
 }

--- a/pkg/alerting/pagerduty_test.go
+++ b/pkg/alerting/pagerduty_test.go
@@ -2,14 +2,17 @@ package alerting
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"github.com/square/p2/pkg/util"
 )
 
 func TestNewPagerduty(t *testing.T) {
-	alerter, err := NewPagerduty("some_service_key", nil)
+	alerter, err := NewPagerduty("some_service_key", "some_other_service_key", nil)
 	if err != nil {
 		t.Fatalf("Unexpected error creating pagerduty alerter: %s", err)
 	}
@@ -27,9 +30,18 @@ func TestNewPagerduty(t *testing.T) {
 		t.Fatalf("NewPagerduty() should have created an http.Client for pagerdutyAlerter")
 	}
 
-	alerter, err = NewPagerduty("", nil)
+	alerter, err = NewPagerduty("", "low_urgency", nil)
 	if err == nil {
-		t.Fatalf("Should have had an error creating a pagerduty alerter with an empty service key")
+		t.Fatalf("Should have had an error creating a pagerduty alerter with an empty high urgency service key")
+	}
+
+	if alerter != nil {
+		t.Fatalf("Returned alerter should be nil if there was an error")
+	}
+
+	alerter, err = NewPagerduty("high_urgency", "", nil)
+	if err == nil {
+		t.Fatalf("Should have had an error creating a pagerduty alerter with an empty low urgency service key")
 	}
 
 	if alerter != nil {
@@ -39,8 +51,8 @@ func TestNewPagerduty(t *testing.T) {
 
 func TestAlert(t *testing.T) {
 	alerter := pagerdutyAlerter{
-		ServiceKey: "service_key",
-		Client:     okPagerdutyClient{},
+		HighUrgencyServiceKey: "high_urgency_service_key",
+		Client:                okPagerdutyClient{},
 	}
 
 	alertInfo := AlertInfo{
@@ -51,7 +63,7 @@ func TestAlert(t *testing.T) {
 		}{"host.com"},
 	}
 
-	err := alerter.Alert(alertInfo)
+	err := alerter.Alert(alertInfo, HighUrgency)
 	if err != nil {
 		t.Fatalf("Unexpected error sending fake alert: %s", err)
 	}
@@ -59,8 +71,8 @@ func TestAlert(t *testing.T) {
 
 func TestForbidden(t *testing.T) {
 	alerter := pagerdutyAlerter{
-		ServiceKey: "service_key",
-		Client:     forbiddenPagerdutyClient{},
+		HighUrgencyServiceKey: "high_urgency_service_key",
+		Client:                forbiddenPagerdutyClient{},
 	}
 
 	alertInfo := AlertInfo{
@@ -71,7 +83,7 @@ func TestForbidden(t *testing.T) {
 		}{"host.com"},
 	}
 
-	err := alerter.Alert(alertInfo)
+	err := alerter.Alert(alertInfo, HighUrgency)
 	if err == nil {
 		t.Fatalf("Expected error message due to rate limiting")
 	}
@@ -79,8 +91,8 @@ func TestForbidden(t *testing.T) {
 
 func TestServerError(t *testing.T) {
 	alerter := pagerdutyAlerter{
-		ServiceKey: "service_key",
-		Client:     badPagerdutyClient{},
+		HighUrgencyServiceKey: "high_urgency_service_key",
+		Client:                badPagerdutyClient{},
 	}
 
 	alertInfo := AlertInfo{
@@ -91,7 +103,7 @@ func TestServerError(t *testing.T) {
 		}{"host.com"},
 	}
 
-	err := alerter.Alert(alertInfo)
+	err := alerter.Alert(alertInfo, HighUrgency)
 	if err == nil {
 		t.Fatalf("Expected error message due to server error")
 	}
@@ -99,8 +111,8 @@ func TestServerError(t *testing.T) {
 
 func TestIncompleteInformation(t *testing.T) {
 	alerter := pagerdutyAlerter{
-		ServiceKey: "service_key",
-		Client:     okPagerdutyClient{},
+		HighUrgencyServiceKey: "high_urgency_service_key",
+		Client:                okPagerdutyClient{},
 	}
 
 	// missing Description
@@ -111,7 +123,7 @@ func TestIncompleteInformation(t *testing.T) {
 		}{"host.com"},
 	}
 
-	err := alerter.Alert(alertInfo)
+	err := alerter.Alert(alertInfo, HighUrgency)
 	if err == nil {
 		t.Fatalf("Expected error message due to missing description")
 	}
@@ -124,9 +136,44 @@ func TestIncompleteInformation(t *testing.T) {
 		}{"host.com"},
 	}
 
-	err = alerter.Alert(alertInfo)
+	err = alerter.Alert(alertInfo, HighUrgency)
 	if err == nil {
 		t.Fatalf("Expected error message due to missing incident key")
+	}
+}
+
+func TestUrgencyAndServiceKey(t *testing.T) {
+	recordingClient := &serviceKeyRecordingPagerdutyClient{}
+	alerter := pagerdutyAlerter{
+		HighUrgencyServiceKey: "high_urgency",
+		LowUrgencyServiceKey:  "low_urgency",
+		Client:                recordingClient,
+	}
+
+	alertInfo := AlertInfo{
+		Description: "a fake error happened",
+		IncidentKey: "incident_key",
+		Details: struct {
+			Host string `json:"host"`
+		}{"host.com"},
+	}
+
+	err := alerter.Alert(alertInfo, HighUrgency)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if recordingClient.serviceKeyUsed != "high_urgency" {
+		t.Errorf("expected the alerter to use the high urgency service key %q for high urgency alerts but used %q", "high_urgency", recordingClient.serviceKeyUsed)
+	}
+
+	err = alerter.Alert(alertInfo, LowUrgency)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if recordingClient.serviceKeyUsed != "low_urgency" {
+		t.Errorf("expected the alerter to use the low urgency service key %q for low urgency alerts but used %q", "low_urgency", recordingClient.serviceKeyUsed)
 	}
 }
 
@@ -160,5 +207,31 @@ func (badPagerdutyClient) Post(uri string, contentType string, body io.Reader) (
 	return &http.Response{
 		StatusCode: http.StatusInternalServerError,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte("an error occurred"))),
+	}, nil
+}
+
+type serviceKeyRecordingPagerdutyClient struct {
+	serviceKeyUsed string
+}
+
+var _ Poster = &serviceKeyRecordingPagerdutyClient{}
+
+func (s *serviceKeyRecordingPagerdutyClient) Post(uri string, contentType string, body io.Reader) (*http.Response, error) {
+	pdBody := pagerdutyBody{}
+	bodyBytes, err := ioutil.ReadAll(body)
+	if err != nil {
+		return nil, util.Errorf("Test reader couldn't read the pagerduty request's body: %s", err)
+	}
+
+	err = json.Unmarshal(bodyBytes, &pdBody)
+	if err != nil {
+		return nil, util.Errorf("serviceKeyRecordingPagerdutyClient couldn't unmarshal the body of the request as JSON: %s", err)
+	}
+
+	s.serviceKeyUsed = pdBody.ServiceKey
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       ioutil.NopCloser(bytes.NewReader([]byte("ok"))),
 	}, nil
 }

--- a/pkg/ds/farm.go
+++ b/pkg/ds/farm.go
@@ -531,7 +531,7 @@ func (dsf *Farm) raiseContentionAlert(oldDS ds_fields.DaemonSet, newDS ds_fields
 			NewdPodID:       newDS.PodID,
 			NewDisabled:     newDS.Disabled,
 		},
-	}); alertErr != nil {
+	}, alerting.LowUrgency); alertErr != nil {
 		dsf.logger.WithError(alertErr).Errorln("Unable to deliver alert!")
 	}
 }

--- a/pkg/rc/farm.go
+++ b/pkg/rc/farm.go
@@ -351,7 +351,7 @@ func (rcf *Farm) initialFailsafe() {
 		if err := rcf.alerter.Alert(alerting.AlertInfo{
 			Description: "No RCs have been scheduled",
 			IncidentKey: "no_rcs_found",
-		}); err != nil {
+		}, alerting.HighUrgency); err != nil {
 			rcf.logger.WithError(err).Errorln("Unable to deliver alert!")
 		}
 		panic("No RCs are scheduled at all. Create one RC to enable the farm. Panicking to escape a potentially bad situation.")
@@ -367,7 +367,7 @@ func (rcf *Farm) initialFailsafe() {
 	if err := rcf.alerter.Alert(alerting.AlertInfo{
 		Description: "All RCs have zero replicas requested",
 		IncidentKey: "zero_replicas_found",
-	}); err != nil {
+	}, alerting.HighUrgency); err != nil {
 		rcf.logger.WithError(err).Errorln("Unable to deliver alert!")
 	}
 	panic("The sum of all replicas is 0. Panicking to escape a potentially bad situation")
@@ -381,7 +381,7 @@ func (rcf *Farm) failsafe(rcs []rcstore.RCLockResult) {
 		if err := rcf.alerter.Alert(alerting.AlertInfo{
 			Description: "No RCs have been scheduled",
 			IncidentKey: "no_rcs_found",
-		}); err != nil {
+		}, alerting.HighUrgency); err != nil {
 			rcf.logger.WithError(err).Errorln("Unable to deliver alert!")
 		}
 		panic("No RCs are scheduled at all. Create one RC to enable the farm. Panicking to escape a potentially bad situation.")

--- a/pkg/rc/farm_test.go
+++ b/pkg/rc/farm_test.go
@@ -18,7 +18,7 @@ type failsafeAlerter struct {
 	savedInfo alerting.AlertInfo
 }
 
-func (f *failsafeAlerter) Alert(info alerting.AlertInfo) error {
+func (f *failsafeAlerter) Alert(info alerting.AlertInfo, urgency alerting.Urgency) error {
 	f.savedInfo = info
 	return nil
 }

--- a/pkg/rc/replication_controller.go
+++ b/pkg/rc/replication_controller.go
@@ -291,7 +291,7 @@ func (rc *replicationController) addPods(current types.PodLocations, eligible []
 				"Not enough nodes to meet desire: %d replicas desired, %d currentNodes, %d eligible. Scheduled on %d nodes instead.",
 				rc.ReplicasDesired, len(currentNodes), len(eligible), i,
 			)
-			err := rc.alerter.Alert(rc.alertInfo(errMsg))
+			err := rc.alerter.Alert(rc.alertInfo(errMsg), alerting.LowUrgency)
 			if err != nil {
 				rc.logger.WithError(err).Errorln("Unable to send alert")
 			}
@@ -659,7 +659,7 @@ func (rc *replicationController) transferCattleNodes(ineligibleCurrent []types.N
 	rc.mu.Unlock()
 	if err != nil || len(newNodes) < 1 {
 		errMsg := fmt.Sprintf("Unable to allocate nodes over grpc: %s", err)
-		err := rc.alerter.Alert(rc.alertInfo(errMsg))
+		err := rc.alerter.Alert(rc.alertInfo(errMsg), alerting.LowUrgency)
 		if err != nil {
 			rc.logger.WithError(err).Errorln("Unable to send alert")
 		}
@@ -696,7 +696,7 @@ func (rc *replicationController) transferCattleNodes(ineligibleCurrent []types.N
 
 func (rc *replicationController) transferPetNodes(ineligibleCurrent []types.NodeName) error {
 	errMsg := fmt.Sprintf("RC has scheduled %d ineligible nodes: %s", len(ineligibleCurrent), ineligibleCurrent)
-	err := rc.alerter.Alert(rc.alertInfo(errMsg))
+	err := rc.alerter.Alert(rc.alertInfo(errMsg), alerting.LowUrgency)
 	if err != nil {
 		rc.logger.WithError(err).Errorln("Unable to send alert")
 	}

--- a/pkg/roll/farm.go
+++ b/pkg/roll/farm.go
@@ -461,7 +461,7 @@ func (rlf *Farm) mustDeleteRU(id roll_fields.ID, logger logging.Logger) {
 			}{
 				Errors: resp.Errors,
 			},
-		})
+		}, alerting.LowUrgency)
 	}
 
 	for err = f2(); err != nil; err = f2() {

--- a/pkg/roll/integration_test.go
+++ b/pkg/roll/integration_test.go
@@ -112,7 +112,7 @@ type errorOnceChannelAlerter struct {
 	ranOnce bool
 }
 
-func (c errorOnceChannelAlerter) Alert(alerting.AlertInfo) error {
+func (c errorOnceChannelAlerter) Alert(_ alerting.AlertInfo, _ alerting.Urgency) error {
 	c.out <- struct{}{}
 	if c.ranOnce {
 		return nil

--- a/pkg/roll/run_update.go
+++ b/pkg/roll/run_update.go
@@ -222,8 +222,7 @@ func (u *update) cleanupOldRC(quit <-chan struct{}) {
 					RUID:        u.ID().String(),
 					NumReplicas: oldRC.ReplicasDesired,
 				},
-			},
-			)
+			}, alerting.LowUrgency)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
The alerting package provides an interface for sending alerts when
something goes wrong within P2, and has an implementation of that
interface that uses the pagerduty API.

This commit adds the ability to configure the pagerduty alerter with
high and low urgency service keys to use with pagerduty's API as well as
the ability to specify whether an alert is high or low urgency. The
correct key will be used depending on the urgency of the alert.