### PR TITLE
Support pod level cgroup in p2-exec

### DIFF
--- a/bin/p2-exec/main.go
+++ b/bin/p2-exec/main.go
@@ -89,25 +89,16 @@ func main() {
 			log.Fatal(err)
 		}
 
-		node, err := os.Hostname()
-		if err != nil {
-			log.Fatal(err)
-		}
-
 		cg, err := cgroups.Find()
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		err = os.MkdirAll(filepath.Join(cg.CPU, "p2", node), 0755)
-		if err != nil && !os.IsExist(err) {
+		// Create p2/{nodename} cgroup if it does not already exist
+		cgroupPath, err = cg.CreateBaseCgroup()
+		if err != nil {
 			log.Fatal(err)
 		}
-		err = os.MkdirAll(filepath.Join(cg.Memory, "p2", node), 0755)
-		if err != nil && !os.IsExist(err) {
-			log.Fatal(err)
-		}
-		cgroupPath = filepath.Join(cgroupPath, node)
 
 		err = cgCreate(*podID, cgroupPath, cgConfig)
 		if err != nil {

--- a/bin/p2-exec/main.go
+++ b/bin/p2-exec/main.go
@@ -88,22 +88,25 @@ func main() {
 			log.Fatal(err)
 		}
 
-		err = cgCreate("p2", cgroupPath, cgConfig)
-		if err != nil {
-			log.Fatalf("Could not create p2 cgroup %v\n", err)
-		}
-		cgroupPath = "p2"
-
 		node, err := os.Hostname()
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		err = cgCreate(node, cgroupPath, cgConfig)
+		cg, err := cgroups.Find()
 		if err != nil {
-			log.Fatalf("Could not create cgroup for node %v %v\n", node, err)
+			log.Fatal(err)
 		}
-		cgroupPath = cgroupPath + "/" + node
+
+		err = os.MkdirAll(filepath.Join(cg.CPU, "p2", node), 0755)
+		if err != nil && !os.IsExist(err) {
+			log.Fatal(err)
+		}
+		err = os.MkdirAll(filepath.Join(cg.Memory, "p2", node), 0755)
+		if err != nil && !os.IsExist(err) {
+			log.Fatal(err)
+		}
+		cgroupPath = "p2" + "/" + node
 
 		err = cgCreate(*podID, cgroupPath, cgConfig)
 		if err != nil {

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/square/p2/pkg/util"
+	"gopkg.in/yaml.v2"
 )
 
 // maps cgroup subsystems to their respective paths
@@ -72,11 +73,18 @@ func Find() (Subsystems, error) {
 	return ret, nil
 }
 
-func FindWithParentGroup(parentGroupName string) (Subsystems, error) {
+func FindWithParentGroup(podID string) (Subsystems, error) {
 	subsys, err := Find()
 	if err != nil {
 		return Subsystems{}, err
 	}
+
+	node, err := os.Hostname()
+	if err != nil {
+		return Subsystems{}, err
+	}
+
+	parentGroupName := filepath.Join("p2", node, podID)
 
 	subsys.CPU = filepath.Join(subsys.CPU, parentGroupName)
 	subsys.Memory = filepath.Join(subsys.Memory, parentGroupName)
@@ -195,20 +203,101 @@ func (subsys Subsystems) AddPID(name string, pid int) error {
 	return appendIntToFile(filepath.Join(subsys.CPU, name, "cgroup.procs"), pid)
 }
 
-func (subsys Subsystems) CreateBaseCgroup() (string, error) {
+func CreatePodCgroup(cgroupName string, config Config) error {
+	subsys, err := Find()
+	if err != nil {
+		return err
+	}
 	node, err := os.Hostname()
 	if err != nil {
-		return "", err
+		return err
 	}
 	err = os.MkdirAll(filepath.Join(subsys.CPU, "p2", node), 0755)
 	if err != nil && !os.IsExist(err) {
-		return "", err
+		return err
 	}
 	err = os.MkdirAll(filepath.Join(subsys.Memory, "p2", node), 0755)
 	if err != nil && !os.IsExist(err) {
-		return "", err
+		return err
 	}
-	return filepath.Join("p2", node), nil
+	return create(cgroupName, "", config)
+}
+
+func CreateLaunchableCgroup(cgroupName, podID string, config Config) error {
+	return create(cgroupName, podID, config)
+}
+
+func create(cgroupName string, podID string, config Config) error {
+	config.Name = cgroupName
+
+	var subsys Subsystems
+	var err error
+	if podID != "" {
+		subsys, err = FindWithParentGroup(podID)
+	} else {
+		subsys, err = Find()
+	}
+
+	if err != nil {
+		return util.Errorf("Could not find cgroupfs mount point: %s", err)
+	}
+
+	err = subsys.Write(config)
+	if _, ok := err.(UnsupportedError); ok {
+		// if a subsystem is not supported, just log
+		// and carry on
+		fmt.Printf("Unsupported subsystem (%s), continuing\n", err)
+		return nil
+	} else if err != nil {
+		return util.Errorf("Could not set cgroup parameters: %s", err)
+	}
+	return subsys.AddPID(config.Name, 0)
+}
+
+func GetPodConfig(configPath string) (Config, error) {
+	if config := os.Getenv(configPath); config != "" {
+		confBuf, err := ioutil.ReadFile(config)
+		if err != nil {
+			return Config{}, err
+		}
+		cgMap := make(map[string]Config)
+		err = yaml.Unmarshal(confBuf, cgMap)
+		if err != nil {
+			return Config{}, err
+		}
+		if _, ok := cgMap["cgroup"]; !ok {
+			return Config{}, util.Errorf("%s does not contain cgroup parameters\n", configPath)
+		}
+		cgConfig := cgMap["cgroup"]
+		return cgConfig, nil
+	} else {
+		return Config{}, util.Errorf("No %s found in environment", configPath)
+	}
+}
+
+func GetLaunchableConfig(configPath string, configKey string) (Config, error) {
+	if config := os.Getenv(configPath); config != "" {
+		confBuf, err := ioutil.ReadFile(config)
+		if err != nil {
+			return Config{}, err
+		}
+		cgMap := make(map[string]map[string]Config)
+		err = yaml.Unmarshal(confBuf, cgMap)
+		if err != nil {
+			return Config{}, err
+		}
+
+		if _, ok := cgMap[configKey]; !ok {
+			return Config{}, util.Errorf("Key %q not found in %s", configKey, configPath)
+		}
+		if _, ok := cgMap[configKey]["cgroup"]; !ok {
+			return Config{}, util.Errorf("Key %q in %s does not contain cgroup parameters\n", configKey, configPath)
+		}
+		cgConfig := cgMap[configKey]["cgroup"]
+		return cgConfig, nil
+	} else {
+		return Config{}, util.Errorf("No %s found in environment", configPath)
+	}
 }
 
 func appendIntToFile(filename string, data int) error {

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -195,6 +195,22 @@ func (subsys Subsystems) AddPID(name string, pid int) error {
 	return appendIntToFile(filepath.Join(subsys.CPU, name, "cgroup.procs"), pid)
 }
 
+func (subsys Subsystems) CreateBaseCgroup() (string, error) {
+	node, err := os.Hostname()
+	if err != nil {
+		return "", err
+	}
+	err = os.MkdirAll(filepath.Join(subsys.CPU, "p2", node), 0755)
+	if err != nil && !os.IsExist(err) {
+		return "", err
+	}
+	err = os.MkdirAll(filepath.Join(subsys.Memory, "p2", node), 0755)
+	if err != nil && !os.IsExist(err) {
+		return "", err
+	}
+	return filepath.Join("p2", node), nil
+}
+
 func appendIntToFile(filename string, data int) error {
 	fd, err := os.OpenFile(filename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
 	if err != nil {

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -244,10 +244,7 @@ func create(cgroupName string, podID string, config Config) error {
 
 	err = subsys.Write(config)
 	if _, ok := err.(UnsupportedError); ok {
-		// if a subsystem is not supported, just log
-		// and carry on
-		fmt.Printf("Unsupported subsystem (%s), continuing\n", err)
-		return nil
+		return util.Errorf("Unsupported subsystem: %s", err)
 	} else if err != nil {
 		return util.Errorf("Could not set cgroup parameters: %s", err)
 	}

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -72,6 +72,23 @@ func Find() (Subsystems, error) {
 	return ret, nil
 }
 
+func FindWithParentGroup(parentGroupName string) (Subsystems, error) {
+	subsys, err := Find()
+	if err != nil {
+		return Subsystems{}, err
+	}
+
+	subsys.CPU = filepath.Join(subsys.CPU, parentGroupName)
+	subsys.Memory = filepath.Join(subsys.Memory, parentGroupName)
+
+	if stat, err := os.Stat(subsys.CPU); err == nil && stat.IsDir() {
+		if stat, err := os.Stat(subsys.Memory); err == nil && stat.IsDir() {
+			return subsys, nil
+		}
+	}
+	return Subsystems{}, UnsupportedError(parentGroupName)
+}
+
 // set the number of logical CPUs in a given cgroup, 0 to unrestrict
 // https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt
 func (subsys Subsystems) SetCPU(name string, cpus int) error {

--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -45,6 +45,7 @@ type Launchable struct {
 	CgroupConfig     cgroups.Config             // Cgroup parameters to use with p2-exec
 	CgroupConfigName string                     // The string in PLATFORM_CONFIG to pass to p2-exec
 	CgroupName       string                     // The name of the cgroup to run this launchable in
+	PodCgroup        string                     // If set, execute with the -n (--pod-cgroup) argument to p2-exec
 	RequireFile      string                     // Do not run this launchable until this file exists
 	RestartTimeout   time.Duration              // How long to wait when restarting the services in this launchable.
 	RestartPolicy_   runit.RestartPolicy        // Dictates whether the launchable should be automatically restarted upon exit.
@@ -208,6 +209,7 @@ func (hl *Launchable) InvokeBinScript(script string) (string, error) {
 		NoLimits:         hl.ExecNoLimit,
 		CgroupConfigName: hl.CgroupConfigName,
 		CgroupName:       cgroupName,
+		PodCgroup:        hl.PodCgroup,
 		RequireFile:      hl.RequireFile,
 	}
 	cmd := exec.Command(hl.P2Exec, p2ExecArgs.CommandLine()...)
@@ -370,6 +372,7 @@ func (hl *Launchable) Executables(
 				NoLimits:         hl.ExecNoLimit,
 				CgroupConfigName: hl.CgroupConfigName,
 				CgroupName:       hl.CgroupName,
+				PodCgroup:        hl.PodCgroup,
 				RequireFile:      hl.RequireFile,
 			}
 			execCmd := append([]string{hl.P2Exec}, p2ExecArgs.CommandLine()...)

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -31,7 +31,7 @@ type StatusStanza struct {
 }
 
 type ResourceLimitsStanza struct {
-	CGroup cgroups.Config `yaml:"cgroup,omitempty"`
+	Cgroup cgroups.Config `yaml:"cgroup,omitempty"`
 }
 
 type Builder interface {
@@ -140,7 +140,7 @@ func (manifest *manifest) SetLaunchables(launchableStanzas map[launch.Launchable
 }
 
 func (manifest *manifest) SetPodLevelCgroup(cgroupConfig cgroups.Config) {
-	manifest.ResourceLimits.CGroup = cgroupConfig
+	manifest.ResourceLimits.Cgroup = cgroupConfig
 }
 
 func (manifest *manifest) GetConfig() map[interface{}]interface{} {

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -25,7 +25,7 @@ func TestPodManifestCanBeRead(t *testing.T) {
 	Assert(t).AreEqual(manifest.GetLaunchableStanzas()["app"].Location, "hoisted-hello_def456.tar.gz", "Location read from manifest didn't have expected value")
 	Assert(t).AreEqual("hoist", manifest.GetLaunchableStanzas()["app"].LaunchableType, "LaunchableType read from manifest didn't have expected value")
 
-	Assert(t).AreEqual(4, manifest.GetResourceLimits().CGroup.CPUs, "CPU count for pod level cgroup didn't have expected value")
+	Assert(t).AreEqual(4, manifest.GetResourceLimits().Cgroup.CPUs, "CPU count for pod level cgroup didn't have expected value")
 
 	Assert(t).AreEqual("staging", manifest.GetConfig()["ENVIRONMENT"], "Should have read the ENVIRONMENT from the config stanza")
 	hoptoad := manifest.GetConfig()["hoptoad"].(map[interface{}]interface{})
@@ -153,7 +153,7 @@ func TestPodManifestCanReportItsSHA(t *testing.T) {
 	}
 }
 
-func TestPodManifestLaunchablesCGroups(t *testing.T) {
+func TestPodManifestLaunchablesCgroups(t *testing.T) {
 	config := testPod()
 	manifest, _ := FromBytes([]byte(config))
 	launchables := manifest.GetLaunchableStanzas()

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -25,6 +25,8 @@ func TestPodManifestCanBeRead(t *testing.T) {
 	Assert(t).AreEqual(manifest.GetLaunchableStanzas()["app"].Location, "hoisted-hello_def456.tar.gz", "Location read from manifest didn't have expected value")
 	Assert(t).AreEqual("hoist", manifest.GetLaunchableStanzas()["app"].LaunchableType, "LaunchableType read from manifest didn't have expected value")
 
+	Assert(t).AreEqual(4, manifest.GetResourceLimits().CGroup.CPUs, "CPU count for pod level cgroup didn't have expected value")
+
 	Assert(t).AreEqual("staging", manifest.GetConfig()["ENVIRONMENT"], "Should have read the ENVIRONMENT from the config stanza")
 	hoptoad := manifest.GetConfig()["hoptoad"].(map[interface{}]interface{})
 	Assert(t).IsTrue(len(hoptoad) == 3, "Should have read the hoptoad value from the config stanza")
@@ -42,6 +44,10 @@ launchables:
       cpus: 4
       memory: 1073741824
     location: https://localhost:4444/foo/bar/baz.tar.gz
+resource_limits:
+  cgroup:
+    cpus: 8
+    memory: 1099511627776
 config:
   ENVIRONMENT: staging
 status:
@@ -103,6 +109,10 @@ func TestPodManifestCanBeWritten(t *testing.T) {
 			},
 		},
 	}
+	builder.SetPodLevelCgroup(cgroups.Config{
+		CPUs:   8,
+		Memory: 1 * size.Tebibyte,
+	})
 	builder.SetLaunchables(launchables)
 	err := builder.SetConfig(map[interface{}]interface{}{
 		"ENVIRONMENT": "staging",

--- a/pkg/manifest/test_manifest.yaml
+++ b/pkg/manifest/test_manifest.yaml
@@ -13,6 +13,11 @@ launchables:
     launchable_id: app
     location: hoisted-hello_def456.tar.gz
 
+resource_limits:
+  cgroup:
+    cpus: 4
+    memory: 1
+
 config:
   # is written to a file and passed as CONFIG_FILE to the process
   ENVIRONMENT: staging

--- a/pkg/p2exec/p2_exec.go
+++ b/pkg/p2exec/p2_exec.go
@@ -20,6 +20,7 @@ type P2ExecArgs struct {
 	Command          []string
 	WorkDir          string
 	RequireFile      string
+	Pod              string
 }
 
 func (args P2ExecArgs) CommandLine() []string {
@@ -54,6 +55,10 @@ func (args P2ExecArgs) CommandLine() []string {
 
 	if args.RequireFile != "" {
 		cmd = append(cmd, "--require-file", args.RequireFile)
+	}
+
+	if args.Pod != "" {
+		cmd = append(cmd, "-p", args.Pod)
 	}
 
 	if len(cmd) > 0 {

--- a/pkg/p2exec/p2_exec.go
+++ b/pkg/p2exec/p2_exec.go
@@ -20,7 +20,7 @@ type P2ExecArgs struct {
 	Command          []string
 	WorkDir          string
 	RequireFile      string
-	Pod              string
+	PodCgroup        string
 }
 
 func (args P2ExecArgs) CommandLine() []string {
@@ -57,8 +57,8 @@ func (args P2ExecArgs) CommandLine() []string {
 		cmd = append(cmd, "--require-file", args.RequireFile)
 	}
 
-	if args.Pod != "" {
-		cmd = append(cmd, "-p", args.Pod)
+	if args.PodCgroup != "" {
+		cmd = append(cmd, "-p", args.PodCgroup)
 	}
 
 	if len(cmd) > 0 {

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/square/p2/pkg/artifact"
 	"github.com/square/p2/pkg/auth"
+	"github.com/square/p2/pkg/cgroups"
 	"github.com/square/p2/pkg/digest"
 	"github.com/square/p2/pkg/hoist"
 	"github.com/square/p2/pkg/launch"
@@ -732,6 +733,16 @@ func (pod *Pod) getLaunchable(launchableID launch.LaunchableID, launchableStanza
 		pod.logger.WithError(err).Warnf("Could not parse version from launchable %s.", launchableID)
 	}
 
+	podCgroup := ""
+	if *NestedCgroups {
+		err = pod.installCgroup()
+		if err != nil {
+			pod.logger.WithError(err).Errorf("Could not create pod cgroup")
+		}
+
+		podCgroup = pod.UniqueName()
+	}
+
 	if launchableStanza.LaunchableType == "hoist" {
 		entryPointPaths := launchableStanza.EntryPoints
 		implicitEntryPoints := false
@@ -739,19 +750,15 @@ func (pod *Pod) getLaunchable(launchableID launch.LaunchableID, launchableStanza
 			implicitEntryPoints = true
 			entryPointPaths = append(entryPointPaths, path.Join("bin", "launch"))
 		}
-		cgroupName := serviceId
-		if *NestedCgroups {
-			cgroupName = filepath.Join(
-				"p2",
-				pod.node.String(),
-				pod.UniqueName(),
-				launchableID.String(),
-			)
-		}
 
 		entryPoints := hoist.EntryPoints{
 			Paths:    entryPointPaths,
 			Implicit: implicitEntryPoints,
+		}
+
+		cgroupName := serviceId
+		if *NestedCgroups {
+			cgroupName = launchableID.String()
 		}
 
 		ret := &hoist.Launchable{
@@ -768,6 +775,7 @@ func (pod *Pod) getLaunchable(launchableID launch.LaunchableID, launchableStanza
 			CgroupConfig:     launchableStanza.CgroupConfig,
 			CgroupConfigName: launchableID.String(),
 			CgroupName:       cgroupName,
+			PodCgroup:        podCgroup,
 			SuppliedEnvVars:  launchableStanza.Env,
 			EntryPoints:      entryPoints,
 			IsUUIDPod:        pod.uniqueKey != "",
@@ -821,6 +829,20 @@ func (pod *Pod) disableAndHaltLaunchables(currentManifest manifest.Manifest) err
 		}
 	}
 
+	return nil
+}
+
+func (pod *Pod) installCgroup() error {
+	if *NestedCgroups {
+		cgConfig, err := cgroups.GetPodConfig(ResourceLimitsConfigPathEnvVar)
+		if err != nil {
+			return err
+		}
+		err = cgroups.CreatePodCgroup(pod.UniqueName(), cgConfig)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -590,7 +590,7 @@ func (pod *Pod) setupConfig(manifest manifest.Manifest, launchables []launch.Lau
 	if err != nil {
 		return err
 	}
-	err = writeEnvFile(pod.EnvDir(), ResourceLimitsConfigPathEnvVar, platConfigPath, uid, gid)
+	err = writeEnvFile(pod.EnvDir(), ResourceLimitsConfigPathEnvVar, resourceLimitsConfigPath, uid, gid)
 	if err != nil {
 		return err
 	}

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -130,6 +130,10 @@ launchables:
       memory: 4G
     env:
       ENABLED_BLAMS: 5
+resource_limits:
+  cgroup:
+    cpus: 9
+    memory: 8G
 config:
   ENVIRONMENT: staging
 `
@@ -203,6 +207,21 @@ config:
 		Assert(t).IsNil(err, "should not have erred reading custom env var")
 		Assert(t).AreEqual("5", string(enableBlamSetting), "The user-supplied custom env var was wrong")
 	}
+
+	resourceLimitsConfigFileName, err := manifest.ResourceLimitsConfigFileName()
+	Assert(t).IsNil(err, "Couldn't generate resource limits config filename")
+	resourceLimitsConfigPath := filepath.Join(pod.ConfigDir(), resourceLimitsConfigFileName)
+	resourceLimitsConfig, err := ioutil.ReadFile(resourceLimitsConfigPath)
+
+	expectedResourceLimitsConfig := `cgroup:
+  cpus: 9
+  memory: 8589934592
+`
+	Assert(t).AreEqual(expectedResourceLimitsConfig, string(resourceLimitsConfig), "the resource limits config didn't match")
+
+	resourceEnv, err := ioutil.ReadFile(filepath.Join(pod.EnvDir(), "RESOURCE_LIMITS_PATH"))
+	Assert(t).IsNil(err, "should not have erred while reading the resource limits env file")
+	Assert(t).AreEqual(resourceLimitsConfigPath, string(resourceEnv), "The env path to resource limits didn't match")
 }
 
 func TestLogLaunchableError(t *testing.T) {


### PR DESCRIPTION
p2-exec takes a "pod" argument, that creates a parent "pod level" cgroup wrapping the launchable

/cgroup/CPU/p2/nodename/{pod}/{cgroupname}
/cgroup/Memory/p2/nodename/{pod}/{cgroupname}

as of right now, it pulls the parameters for this "pod level" cgroup from _RESOURCE_LIMITS_PATH_, searching for a key of the same name
