### PR TITLE
Add LockIfKeyNotExistsTxn() function

### DIFF
--- a/pkg/rc/replication_controller.go
+++ b/pkg/rc/replication_controller.go
@@ -92,6 +92,15 @@ type consulStore interface {
 		nodeName types.NodeName,
 		manifestID types.PodID,
 	) error
+
+	LockIfKeyNotExistsTxn(
+		ctx context.Context,
+		podPrefix consul.PodPrefix,
+		nodeName types.NodeName,
+		manifest manifest.Manifest,
+		session consul.Session,
+	) error
+
 	NewUnmanagedSession(session, name string) consul.Session
 }
 


### PR DESCRIPTION
This will be used by the replication controller to schedule a new node
during a node transfer. By using a check and set with a modify index of
0, it is guaranteed that the intent/ key does not yet exist. If the CAS
fails, another RC has already taken over the node and we can rollback
the node transfer.