### PR TITLE
Add rebuild reality logic to p2-preparer setup

### DIFF
--- a/bin/p2-preparer/main.go
+++ b/bin/p2-preparer/main.go
@@ -79,6 +79,12 @@ func main() {
 	if err != nil {
 		logger.WithError(err).Fatalln("Could not do initial hook installation")
 	}
+
+	err = prep.BuildRealityAtLaunch()
+	if err != nil {
+		logger.WithError(err).Fatalf("Could not do initial build reality at launch: %s", err)
+	}
+
 	go prep.WatchForPodManifestsForNode(quitMainUpdate)
 
 	if prep.PodProcessReporter != nil {

--- a/pkg/pods/factory.go
+++ b/pkg/pods/factory.go
@@ -3,7 +3,6 @@ package pods
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/square/p2/pkg/logging"
@@ -142,12 +141,14 @@ func PodFromPodHomeWithReqFile(node types.NodeName, home string, requireFile str
 	// Check if the pod home is namespaced by a UUID by splitting on a hyphen and
 	// checking the last part. If it parses as a UUID, pass it to newPodWithHome.
 	// Otherwise, pass a nil uniqueKey
-	homeParts := strings.Split(filepath.Base(home), "-")
+	podID := filepath.Base(home)
 
 	var uniqueKey types.PodUniqueKey
-	podUUID := uuid.Parse(homeParts[len(homeParts)-1])
-	if podUUID != nil {
-		uniqueKey = types.PodUniqueKey(podUUID.String())
+	if len(podID) > types.PodUUIDLength {
+		podUUID := uuid.Parse(podID[len(podID)-types.PodUUIDLength:])
+		if podUUID != nil {
+			uniqueKey = types.PodUniqueKey(podUUID.String())
+		}
 	}
 
 	temp := Pod{

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -10,6 +10,10 @@ import (
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
+const (
+	PodUUIDLength int = 36
+)
+
 type NodeName string
 
 // Refers to the id: key in a pod manifest, i.e. the name of the application


### PR DESCRIPTION
  - if a node is missing the reality tree on startup, apply rebuild reality logic to prevent orphaned pods
  - an orphaned pod will have its data still in /data/apps but not exist in intent
  - also fix a bug in pkg/pods/factory.go PodFromPodHomeWithReqFile where it wasn't parsing the uuid of pods correctly