### PR TITLE
Remove incorrect node transfer text from log

### DIFF
--- a/pkg/rc/replication_controller.go
+++ b/pkg/rc/replication_controller.go
@@ -298,7 +298,7 @@ func (rc *replicationController) meetDesires(rcFields fields.RC) error {
 
 	ineligible := rc.checkForIneligible(current, eligible)
 	if len(ineligible) > 0 {
-		rc.logger.Infof("Ineligible nodes: %s found, starting node transfer", ineligible)
+		rc.logger.Infof("Ineligible nodes: %s found", ineligible)
 		err := rc.transferNodes(rcFields, ineligible)
 		if err != nil {
 			return err
@@ -662,6 +662,8 @@ func (rc *replicationController) transferNodes(rcFields fields.RC, ineligible []
 		// a node transfer to replace the ineligible node is already in progress
 		return nil
 	}
+
+	rc.logger.Infoln("Starting node transfer")
 
 	if rcFields.AllocationStrategy != fields.DynamicStrategy {
 		errMsg := fmt.Sprintf("static strategy RC has scheduled %d ineligible nodes: %s", len(ineligible), ineligible)


### PR DESCRIPTION
When ineligible nodes were detected, a message was logged suggesting
that a node transfer was starting. However, that was only true if a node
transfer was not already in progress. The logging has been updated to
only log "Starting node transfer" when one is actually going to start.