### PR TITLE
Add rebuild reality logic to p2-preparer setup

### DIFF
--- a/bin/p2-preparer/main.go
+++ b/bin/p2-preparer/main.go
@@ -79,6 +79,12 @@ func main() {
 	if err != nil {
 		logger.WithError(err).Fatalln("Could not do initial hook installation")
 	}
+
+	err = prep.BuildRealityAtLaunch()
+	if err != nil {
+		logger.WithError(err).Fatalf("Could not do initial build reality at launch: %s", err)
+	}
+
 	go prep.WatchForPodManifestsForNode(quitMainUpdate)
 
 	if prep.PodProcessReporter != nil {

--- a/pkg/pods/factory.go
+++ b/pkg/pods/factory.go
@@ -3,7 +3,6 @@ package pods
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/square/p2/pkg/logging"
@@ -14,7 +13,6 @@ import (
 	"github.com/square/p2/pkg/util"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/pborman/uuid"
 )
 
 const DefaultPath = "/data/pods"
@@ -139,13 +137,10 @@ func PodFromPodHome(node types.NodeName, home string) (*Pod, error) {
 }
 
 func PodFromPodHomeWithReqFile(node types.NodeName, home string, requireFile string) (*Pod, error) {
-	// Check if the pod home is namespaced by a UUID by splitting on a hyphen and
-	// checking the last part. If it parses as a UUID, pass it to newPodWithHome.
-	// Otherwise, pass a nil uniqueKey
-	homeParts := strings.Split(filepath.Base(home), "-")
-
+	// Check if the pod home is namespaced by a UUID and pass it to newPodWithHome
+	// uniqueKey can be nil if pod home is not namespaced by a UUID
 	var uniqueKey types.PodUniqueKey
-	podUUID := uuid.Parse(homeParts[len(homeParts)-1])
+	podUUID := types.HomeToPodUUID(home)
 	if podUUID != nil {
 		uniqueKey = types.PodUniqueKey(podUUID.String())
 	}

--- a/pkg/preparer/testdata/test_current_manifest.yaml
+++ b/pkg/preparer/testdata/test_current_manifest.yaml
@@ -1,0 +1,8 @@
+id: some-app
+launchables:
+  some-app:
+    launchable_type: hoist
+    version:
+      id: asdf
+      tags:
+        directory: deployable

--- a/pkg/store/consul/podstore/consul_store.go
+++ b/pkg/store/consul/podstore/consul_store.go
@@ -225,7 +225,7 @@ func (c *consulStore) WriteRealityIndex(ctx context.Context, podKey types.PodUni
 
 	realityIndexPath := computeRealityIndexPath(podKey, node)
 
-	// Now, write the secondary index to /intent/<node>/<key>
+	// Now, write the secondary index to /reality/<node>/<key>
 	index := PodIndex{
 		PodKey: podKey,
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -10,6 +10,18 @@ import (
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
+const (
+	PodUUIDLength int = 36
+)
+
+func HomeToPodUUID(home string) uuid.UUID {
+	var podUUID uuid.UUID
+	if len(home) > PodUUIDLength {
+		podUUID = uuid.Parse(home[len(home)-PodUUIDLength:])
+	}
+	return podUUID
+}
+
 type NodeName string
 
 // Refers to the id: key in a pod manifest, i.e. the name of the application


### PR DESCRIPTION
  - if a node is missing the reality tree on startup, apply rebuild reality logic to prevent orphaned pods
  - an orphaned pod will have its data still in /data/apps but not exist in intent
  - also fix a bug in pkg/pods/factory.go PodFromPodHomeWithReqFile where it wasn't parsing the uuid of pods correctly