### PR TITLE
pkg/rc: stop using an RC pointer passed to a watch function

### DIFF
--- a/pkg/rc/auditing_transaction_test.go
+++ b/pkg/rc/auditing_transaction_test.go
@@ -25,18 +25,19 @@ func TestAuditingTransaction(t *testing.T) {
 	defer fixture.Stop()
 
 	auditLogStore := auditlogstore.NewConsulStore(fixture.Client.KV())
-	rc := &replicationController{
-		RC: rc_fields.RC{
-			Manifest: testManifest(),
-			PodLabels: klabels.Set{
-				pc_fields.AvailabilityZoneLabel: "some_az",
-				pc_fields.ClusterNameLabel:      "some_cn",
-			},
+	rcFields := rc_fields.RC{
+		Manifest: testManifest(),
+		PodLabels: klabels.Set{
+			pc_fields.AvailabilityZoneLabel: "some_az",
+			pc_fields.ClusterNameLabel:      "some_cn",
 		},
+	}
+
+	rc := &replicationController{
 		auditLogStore: auditLogStore,
 	}
 
-	ctx, cancel := rc.newAuditingTransaction(context.Background(), []types.NodeName{"node1", "node2"})
+	ctx, cancel := rc.newAuditingTransaction(context.Background(), rcFields, []types.NodeName{"node1", "node2"})
 	defer cancel()
 
 	ctx.AddNode("node3")
@@ -195,18 +196,18 @@ func TestCommitWithRetriesDoesntRetryRollback(t *testing.T) {
 func testCommitWithRetries(fixture consulutil.Fixture, t *testing.T, shouldErr bool, shouldRollback bool) (signalingTxner, auditlogstore.ConsulStore) {
 
 	auditLogStore := auditlogstore.NewConsulStore(fixture.Client.KV())
-	rc := &replicationController{
-		RC: rc_fields.RC{
-			Manifest: testManifest(),
-			PodLabels: klabels.Set{
-				pc_fields.AvailabilityZoneLabel: "some_az",
-				pc_fields.ClusterNameLabel:      "some_cn",
-			},
+	rcFields := rc_fields.RC{
+		Manifest: testManifest(),
+		PodLabels: klabels.Set{
+			pc_fields.AvailabilityZoneLabel: "some_az",
+			pc_fields.ClusterNameLabel:      "some_cn",
 		},
+	}
+	rc := &replicationController{
 		auditLogStore: auditLogStore,
 	}
 
-	ctx, cancel := rc.newAuditingTransaction(context.Background(), []types.NodeName{"node1", "node2"})
+	ctx, cancel := rc.newAuditingTransaction(context.Background(), rcFields, []types.NodeName{"node1", "node2"})
 
 	ctx.AddNode("node3")
 	ctx.RemoveNode("node2")

--- a/pkg/rc/farm.go
+++ b/pkg/rc/farm.go
@@ -261,26 +261,8 @@ START_LOOP:
 				// at this point the rc is ours, time to spin it up
 				rcLogger.NoFields().Infoln("Acquired lock on new replication controller, spawning")
 
-				// TODO: maybe we don't need to fetch the RC
-				// here, but that involves changing replication
-				// controller code which expands the scope of
-				// the change to watching RC keys rather than
-				// values.  Also it probably doesn't matter
-				// much since we won't actually be doing a
-				// fetch that often (only when lock not held)
-				rc, err := rcf.rcStore.Get(rcKey.ID)
-				if err != nil {
-					rcLogger.WithError(err).Error("unable to fetch RC to process it")
-
-					unlockErr := rcUnlocker.Unlock()
-					if unlockErr != nil {
-						rcLogger.WithError(unlockErr).Error("unable to unlock RC after processing failure")
-					}
-					continue
-				}
-
 				newChild := New(
-					rc,
+					rcKey.ID,
 					rcf.store,
 					rcf.client,
 					rcf.rcStatusStore,


### PR DESCRIPTION
Prior to this commit, the main replication controller loop would start
by calling the Watch() function on the RC store, passing it a pointer to
an RC struct and also a mutex. Whenever the watch goroutine detected a
change to the RC, it would lock the mutex and then mutate the RC
pointer.

This meant that whenever the main RC loop tried to access a field on the
RC pointer, it would need to grab a mutex while it did so. This is
untenable as new references to the field are added all the time and it's
hard to remember to hold the mutex, creating data races.

Furthermore, it's hard to reason about what happens if the RC is mutated
in the middle of a meetDesires() invocation.

To address this, this PR changes the way Watch() on the rc store works
so that it returns a channel of RC structs (not pointers). Whenever a
value is read from the channel, this value is passed to meetDesires()
where it is processed without fear of mutation occurring during the
call.

Now the only mutex needed by the replication controller handler is to
guard the node transfer struct which is still used by multiple
goroutines.