### PR TITLE
node transfers: only write label for new node if it was locked

### DIFF
--- a/pkg/rc/auditing_transaction.go
+++ b/pkg/rc/auditing_transaction.go
@@ -28,7 +28,7 @@ func (rc *replicationController) newAuditingTransaction(
 	ctx context.Context,
 	rcFields fields.RC,
 	startingNodes []types.NodeName,
-) (*auditingTransaction, func()) {
+) (*auditingTransaction, context.CancelFunc) {
 	annotatedContext := context.WithValue(ctx, scheduledNodesKey{}, startingNodes)
 	ctx, cancelFunc := transaction.New(annotatedContext)
 

--- a/pkg/rc/replication_controller.go
+++ b/pkg/rc/replication_controller.go
@@ -521,6 +521,10 @@ func (rc *replicationController) removePods(rcFields fields.RC, current types.Po
 }
 
 func (rc *replicationController) ensureConsistency(rcFields fields.RC, current []types.NodeName, eligible []types.NodeName) error {
+	if rcFields.Disabled {
+		return nil
+	}
+
 	manifest := rcFields.Manifest
 
 	eligibleCurrent := types.NewNodeSet(current...).Intersection(types.NewNodeSet(eligible...)).ListNodes()

--- a/pkg/roll/update_test.go
+++ b/pkg/roll/update_test.go
@@ -940,11 +940,9 @@ func TestRollLoopTypicalCase(t *testing.T) {
 		"node2": {Status: health.Passing},
 		"node3": {Status: health.Passing},
 	}
-	healths <- checks
 
 	assertRCUpdates(t, oldRCCh, 3, "old RC")
 	assertRCUpdates(t, newRCCh, 0, "new RC")
-
 	healths <- checks
 
 	assertRCUpdates(t, oldRCCh, 2, "old RC")
@@ -954,6 +952,7 @@ func TestRollLoopTypicalCase(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	healths <- checks
 
 	assertRCUpdates(t, oldRCCh, 1, "old RC")
@@ -963,6 +962,7 @@ func TestRollLoopTypicalCase(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	healths <- checks
 
 	assertRCUpdates(t, oldRCCh, 0, "old RC")
@@ -972,6 +972,7 @@ func TestRollLoopTypicalCase(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	healths <- checks
 
 	assertRollLoopResult(t, rollLoopResult, true)
@@ -1011,13 +1012,14 @@ func TestRollLoopMigrateFromZero(t *testing.T) {
 	}()
 
 	checks := map[types.NodeName]health.Result{}
-	healths <- checks
 
 	assertRCUpdates(t, newRCCh, 0, "new RC")
 
 	healths <- checks
 
 	assertRCUpdates(t, newRCCh, 1, "new RC")
+
+	healths <- checks
 
 	checks["node1"] = health.Result{Status: health.Passing}
 	err := transferNode("node1", manifest, upd)


### PR DESCRIPTION
Background: the RC handler routine is expected to kick off a "node
transfer" if the scheduler tells it that one of its "current" nodes are
not eligible to run the pod anymore. This is complex to get right
because there might be 2 RCs that share the same resources (nodes) from
the scheduler when a rolling update is in progress.

What should happen when a node is ineligible is that the RC will request
a new node from the scheduler to replace it, from then on we want one of
the RCs to schedule the pod on that node, but we don't really care which
one during a deploy situation. As a result, an RC scheduling a node
transfer will attempt to schedule the new node using a lock and then
later clean up that lock when the node transfer is complete.

However, if the lock operation fails because the node is already
scheduled, we assume that another RC already scheduled it in a race, and
we want the node transfer to continue without errors. Therefore, when
the node transfer is complete (determined by the new pod being healthy),
we want the RC to only unlock the intent key if it initially scheduled
it in the first place.

This commit fixes a bug where even if the intent key is not locked by
this RC, we still write a label at the end as if it was. This means that
the RC that actually scheduled the pod will have its label overwritten
inappropriately