### PR TITLE
Add allocation strategy field to pod clusters

### DIFF
--- a/bin/p2-pcctl/main.go
+++ b/bin/p2-pcctl/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pc/control"
 	"github.com/square/p2/pkg/pc/fields"
+	rc_fields "github.com/square/p2/pkg/rc/fields"
 	"github.com/square/p2/pkg/store/consul"
 	"github.com/square/p2/pkg/store/consul/flags"
 	"github.com/square/p2/pkg/store/consul/pcstore"
@@ -41,6 +42,7 @@ var (
 	createAZ          = cmdCreate.Flag("az", "The availability zone of the pod cluster").Required().String()
 	createName        = cmdCreate.Flag("name", "The cluster name (ie. staging, production)").Required().String()
 	createAnnotations = cmdCreate.Flag("annotations", "Complete set of annotations - must parse as JSON!").String()
+	createStrategy    = cmdCreate.Flag("allocation-strategy", "The allocation strategy to use for RCs created for this pod cluster").Required().Enum(rc_fields.PetStrategy.String(), rc_fields.CattleStrategy.String())
 )
 
 // "get" command and flags
@@ -108,7 +110,8 @@ func main() {
 		cn := fields.ClusterName(*createName)
 		podID := types.PodID(*createPodID)
 		selector := defaultSelector(az, cn, podID)
-		pccontrol := control.NewPodCluster(az, cn, podID, pcstore, selector)
+		strategy := rc_fields.Strategy(*createStrategy)
+		pccontrol := control.NewPodCluster(az, cn, podID, pcstore, selector, strategy)
 
 		annotations := *createAnnotations
 		var parsedAnnotations map[string]interface{}
@@ -137,7 +140,7 @@ func main() {
 			pccontrol = control.NewPodClusterFromID(pcID, pcstore)
 		} else if az != "" && cn != "" && podID != "" {
 			selector := defaultSelector(az, cn, podID)
-			pccontrol = control.NewPodCluster(az, cn, podID, pcstore, selector)
+			pccontrol = control.NewPodCluster(az, cn, podID, pcstore, selector, "")
 		} else {
 			log.Fatalf("Expected one of: pcID or (pod,az,name)")
 		}
@@ -163,7 +166,7 @@ func main() {
 			pccontrol = control.NewPodClusterFromID(pcID, pcstore)
 		} else if az != "" && cn != "" && podID != "" {
 			selector := defaultSelector(az, cn, podID)
-			pccontrol = control.NewPodCluster(az, cn, podID, pcstore, selector)
+			pccontrol = control.NewPodCluster(az, cn, podID, pcstore, selector, "")
 		} else {
 			log.Fatalf("Expected one of: pcID or (pod,az,name)")
 		}
@@ -186,7 +189,7 @@ func main() {
 			pccontrol = control.NewPodClusterFromID(pcID, pcstore)
 		} else if az != "" && cn != "" && podID != "" {
 			selector := defaultSelector(az, cn, podID)
-			pccontrol = control.NewPodCluster(az, cn, podID, pcstore, selector)
+			pccontrol = control.NewPodCluster(az, cn, podID, pcstore, selector, "")
 		} else {
 			log.Fatalf("Expected one of: pcID or (pod,az,name)")
 		}

--- a/pkg/pc/control/control.go
+++ b/pkg/pc/control/control.go
@@ -5,6 +5,7 @@ package control
 
 import (
 	"github.com/square/p2/pkg/pc/fields"
+	rc_fields "github.com/square/p2/pkg/rc/fields"
 	"github.com/square/p2/pkg/store/consul/pcstore"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
@@ -25,6 +26,7 @@ type PodClusterStore interface {
 		clusterName fields.ClusterName,
 		podSelector labels.Selector,
 		annotations fields.Annotations,
+		allocationStrategy rc_fields.Strategy,
 		session pcstore.Session,
 	) (fields.PodCluster, error)
 	MutatePC(
@@ -42,6 +44,7 @@ type PodCluster struct {
 	cn       fields.ClusterName
 	podID    types.PodID
 	selector labels.Selector
+	strategy rc_fields.Strategy
 }
 
 func NewPodCluster(
@@ -50,6 +53,7 @@ func NewPodCluster(
 	podID types.PodID,
 	pcstore PodClusterStore,
 	selector labels.Selector,
+	strategy rc_fields.Strategy,
 ) *PodCluster {
 
 	pc := &PodCluster{}
@@ -58,6 +62,7 @@ func NewPodCluster(
 	pc.podID = podID
 	pc.pcStore = pcstore
 	pc.selector = selector
+	pc.strategy = strategy
 
 	return pc
 }
@@ -100,7 +105,7 @@ func (pccontrol *PodCluster) Delete() (errors []error) {
 }
 
 func (pccontrol *PodCluster) Create(annotations fields.Annotations, session pcstore.Session) (fields.PodCluster, error) {
-	return pccontrol.pcStore.Create(pccontrol.podID, pccontrol.az, pccontrol.cn, pccontrol.selector, annotations, session)
+	return pccontrol.pcStore.Create(pccontrol.podID, pccontrol.az, pccontrol.cn, pccontrol.selector, annotations, pccontrol.strategy, session)
 }
 
 func (pccontrol *PodCluster) Get() (fields.PodCluster, error) {

--- a/pkg/pc/control/control_test.go
+++ b/pkg/pc/control/control_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/square/p2/pkg/pc/fields"
+	rc_fields "github.com/square/p2/pkg/rc/fields"
 	"github.com/square/p2/pkg/store/consul/consultest"
 	"github.com/square/p2/pkg/store/consul/pcstore"
 	"github.com/square/p2/pkg/store/consul/pcstore/pcstoretest"
@@ -22,8 +23,9 @@ func TestCreate(t *testing.T) {
 		Add(fields.ClusterNameLabel, labels.EqualsOperator, []string{testCN.String()})
 	session := consultest.NewSession()
 	pcstore := pcstoretest.NewFake()
+	strategy := rc_fields.PetStrategy
 
-	pcController := NewPodCluster(testAZ, testCN, testPodID, pcstore, selector)
+	pcController := NewPodCluster(testAZ, testCN, testPodID, pcstore, selector, strategy)
 
 	annotations := map[string]string{
 		"load_balancer_info": "totally",
@@ -83,8 +85,9 @@ func TestUpdateAnnotations(t *testing.T) {
 		Add(fields.ClusterNameLabel, labels.EqualsOperator, []string{testCN.String()})
 	session := consultest.NewSession()
 	pcstore := pcstoretest.NewFake()
+	strategy := rc_fields.PetStrategy
 
-	pcController := NewPodCluster(testAZ, testCN, testPodID, pcstore, selector)
+	pcController := NewPodCluster(testAZ, testCN, testPodID, pcstore, selector, strategy)
 
 	var annotations = map[string]string{
 		"load_balancer_info": "totally",
@@ -150,7 +153,8 @@ func TestPodClusterFromID(t *testing.T) {
 	session := consultest.NewSession()
 	fakePCStore := pcstoretest.NewFake()
 
-	pcControllerFromLabels := NewPodCluster(testAZ, testCN, testPodID, fakePCStore, selector)
+	strategy := rc_fields.PetStrategy
+	pcControllerFromLabels := NewPodCluster(testAZ, testCN, testPodID, fakePCStore, selector, strategy)
 	pc, err := pcControllerFromLabels.Create(fields.Annotations{}, session)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/pc/fields/fields_test.go
+++ b/pkg/pc/fields/fields_test.go
@@ -3,6 +3,8 @@ package fields
 import (
 	"k8s.io/kubernetes/pkg/labels"
 
+	rc_fields "github.com/square/p2/pkg/rc/fields"
+
 	"testing"
 )
 
@@ -24,7 +26,8 @@ func equalPodClusters() (*PodCluster, *PodCluster) {
 			"key1": "value",
 			"key2": 2,
 		},
-		PodSelector: labels.Everything().Add("environment", labels.EqualsOperator, []string{"fancy"}),
+		PodSelector:        labels.Everything().Add("environment", labels.EqualsOperator, []string{"fancy"}),
+		AllocationStrategy: rc_fields.PetStrategy,
 	}
 	b := &PodCluster{
 		ID:               "abc123",
@@ -35,7 +38,8 @@ func equalPodClusters() (*PodCluster, *PodCluster) {
 			"key1": "value",
 			"key2": 2,
 		},
-		PodSelector: labels.Everything().Add("environment", labels.EqualsOperator, []string{"fancy"}),
+		PodSelector:        labels.Everything().Add("environment", labels.EqualsOperator, []string{"fancy"}),
+		AllocationStrategy: rc_fields.PetStrategy,
 	}
 	return a, b
 }
@@ -80,6 +84,10 @@ func TestPodEquality(t *testing.T) {
 	a.PodSelector = labels.Everything().Add("environment", labels.EqualsOperator, []string{"special"})
 	assertNotEqual("different pod selector")
 	a.PodSelector = b.PodSelector
+
+	a.AllocationStrategy = "foo"
+	assertNotEqual("AllocationStrategy")
+	a.AllocationStrategy = b.AllocationStrategy
 
 	ax := a
 	a = nil

--- a/pkg/rc/fields/fields.go
+++ b/pkg/rc/fields/fields.go
@@ -11,20 +11,9 @@ import (
 	"github.com/square/p2/pkg/util"
 )
 
-const (
-	// CattleStrategy is used for dynamic node allocation to one of many
-	// replaceable nodes i.e. cattle, while PetStrategy is used when a manifest
-	// must be scheduled on specific nodes i.e. pets
-	CattleStrategy = Strategy("cattle_strategy")
-	PetStrategy    = Strategy("pet_strategy")
-)
-
 // ID is a named type alias for Resource Controller IDs. This is preferred to the raw
 // string format so that Go will typecheck its uses.
 type ID string
-
-// Strategy is a type alias used for node allocation strategies.
-type Strategy string
 
 // String implements fmt.Stringer
 func (id ID) String() string {
@@ -39,6 +28,19 @@ func ToRCID(rcID string) (ID, error) {
 
 	return ID(rcUUID.String()), nil
 }
+
+// Strategy is a type alias used for node allocation strategies.
+type Strategy string
+
+func (s Strategy) String() string { return string(s) }
+
+const (
+	// CattleStrategy is used for dynamic node allocation to one of many
+	// replaceable nodes i.e. cattle, while PetStrategy is used when a manifest
+	// must be scheduled on specific nodes i.e. pets
+	CattleStrategy = Strategy("cattle_strategy")
+	PetStrategy    = Strategy("pet_strategy")
+)
 
 // RC holds the runtime state of a Resource Controller as saved in Consul.
 type RC struct {

--- a/pkg/store/consul/pcstore/consul_store.go
+++ b/pkg/store/consul/pcstore/consul_store.go
@@ -17,6 +17,7 @@ import (
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pc/fields"
+	rc_fields "github.com/square/p2/pkg/rc/fields"
 	"github.com/square/p2/pkg/store/consul"
 	"github.com/square/p2/pkg/store/consul/consulutil"
 	"github.com/square/p2/pkg/types"
@@ -122,6 +123,7 @@ func (s *ConsulStore) Create(
 	clusterName fields.ClusterName,
 	podSelector klabels.Selector,
 	annotations fields.Annotations,
+	allocationStrategy rc_fields.Strategy,
 	session Session,
 ) (fields.PodCluster, error) {
 	id := fields.ID(uuid.New())
@@ -141,12 +143,13 @@ func (s *ConsulStore) Create(
 	}
 
 	pc := fields.PodCluster{
-		ID:               id,
-		PodID:            podID,
-		AvailabilityZone: availabilityZone,
-		Name:             clusterName,
-		PodSelector:      podSelector,
-		Annotations:      annotations,
+		ID:                 id,
+		PodID:              podID,
+		AvailabilityZone:   availabilityZone,
+		Name:               clusterName,
+		PodSelector:        podSelector,
+		Annotations:        annotations,
+		AllocationStrategy: allocationStrategy,
 	}
 
 	key, err := pcPath(id)

--- a/pkg/store/consul/pcstore/consul_store_test.go
+++ b/pkg/store/consul/pcstore/consul_store_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/pc/fields"
+	rc_fields "github.com/square/p2/pkg/rc/fields"
 	"github.com/square/p2/pkg/store/consul"
 	"github.com/square/p2/pkg/store/consul/consultest"
 	"github.com/square/p2/pkg/store/consul/consulutil"
@@ -124,9 +125,10 @@ func createPodCluster(store *ConsulStore, t *testing.T) fields.PodCluster {
 	annotations := fields.Annotations(map[string]interface{}{
 		"foo": "bar",
 	})
+	strategy := rc_fields.PetStrategy
 
 	session := consultest.NewSession()
-	pc, err := store.Create(podID, az, clusterName, selector, annotations, session)
+	pc, err := store.Create(podID, az, clusterName, selector, annotations, strategy, session)
 	if err != nil {
 		t.Fatalf("Unable to create pod cluster: %s", err)
 	}
@@ -182,7 +184,7 @@ func TestLabelsOnCreate(t *testing.T) {
 		"foo": "bar",
 	})
 
-	pc, err := store.Create(podID, az, clusterName, selector, annotations, consultest.NewSession())
+	pc, err := store.Create(podID, az, clusterName, selector, annotations, rc_fields.PetStrategy, consultest.NewSession())
 	if err != nil {
 		t.Fatalf("Unable to create pod cluster: %s", err)
 	}
@@ -217,7 +219,7 @@ func TestGet(t *testing.T) {
 	})
 
 	// Create a pod cluster
-	pc, err := store.Create(podID, az, clusterName, selector, annotations, consultest.NewSession())
+	pc, err := store.Create(podID, az, clusterName, selector, annotations, rc_fields.PetStrategy, consultest.NewSession())
 	if err != nil {
 		t.Fatalf("Unable to create pod cluster: %s", err)
 	}
@@ -291,7 +293,7 @@ func TestDelete(t *testing.T) {
 	})
 
 	// Create a pod cluster
-	pc, err := store.Create(podID, az, clusterName, selector, annotations, consultest.NewSession())
+	pc, err := store.Create(podID, az, clusterName, selector, annotations, rc_fields.PetStrategy, consultest.NewSession())
 	if err != nil {
 		t.Fatalf("Unable to create pod cluster: %s", err)
 	}
@@ -338,13 +340,13 @@ func TestList(t *testing.T) {
 	})
 
 	// Create a pod cluster
-	pc, err := store.Create(podID, az, clusterName, selector, annotations, consultest.NewSession())
+	pc, err := store.Create(podID, az, clusterName, selector, annotations, rc_fields.PetStrategy, consultest.NewSession())
 	if err != nil {
 		t.Fatalf("Unable to create pod cluster: %s", err)
 	}
 
 	// Create another one
-	pc2, err := store.Create(podID+"2", az, clusterName, selector, annotations, consultest.NewSession())
+	pc2, err := store.Create(podID+"2", az, clusterName, selector, annotations, rc_fields.PetStrategy, consultest.NewSession())
 	if err != nil {
 		t.Fatalf("Unable to create pod cluster: %s", err)
 	}
@@ -390,12 +392,12 @@ func TestWatch(t *testing.T) {
 
 	var watched WatchedPodClusters
 	session := consultest.NewSession()
-	pc, err := store.Create(podID, az, clusterName, selector, annotations, session)
+	pc, err := store.Create(podID, az, clusterName, selector, annotations, rc_fields.PetStrategy, session)
 	if err != nil {
 		t.Fatalf("Unable to create first pod cluster: %s", err)
 	}
 
-	pc2, err := store.Create(podID, "us-east", clusterName, selector, annotations, session)
+	pc2, err := store.Create(podID, "us-east", clusterName, selector, annotations, rc_fields.PetStrategy, session)
 	if err != nil {
 		t.Fatalf("Unable to create second pod cluster: %s", err)
 	}
@@ -447,7 +449,7 @@ func TestWatchPodCluster(t *testing.T) {
 	})
 
 	session := consultest.NewSession()
-	pc, err := store.Create(podID, az, clusterName, selector, annotations, session)
+	pc, err := store.Create(podID, az, clusterName, selector, annotations, rc_fields.PetStrategy, session)
 	if err != nil {
 		t.Fatalf("Unable to create pod cluster: %s", err)
 	}
@@ -971,6 +973,7 @@ func TestWatchAndSync(t *testing.T) {
 		"name1",
 		example.PodSelector,
 		example.Annotations,
+		rc_fields.PetStrategy,
 		consultest.NewSession(),
 	)
 	if err != nil {
@@ -983,6 +986,7 @@ func TestWatchAndSync(t *testing.T) {
 		"name2",
 		example.PodSelector,
 		example.Annotations,
+		rc_fields.PetStrategy,
 		consultest.NewSession(),
 	)
 	if err != nil {
@@ -1044,6 +1048,7 @@ func TestWatchAndSyncWithDelete(t *testing.T) {
 		"name1",
 		example.PodSelector,
 		example.Annotations,
+		rc_fields.PetStrategy,
 		consultest.NewSession(),
 	)
 	if err != nil {

--- a/pkg/store/consul/pcstore/pcstoretest/fake_pcstore.go
+++ b/pkg/store/consul/pcstore/pcstoretest/fake_pcstore.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/pc/fields"
+	rc_fields "github.com/square/p2/pkg/rc/fields"
 	"github.com/square/p2/pkg/store/consul"
 	"github.com/square/p2/pkg/store/consul/pcstore"
 	"github.com/square/p2/pkg/types"
@@ -32,16 +33,18 @@ func (p *FakePCStore) Create(
 	clusterName fields.ClusterName,
 	podSelector klabels.Selector,
 	annotations fields.Annotations,
+	strategy rc_fields.Strategy,
 	_ pcstore.Session,
 ) (fields.PodCluster, error) {
 	id := fields.ID(uuid.New())
 	pc := fields.PodCluster{
-		ID:               id,
-		PodID:            podID,
-		AvailabilityZone: availabilityZone,
-		Name:             clusterName,
-		PodSelector:      podSelector,
-		Annotations:      annotations,
+		ID:                 id,
+		PodID:              podID,
+		AvailabilityZone:   availabilityZone,
+		Name:               clusterName,
+		PodSelector:        podSelector,
+		Annotations:        annotations,
+		AllocationStrategy: strategy,
 	}
 
 	p.podClusters[id] = pc


### PR DESCRIPTION
This strategy field will be a long-term place to store the desired
configuration for the RC strategy for RCs created within this pod
cluster (since RCs are ephemeral).