### PR TITLE
Add missing log fields to hook messages

### DIFF
--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -110,9 +110,9 @@ func TestHookRunWithTimeout(t *testing.T) {
 	defer os.Remove(tmpFile)
 
 	logger := logging.TestLogger()
-	hook := NewHookExecContext(tmpFile, "timeout-test-hook", timeout, HookExecutionEnvironment{}, &logger)
+	hook := NewHookExecContext(tmpFile, "timeout-test-hook", timeout, HookExecutionEnvironment{}, logger)
 
-	toErr := hook.RunWithTimeout()
+	toErr := hook.RunWithTimeout(logger)
 	if _, ok := toErr.(ErrHookTimeout); !ok {
 		// we either had no error or a different error
 		t.Errorf("timeout did not throw a HookTimeoutError: timeout: %#v / sleep: %#v / err: %#v", timeout, sleep, toErr)

--- a/pkg/hooks/types.go
+++ b/pkg/hooks/types.go
@@ -133,11 +133,11 @@ type HookExecContext struct {
 	Name        string // human-readable name of Hook
 	Timeout     time.Duration
 	env         HookExecutionEnvironment // This will be used as the set of UNIX environment variables for the hook's execution
-	logger      *logging.Logger
+	logger      logging.Logger
 	auditLogger AuditLogger
 }
 
-func NewHookExecContext(path string, name string, timeout time.Duration, env HookExecutionEnvironment, logger *logging.Logger) *HookExecContext {
+func NewHookExecContext(path string, name string, timeout time.Duration, env HookExecutionEnvironment, logger logging.Logger) *HookExecContext {
 	return &HookExecContext{
 		Path:    path,
 		Name:    name,


### PR DESCRIPTION
Most preparer log messages have the associated "pod" key using the
logrus logger, however inadvertently when executing hooks a created
sublogger was not being passed through, which caused some fields to be
dropped. For example, when a hook fails there's no "pod=" key to tell
the user which pod the hook failed for.

This commit plumbs the sublogger through to every place in the hook
runner that needs it