### PR TITLE
clear the env for bin scripts

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -209,6 +209,7 @@ func (hl *Launchable) InvokeBinScript(script string) (string, error) {
 		CgroupConfigName: hl.CgroupConfigName,
 		CgroupName:       cgroupName,
 		RequireFile:      hl.RequireFile,
+		ClearEnv:         true,
 	}
 	cmd := exec.Command(hl.P2Exec, p2ExecArgs.CommandLine()...)
 	buffer := bytes.Buffer{}

--- a/pkg/p2exec/p2_exec.go
+++ b/pkg/p2exec/p2_exec.go
@@ -20,6 +20,7 @@ type P2ExecArgs struct {
 	Command          []string
 	WorkDir          string
 	RequireFile      string
+	ClearEnv         bool
 }
 
 func (args P2ExecArgs) CommandLine() []string {
@@ -54,6 +55,10 @@ func (args P2ExecArgs) CommandLine() []string {
 
 	if args.RequireFile != "" {
 		cmd = append(cmd, "--require-file", args.RequireFile)
+	}
+
+	if args.ClearEnv {
+		cmd = append(cmd, "--clearenv")
 	}
 
 	if len(cmd) > 0 {


### PR DESCRIPTION
p2-exec has a --clearenv argument. We ought to be using it when invoking bin scripts!