### PR TITLE
Call allocate before deallocate in node transfer

### DIFF
--- a/pkg/rc/replication_controller.go
+++ b/pkg/rc/replication_controller.go
@@ -737,13 +737,6 @@ func (rc *replicationController) updateAllocations(ineligible []types.NodeName) 
 	sel := rc.NodeSelector
 	rc.mu.Unlock()
 
-	oldNode := ineligible[0]
-	err := rc.scheduler.DeallocateNodes(sel, []types.NodeName{oldNode})
-	if err != nil {
-		return "", "", util.Errorf("Could not deallocate from %s: %s", oldNode, err)
-	}
-	rc.logger.Infof("Deallocated ineligible node %s", oldNode)
-
 	eligible, err := rc.eligibleNodes()
 	if err != nil {
 		return "", "", err
@@ -777,6 +770,13 @@ func (rc *replicationController) updateAllocations(ineligible []types.NodeName) 
 		newNode = newNodes[0]
 		rc.logger.Infof("Allocated node %s for transfer", newNode)
 	}
+
+	oldNode := ineligible[0]
+	err = rc.scheduler.DeallocateNodes(sel, []types.NodeName{oldNode})
+	if err != nil {
+		return "", "", util.Errorf("Could not deallocate from %s: %s", oldNode, err)
+	}
+	rc.logger.Infof("Deallocated ineligible node %s", oldNode)
 
 	status := rcstatus.Status{
 		NodeTransfer: &rcstatus.NodeTransfer{


### PR DESCRIPTION
This change prevents the chance of a logical error in which
AllocateNodes() would return the same node that DeallocateNodes() just
removed. While that wouldn't happen if we set the cologroup of the deallocated
node correctly, it is nice to ensure it can't happen even in the event of
cologroup oversight.