### PR TITLE
p2-rm: allow flag to check for missing RC

### DIFF
--- a/bin/p2-rm/main.go
+++ b/bin/p2-rm/main.go
@@ -23,6 +23,7 @@ var (
 	nodeName     = kingpin.Flag("node", "The node to unschedule the pod from. Uses the hostname by default. Only applies to \"legacy\" pods.").String()
 	podUniqueKey = kingpin.Flag("pod-unique-key", "The pod unique key to unschedule. Only applies to \"uuid\" pods. Cannot be used with --node").Short('k').String()
 	deallocation = kingpin.Flag("deallocate", "Specifies that we are deallocating this pod on this node. Using this switch will mutate the desired_replicas value on a managing RC, if one exists.").Bool()
+	removeOrphan = kingpin.Flag("remove-orphan", "Remove the pod even if it is labeled with a replication controller ID, but only if no RC with that ID exists").Bool()
 )
 
 func main() {
@@ -63,7 +64,7 @@ func handlePodRemoval(consulClient consulutil.ConsulClient, labeler Labeler) err
 		rm = NewLegacyP2RM(consulClient, types.PodID(*podName), types.NodeName(*nodeName), labeler)
 	}
 
-	podIsManagedByRC, rcID, err := rm.checkForManagingReplicationController()
+	podIsManagedByRC, rcID, err := rm.checkForManagingReplicationController(*removeOrphan)
 	if err != nil {
 		return err
 	}

--- a/pkg/hoist/hoist_launchable_test.go
+++ b/pkg/hoist/hoist_launchable_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/square/p2/pkg/launch"
@@ -234,9 +235,11 @@ func TestDisable(t *testing.T) {
 	disableOutput, err := hl.disable()
 	Assert(t).IsNil(err, "Got an unexpected error when calling disable on the test hoist launchable")
 
-	expectedDisableOutput := "disable invoked\n"
+	expectedDisableOutput := "disable invoked"
 
-	Assert(t).AreEqual(disableOutput, expectedDisableOutput, "Did not get expected output from test disable script")
+	if !strings.Contains(disableOutput, "disable invoked") {
+		t.Fatalf("expected to see %q in the disable output. Full output:\n%s", expectedDisableOutput, disableOutput)
+	}
 }
 
 func TestFailingDisable(t *testing.T) {
@@ -247,9 +250,11 @@ func TestFailingDisable(t *testing.T) {
 	disableOutput, err := hl.disable()
 	Assert(t).IsNotNil(err, "Expected disable to fail for this test, but it didn't")
 
-	expectedDisableOutput := "Error: this script failed\n"
+	expectedDisableOutput := "Error: this script failed"
 
-	Assert(t).AreEqual(disableOutput, expectedDisableOutput, "Did not get expected output from test disable script")
+	if !strings.Contains(disableOutput, expectedDisableOutput) {
+		t.Fatalf("expected to see %q in the disable output. Full output:\n%s", expectedDisableOutput, disableOutput)
+	}
 }
 
 // providing a disable script is optional, make sure we don't error
@@ -274,9 +279,10 @@ func TestEnable(t *testing.T) {
 	enableOutput, err := hl.enable()
 	Assert(t).IsNil(err, "Got an unexpected error when calling enable on the test hoist launchable")
 
-	expectedEnableOutput := "enable invoked\n"
-
-	Assert(t).AreEqual(enableOutput, expectedEnableOutput, "Did not get expected output from test enable script")
+	expectedEnableOutput := "enable invoked"
+	if !strings.Contains(enableOutput, expectedEnableOutput) {
+		t.Fatalf("expected to see %q in the enable output. Full output:\n%s", expectedEnableOutput, enableOutput)
+	}
 }
 
 func TestNoEnableForUUIDPods(t *testing.T) {
@@ -299,9 +305,11 @@ func TestFailingEnable(t *testing.T) {
 	enableOutput, err := hl.enable()
 	Assert(t).IsNotNil(err, "Expected enable to fail for this test, but it didn't")
 
-	expectedEnableOutput := "Error: this script failed\n"
+	expectedEnableOutput := "Error: this script failed"
 
-	Assert(t).AreEqual(enableOutput, expectedEnableOutput, "Did not get expected output from test enable script")
+	if !strings.Contains(enableOutput, expectedEnableOutput) {
+		t.Fatalf("expected to see %q in the enable output. Full output:\n%s", expectedEnableOutput, enableOutput)
+	}
 }
 
 // providing an enable script is optional, make sure we don't error


### PR DESCRIPTION
Typically p2-rm assumes that a pod either does not have a
replication_contoller_id label (and thus is safe to unschedule) or it
does have one, and decrementing the replica count on the managing RC is
the proper course of action.

However in practice a pod will occasionally end up in a state where it
has the replication_controller_id label but no RC with that ID exists,
which means that we should use the manual method of removing the pod.
This commit adds a --remove-orphan flag which will make p2-rm do an
extra check that the replication controller ID returns actually exists

Additionally this commit makes p2-rm remove the labels for any pods it
deletes