### PR TITLE
Fix an error checking bug in replication package

### DIFF
--- a/pkg/replication/replication.go
+++ b/pkg/replication/replication.go
@@ -482,12 +482,12 @@ func (r *replication) handleReplicationEnd(session consul.Session, renewalErrCh 
 
 func (r *replication) shouldScheduleForNode(node types.NodeName, logger logging.Logger) bool {
 	nodeReality, err := r.queryReality(node)
-	if err != nil {
-		logger.WithError(err).Errorln("Could not read Reality for this node. Will proceed to schedule onto it.")
-		return true
-	}
-	if err == pods.NoCurrentManifest {
+	switch {
+	case err == pods.NoCurrentManifest:
 		logger.Infoln("Nothing installed on this node yet.")
+		return true
+	case err != nil:
+		logger.WithError(err).Errorln("Could not read Reality for this node. Will proceed to schedule onto it.")
 		return true
 	}
 


### PR DESCRIPTION
This bug resulted in log messages that said "could not read reality for
this node" when in fact the read was successful but there was just a
missing key. It's clear the code meant to separate these two situations
but the missing key block was unreachable.