### PR TITLE
Update signature of Run() roll.Update interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.7.4
+  - 1.9.2
 
 env:
   - RACE=-race

--- a/bin/p2-exec/main_linux.go
+++ b/bin/p2-exec/main_linux.go
@@ -35,14 +35,9 @@ func sysMaxFDs() (*C.struct_rlimit, error) {
 }
 
 func sysUnRlimit() *C.struct_rlimit {
-	// this constant is set to -1. in C, you can coerce this to an
-	// unsigned integer, but in go, you cannot
-	// we have to delay the signed->unsigned cast until runtime to
-	// avoid compile errors
-	inf := C.RLIM_INFINITY
 	return &C.struct_rlimit{
-		C.rlim_t(inf),
-		C.rlim_t(inf),
+		C.rlim_t(C.RLIM_INFINITY),
+		C.rlim_t(C.RLIM_INFINITY),
 	}
 }
 

--- a/bin/p2-rctl/main.go
+++ b/bin/p2-rctl/main.go
@@ -405,12 +405,12 @@ func (r rctlParams) RollingUpdate(oldID, newID string, want, need int) {
 	}
 	session := r.consuls.NewUnmanagedSession(sessionID, "")
 
-	result := make(chan bool, 1)
+	result := make(chan struct{})
+	ctx, cancel := transaction.New(context.Background())
 	go func() {
-		ctx, cancel := transaction.New(context.Background())
 		defer cancel()
 		watchDelay := 1 * time.Second
-		result <- roll.NewUpdate(
+		roll.NewUpdate(
 			roll_fields.Update{
 				OldRC:           rc_fields.ID(oldID),
 				NewRC:           rc_fields.ID(newID),
@@ -441,19 +441,19 @@ LOOP:
 		select {
 		case <-signals:
 			// try to clean up locks on ^C
+			cancel()
 			close(quit)
+
 			// do not exit right away - the session and result channels will be
 			// closed after the quit is requested, ensuring that the locks held
 			// by the farm were released.
 			r.logger.NoFields().Errorln("Got signal, exiting")
 		case <-sessions:
 			r.logger.NoFields().Fatalln("Lost session")
-		case res := <-result:
+		case <-result:
 			// done, either due to ^C (already printed message above) or
 			// clean finish
-			if res {
-				r.logger.NoFields().Infoln("Done")
-			}
+			r.logger.NoFields().Infoln("Done")
 			break LOOP
 		}
 	}

--- a/pkg/roll/update_test.go
+++ b/pkg/roll/update_test.go
@@ -905,27 +905,34 @@ func TestRollLoopTypicalCase(t *testing.T) {
 	assertRCUpdates(t, oldRCCh, 2, "old RC")
 	assertRCUpdates(t, newRCCh, 1, "new RC")
 
-	transferNode("node1", manifest, upd)
+	err := transferNode("node1", manifest, upd)
+	if err != nil {
+		t.Fatal(err)
+	}
 	healths <- checks
 
 	assertRCUpdates(t, oldRCCh, 1, "old RC")
 	assertRCUpdates(t, newRCCh, 2, "new RC")
 
-	transferNode("node2", manifest, upd)
+	err = transferNode("node2", manifest, upd)
+	if err != nil {
+		t.Fatal(err)
+	}
 	healths <- checks
 
 	assertRCUpdates(t, oldRCCh, 0, "old RC")
 	assertRCUpdates(t, newRCCh, 3, "new RC")
 
-	transferNode("node3", manifest, upd)
+	err = transferNode("node3", manifest, upd)
+	if err != nil {
+		t.Fatal(err)
+	}
 	healths <- checks
 
 	assertRollLoopResult(t, rollLoopResult, true)
 
 	cancel()
 	wg.Wait()
-
-	fmt.Println("WE HERE")
 }
 
 func failIfRCDesireChanges(t *testing.T, rcCh <-chan rc_fields.RC, expected int) {
@@ -968,19 +975,28 @@ func TestRollLoopMigrateFromZero(t *testing.T) {
 	assertRCUpdates(t, newRCCh, 1, "new RC")
 
 	checks["node1"] = health.Result{Status: health.Passing}
-	transferNode("node1", manifest, upd)
+	err := transferNode("node1", manifest, upd)
+	if err != nil {
+		t.Fatal(err)
+	}
 	healths <- checks
 
 	assertRCUpdates(t, newRCCh, 2, "new RC")
 
 	checks["node2"] = health.Result{Status: health.Passing}
-	transferNode("node2", manifest, upd)
+	err = transferNode("node2", manifest, upd)
+	if err != nil {
+		t.Fatal(err)
+	}
 	healths <- checks
 
 	assertRCUpdates(t, newRCCh, 3, "new RC")
 
 	checks["node3"] = health.Result{Status: health.Passing}
-	transferNode("node3", manifest, upd)
+	err = transferNode("node3", manifest, upd)
+	if err != nil {
+		t.Fatal(err)
+	}
 	healths <- checks
 
 	assertRollLoopResult(t, rollLoopResult, true)
@@ -1029,7 +1045,10 @@ func TestRollLoopStallsIfUnhealthy(t *testing.T) {
 	assertRCUpdates(t, oldRCCh, 2, "old RC")
 	assertRCUpdates(t, newRCCh, 1, "new RC")
 
-	transferNode("node1", manifest, upd)
+	err := transferNode("node1", manifest, upd)
+	if err != nil {
+		t.Fatal(err)
+	}
 	checks["node1"] = health.Result{Status: health.Critical}
 	go failIfRCDesireChanges(t, oldRCCh, 2)
 	go failIfRCDesireChanges(t, newRCCh, 1)

--- a/pkg/roll/update_test.go
+++ b/pkg/roll/update_test.go
@@ -848,7 +848,7 @@ func transferNode(node types.NodeName, manifest manifest.Manifest, upd update) e
 func assertRCUpdates(t *testing.T, rcCh <-chan rc_fields.RC, expect int, desc string) {
 	rc := <-rcCh
 	if rc.ReplicasDesired != expect {
-		t.Errorf("expected replicas desired count to be %d but was %d", expect, rc.ReplicasDesired)
+		t.Fatalf("expected replicas desired count to be %d but was %d", expect, rc.ReplicasDesired)
 	}
 }
 


### PR DESCRIPTION
An UpdateFactory was required to return an Update interface which has a
'Run() bool' function, however the code that calls it was not looking at
the return value. This commit removes the return value from the
interface and fixes the places that return it to not do so