### PR TITLE
daemon set farm: update replication timeout

### DIFF
--- a/pkg/ds/daemon_set_test.go
+++ b/pkg/ds/daemon_set_test.go
@@ -620,6 +620,9 @@ func (n nullReplication) InProgress() bool {
 func (n nullReplication) SetManifest(manifest.Manifest) {
 	panic("SetManifest() not implemented on nullReplication")
 }
+func (n nullReplication) SetTimeout(time.Duration) {
+	panic("SetTimeout() not implemented on nullReplication")
+}
 
 func TestWriteNewestStatus(t *testing.T) {
 	type writeStatusTestCase struct {


### PR DESCRIPTION
The daemon set runner responds to some changes to daemon sets such as
the manifest, but it did not until now respond to changes to the
timeout. This is something that someone might want to take effect before
the daemon set server is restarted.