### PR TITLE
Add ResourceLimitsStanza getter to manifest

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -73,6 +73,7 @@ type Manifest interface {
 	PlatformConfigFileName() (string, error)
 	WritePlatformConfig(out io.Writer) error
 	GetLaunchableStanzas() map[launch.LaunchableID]launch.LaunchableStanza
+	GetResourceLimitsStanza() ResourceLimitsStanza
 	GetConfig() map[interface{}]interface{}
 	SHA() (string, error)
 	GetStatusHTTP() bool
@@ -223,6 +224,10 @@ func (manifest *manifest) SetStatusLocalhostOnly(localhostOnly bool) {
 
 func (manifest *manifest) SetResourceLimits(limits ResourceLimitsStanza) {
 	manifest.ResourceLimits = limits
+}
+
+func (manifest *manifest) GetResourceLimitsStanza() ResourceLimitsStanza {
+	return manifest.ResourceLimits
 }
 
 func (manifest *manifest) RunAsUser() string {


### PR DESCRIPTION
I previously merged this PR [](https://github.com/square/p2/pull/994) that added a setter to the manifest builder to set pod level cgroup resource limits. This PR adds a getter to the manifest to return that created stanza. It will be a nice function to have to interact with those resource limits.