### PR TITLE
Pod Cgroups

### DIFF
--- a/bin/p2-cgroup-info/main.go
+++ b/bin/p2-cgroup-info/main.go
@@ -152,7 +152,7 @@ func main() {
 
 	// P2 only uses the "memory" and "cpu" resource controllers, and it creates an
 	// identical hierarchy in either. Just scan "cpu".
-	sys, err := cgroups.Find()
+	sys, err := cgroups.DefaultSubsystemer.Find()
 	if err != nil {
 		logger.Fatalf("error finding cgroups: %v", err)
 	}

--- a/integration/common-provision.sh
+++ b/integration/common-provision.sh
@@ -49,3 +49,6 @@ sudo yum -y --nogpgcheck localinstall $GOPATH/src/github.com/square/p2/integrati
 sudo yum -y install unzip
 sudo mkdir -p /etc/servicebuilder.d
 sudo mkdir -p /var/service-stage
+
+# symlink cgroup from modern /sys/fs/cgroup to legacy /cgroup
+sudo ln -sf /sys/fs/cgroup /cgroup

--- a/integration/travis.sh
+++ b/integration/travis.sh
@@ -36,4 +36,7 @@ CERTPATH=/var/tmp/certs
 mkdir -p $CERTPATH
 openssl req -x509 -newkey rsa:2048 -keyout $CERTPATH/key.pem -out $CERTPATH/cert.pem -nodes -days 300 -subj "$(echo -n "$subj" | tr "\n" "/")"
 
+# symlink cgroup from modern /sys/fs/cgroup to legacy /cgroup
+sudo ln -sf /sys/fs/cgroup /cgroup
+
 sudo env PATH=$PATH GOPATH=$GOPATH GOROOT=$GOROOT go run integration/single-node-slug-deploy/check.go --no-add-user

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -1,14 +1,13 @@
 package cgroups
 
 import (
-	"bufio"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
 )
 
@@ -16,11 +15,13 @@ import (
 type Subsystems struct {
 	CPU    string
 	Memory string
+	Prefix string
 }
 
-var Default Subsystems = Subsystems{
+var DefaultSubsystems = Subsystems{
 	CPU:    "/cgroup/cpu",
 	Memory: "/cgroup/memory",
+	Prefix: "/cgroup",
 }
 
 type UnsupportedError string
@@ -31,50 +32,16 @@ func (err UnsupportedError) Error() string {
 	return fmt.Sprintf("subsystem %q is not available on this system", string(err))
 }
 
-// Find retrieves the mount points for all cgroup subsystems on the host. The
-// result of this operation should be cached if possible.
-func Find() (Subsystems, error) {
-	// For details about how this file is structured, refer to `man proc` or
-	// https://www.kernel.org/doc/Documentation/filesystems/proc.txt section 3.5
-	mountInfo, err := os.Open("/proc/self/mountinfo")
-	if err != nil {
-		return Subsystems{}, err
-	}
-	defer mountInfo.Close()
+type CgroupID string
 
-	var ret Subsystems
-	scanner := bufio.NewScanner(mountInfo)
-	for scanner.Scan() {
-		lineSegs := strings.Fields(scanner.Text())
-		nSegs := len(lineSegs)
-		if nSegs < 10 || lineSegs[nSegs-4] != "-" {
-			return Subsystems{}, fmt.Errorf("mountinfo: unrecognized format")
-		}
-		mountPoint := lineSegs[4]
-		fsType := lineSegs[nSegs-3]
-		superOptions := strings.Split(lineSegs[nSegs-1], ",")
-
-		if fsType != "cgroup" {
-			// filesystem type is not "cgroup", skip
-			continue
-		}
-
-		for _, opt := range superOptions {
-			switch opt {
-			case "cpu":
-				ret.CPU = mountPoint
-			case "memory":
-				ret.Memory = mountPoint
-			}
-		}
-	}
-
-	return ret, nil
+func (c *CgroupID) String() string {
+	return string(*c)
 }
 
+// SetCPU will set a number of CPU limits in the cgroup specified by the argument
 // set the number of logical CPUs in a given cgroup, 0 to unrestrict
 // https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt
-func (subsys Subsystems) SetCPU(name string, cpus int) error {
+func (subsys Subsystems) SetCPU(name CgroupID, cpus int) error {
 	if subsys.CPU == "" {
 		return UnsupportedError("cpu")
 	}
@@ -88,13 +55,13 @@ func (subsys Subsystems) SetCPU(name string, cpus int) error {
 		quota = -1
 	}
 
-	err := os.MkdirAll(filepath.Join(subsys.CPU, name), 0755)
+	err := os.MkdirAll(filepath.Join(subsys.CPU, name.String()), 0755)
 	if err != nil && !os.IsExist(err) {
 		return err
 	}
 
 	_, err = util.WriteIfChanged(
-		filepath.Join(subsys.CPU, name, "cpu.cfs_period_us"),
+		filepath.Join(subsys.CPU, name.String(), "cpu.cfs_period_us"),
 		[]byte(strconv.Itoa(period)+"\n"),
 		0,
 	)
@@ -103,7 +70,7 @@ func (subsys Subsystems) SetCPU(name string, cpus int) error {
 	}
 
 	_, err = util.WriteIfChanged(
-		filepath.Join(subsys.CPU, name, "cpu.cfs_quota_us"),
+		filepath.Join(subsys.CPU, name.String(), "cpu.cfs_quota_us"),
 		[]byte(strconv.Itoa(quota)+"\n"),
 		0,
 	)
@@ -114,9 +81,10 @@ func (subsys Subsystems) SetCPU(name string, cpus int) error {
 	return nil
 }
 
+// SetMemory will set several memory limits in the cgroup specified in the argument
 // set the memory limit on a cgroup, 0 to unrestrict
 // https://www.kernel.org/doc/Documentation/cgroups/memory.txt
-func (subsys Subsystems) SetMemory(name string, bytes int) error {
+func (subsys Subsystems) SetMemory(name CgroupID, bytes int) error {
 	if subsys.Memory == "" {
 		return UnsupportedError("memory")
 	}
@@ -132,29 +100,29 @@ func (subsys Subsystems) SetMemory(name string, bytes int) error {
 		hardLimit = -1
 	}
 
-	err := os.MkdirAll(filepath.Join(subsys.Memory, name), 0755)
+	err := os.MkdirAll(filepath.Join(subsys.Memory, name.String()), 0755)
 	if err != nil && !os.IsExist(err) {
 		return err
 	}
 
 	// the hard memory limit must be set BEFORE the mem+swap limit
 	// so we must clear the swap limit at the start
-	err = ioutil.WriteFile(filepath.Join(subsys.Memory, name, "memory.memsw.limit_in_bytes"), []byte("-1\n"), 0)
+	err = ioutil.WriteFile(filepath.Join(subsys.Memory, name.String(), "memory.memsw.limit_in_bytes"), []byte("-1\n"), 0600)
 	if err != nil {
 		return err
 	}
 
-	_, err = util.WriteIfChanged(filepath.Join(subsys.Memory, name, "memory.soft_limit_in_bytes"), []byte(strconv.Itoa(softLimit)+"\n"), 0)
+	_, err = util.WriteIfChanged(filepath.Join(subsys.Memory, name.String(), "memory.soft_limit_in_bytes"), []byte(strconv.Itoa(softLimit)+"\n"), 0600)
 	if err != nil {
 		return err
 	}
 
-	_, err = util.WriteIfChanged(filepath.Join(subsys.Memory, name, "memory.limit_in_bytes"), []byte(strconv.Itoa(hardLimit)+"\n"), 0)
+	_, err = util.WriteIfChanged(filepath.Join(subsys.Memory, name.String(), "memory.limit_in_bytes"), []byte(strconv.Itoa(hardLimit)+"\n"), 0600)
 	if err != nil {
 		return err
 	}
 
-	_, err = util.WriteIfChanged(filepath.Join(subsys.Memory, name, "memory.memsw.limit_in_bytes"), []byte(strconv.Itoa(hardLimit)+"\n"), 0)
+	_, err = util.WriteIfChanged(filepath.Join(subsys.Memory, name.String(), "memory.memsw.limit_in_bytes"), []byte(strconv.Itoa(hardLimit)+"\n"), 0600)
 	if err != nil {
 		return err
 	}
@@ -178,6 +146,10 @@ func (subsys Subsystems) AddPID(name string, pid int) error {
 	return appendIntToFile(filepath.Join(subsys.CPU, name, "cgroup.procs"), pid)
 }
 
+func (subsys Subsystems) GetPrefix() string {
+	return subsys.Prefix
+}
+
 func appendIntToFile(filename string, data int) error {
 	fd, err := os.OpenFile(filename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
 	if err != nil {
@@ -186,4 +158,75 @@ func appendIntToFile(filename string, data int) error {
 	defer fd.Close()
 	_, err = fd.WriteString(strconv.Itoa(data))
 	return err
+}
+
+// Subsystemer is anything that can find a set of Subsystems
+type Subsystemer interface {
+	Find() (Subsystems, error)
+}
+
+func ensurePrefix(s Subsystemer) error {
+	ss, err := s.Find()
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(ss.Prefix, 0755)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+	err = os.MkdirAll(ss.Prefix, 0755)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	return nil
+}
+
+// CreatePodCgroup will set cgroup parameters for the specified pod with podID
+// on hostname. In order for nested cgroups to work correctly, the path used here
+// must match the path used in pkg/servicebuilder
+func CreatePodCgroup(podID types.PodID, hostname types.NodeName, c Config, s Subsystemer) error {
+	ss, err := s.Find()
+	if err != nil {
+		return err
+	}
+
+	cgroupID, err := CgroupIDForPod(s, podID, hostname)
+	if err != nil {
+		return err
+	}
+	err = ss.SetCPU(*cgroupID, c.CPUs)
+	if err != nil {
+		return err
+	}
+	err = ss.SetMemory(*cgroupID, int(c.Memory))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CgroupIDForLaunchable encapsulates the cgroup path for launchable cgroups.
+// launchableID is a string because I am too cowardly to break the import cycle
+// caused by importing `launch` here.
+func CgroupIDForLaunchable(s Subsystemer, podID types.PodID, nodeName types.NodeName, launchableID string) (*CgroupID, error) {
+	ss, err := s.Find()
+	if err != nil {
+		return nil, err
+	}
+	cgID := CgroupID(filepath.Join(ss.GetPrefix(), "p2", nodeName.String(), podID.String(), launchableID))
+	return &cgID, nil
+}
+
+// CgroupIDForPod encapsulates the cgroup path for pod cgroups. This function
+// should match CgroupIDForLaunchable
+func CgroupIDForPod(s Subsystemer, podID types.PodID, nodeName types.NodeName) (*CgroupID, error) {
+	ss, err := s.Find()
+	if err != nil {
+		return nil, err
+	}
+	cgID := CgroupID(filepath.Join(ss.GetPrefix(), "p2", nodeName.String(), podID.String()))
+	return &cgID, nil
 }

--- a/pkg/cgroups/cgroups_test.go
+++ b/pkg/cgroups/cgroups_test.go
@@ -1,0 +1,63 @@
+package cgroups
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/square/p2/pkg/types"
+	"github.com/square/p2/pkg/util/size"
+)
+
+type FakeSubsystemer struct {
+	tmpdir string
+}
+
+func (fs *FakeSubsystemer) Find() (Subsystems, error) {
+	var err error
+	if fs.tmpdir == "" {
+		if fs.createTmpdir(); err != nil {
+			return Subsystems{}, err
+		}
+	}
+
+	if err = os.Chmod(fs.tmpdir, os.ModePerm); err != nil {
+		return Subsystems{}, err
+	}
+	return Subsystems{CPU: filepath.Join(fs.tmpdir, "cpu"), Memory: filepath.Join(fs.tmpdir, "memory")}, nil
+}
+
+// createTmpDir is useful only for tests, it creates the tmpdir
+func (fs *FakeSubsystemer) createTmpdir() error {
+	tmpdir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return err
+	}
+	fs.tmpdir = tmpdir
+	return nil
+}
+
+func TestCreatePodCgroup(t *testing.T) {
+	c := Config{CPUs: 2, Memory: size.ByteCount(1024)}
+	podID := types.PodID("podID")
+	hostname := types.NodeName("abc123.example")
+	fs := &FakeSubsystemer{}
+	if err := CreatePodCgroup(podID, hostname, c, fs); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	expectCgroupFileToContain(t, "2048\n", filepath.Join(fs.tmpdir, "memory", "p2", hostname.String(), podID.String(), "memory.limit_in_bytes"))
+	expectCgroupFileToContain(t, "2048\n", filepath.Join(fs.tmpdir, "memory", "p2", hostname.String(), podID.String(), "memory.memsw.limit_in_bytes"))
+	expectCgroupFileToContain(t, "1024\n", filepath.Join(fs.tmpdir, "memory", "p2", hostname.String(), podID.String(), "memory.soft_limit_in_bytes"))
+}
+
+func expectCgroupFileToContain(t *testing.T, s string, file string) {
+	actual, err := ioutil.ReadFile(filepath.Join(file))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if string(actual) != s { // We set the hard limit to 2x the request
+		t.Errorf("expected %s, but got: %s", s, string(actual))
+	}
+}

--- a/pkg/cgroups/cgroups_test.go
+++ b/pkg/cgroups/cgroups_test.go
@@ -38,11 +38,16 @@ func (fs *FakeSubsystemer) createTmpdir() error {
 	return nil
 }
 
+func (fs *FakeSubsystemer) cleanupTmpdir() error {
+	return os.RemoveAll(fs.tmpdir)
+}
+
 func TestCreatePodCgroup(t *testing.T) {
 	c := Config{CPUs: 2, Memory: size.ByteCount(1024)}
 	podID := types.PodID("podID")
 	hostname := types.NodeName("abc123.example")
 	fs := &FakeSubsystemer{}
+	defer fs.cleanupTmpdir()
 	if err := CreatePodCgroup(podID, hostname, c, fs); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -57,7 +62,7 @@ func expectCgroupFileToContain(t *testing.T, s string, file string) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if string(actual) != s { // We set the hard limit to 2x the request
+	if string(actual) != s {
 		t.Errorf("expected %s, but got: %s", s, string(actual))
 	}
 }

--- a/pkg/cgroups/config.go
+++ b/pkg/cgroups/config.go
@@ -4,8 +4,9 @@ import (
 	"github.com/square/p2/pkg/util/size"
 )
 
+// Config combines an ID and subsystem limits
 type Config struct {
-	Name   string         `yaml:"-"`                // The name of the cgroup in cgroupfs
+	Name   CgroupID       `yaml:"-"`                // The name of the cgroup in cgroupfs
 	CPUs   int            `yaml:"cpus,omitempty"`   // The number of logical CPUs
 	Memory size.ByteCount `yaml:"memory,omitempty"` // The number of bytes of memory
 }

--- a/pkg/cgroups/subsystem.go
+++ b/pkg/cgroups/subsystem.go
@@ -15,6 +15,9 @@ type ProcSubsystemer struct {
 var DefaultSubsystemer = &ProcSubsystemer{}
 
 func (ps *ProcSubsystemer) Find() (Subsystems, error) {
+	if ps.CachedSubsystems != nil {
+		return *ps.CachedSubsystems, nil
+	}
 	// For details about how this file is structured, refer to `man proc` or
 	// https://www.kernel.org/doc/Documentation/filesystems/proc.txt section 3.5
 	mountInfo, err := os.Open("/proc/self/mountinfo")
@@ -22,9 +25,6 @@ func (ps *ProcSubsystemer) Find() (Subsystems, error) {
 		return Subsystems{}, err
 	}
 	defer mountInfo.Close()
-	if ps.CachedSubsystems != nil {
-		return *ps.CachedSubsystems, nil
-	}
 
 	var ret Subsystems
 	scanner := bufio.NewScanner(mountInfo)

--- a/pkg/cgroups/subsystem.go
+++ b/pkg/cgroups/subsystem.go
@@ -1,0 +1,58 @@
+package cgroups
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ProcSubsystemer returns cgroup mountpoints based on the /proc filesystem
+type ProcSubsystemer struct {
+	CachedSubsystems *Subsystems
+}
+
+var DefaultSubsystemer = &ProcSubsystemer{}
+
+func (ps *ProcSubsystemer) Find() (Subsystems, error) {
+	// For details about how this file is structured, refer to `man proc` or
+	// https://www.kernel.org/doc/Documentation/filesystems/proc.txt section 3.5
+	mountInfo, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
+		return Subsystems{}, err
+	}
+	defer mountInfo.Close()
+	if ps.CachedSubsystems != nil {
+		return *ps.CachedSubsystems, nil
+	}
+
+	var ret Subsystems
+	scanner := bufio.NewScanner(mountInfo)
+	for scanner.Scan() {
+		lineSegs := strings.Fields(scanner.Text())
+		nSegs := len(lineSegs)
+		if nSegs < 10 || lineSegs[nSegs-4] != "-" {
+			return Subsystems{}, fmt.Errorf("mountinfo: unrecognized format")
+		}
+		mountPoint := lineSegs[4]
+		fsType := lineSegs[nSegs-3]
+		superOptions := strings.Split(lineSegs[nSegs-1], ",")
+
+		if fsType != "cgroup" {
+			// filesystem type is not "cgroup", skip
+			continue
+		}
+
+		for _, opt := range superOptions {
+			switch opt {
+			case "cpu":
+				ret.CPU = mountPoint
+			case "memory":
+				ret.Memory = mountPoint
+			}
+		}
+	}
+	ps.CachedSubsystems = &ret
+
+	return ret, nil
+}

--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -17,6 +17,7 @@ import (
 	"github.com/square/p2/pkg/launch"
 	"github.com/square/p2/pkg/p2exec"
 	"github.com/square/p2/pkg/runit"
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/user"
 	"github.com/square/p2/pkg/util"
 )
@@ -36,6 +37,7 @@ type EntryPoints struct {
 type Launchable struct {
 	Id               launch.LaunchableID        // A (pod-wise) unique identifier for this launchable, used to distinguish it from other launchables in the pod
 	Version          launch.LaunchableVersionID // A version identifier
+	PodID            types.PodID                // A (possibly-null) PodID denoting which launchable this belongs to
 	ServiceId        string                     // A (host-wise) unique identifier for this launchable, used when creating runit services
 	RunAs            string                     // The user to assume when launching the executable
 	OwnAs            string                     // The user that owns all the launcable's artifacts
@@ -43,6 +45,7 @@ type Launchable struct {
 	RootDir          string                     // The root directory of the launchable, containing N:N>=1 installs.
 	P2Exec           string                     // Struct that can be used to build a p2-exec invocation with appropriate flags
 	ExecNoLimit      bool                       // If set, execute with the -n (--no-limit) argument to p2-exec
+	PodCgroupConfig  cgroups.Config             // PodCgroupConfig
 	CgroupConfig     cgroups.Config             // Cgroup parameters to use with p2-exec
 	CgroupConfigName string                     // The string in PLATFORM_CONFIG to pass to p2-exec
 	CgroupName       string                     // The name of the cgroup to run this launchable in
@@ -371,6 +374,7 @@ func (hl *Launchable) Executables(
 				ExtraEnv:         map[string]string{launch.EntryPointEnvVar: relativePath},
 				NoLimits:         hl.ExecNoLimit,
 				CgroupConfigName: hl.CgroupConfigName,
+				PodID:            &hl.PodID,
 				CgroupName:       hl.CgroupName,
 				RequireFile:      hl.RequireFile,
 			}

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -14,11 +14,11 @@ import (
 	"os"
 	"path"
 
+	"github.com/square/p2/pkg/cgroups"
 	"github.com/square/p2/pkg/launch"
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/uri"
 	"github.com/square/p2/pkg/util"
-	"github.com/square/p2/pkg/util/size"
 	"golang.org/x/crypto/openpgp/clearsign"
 	"gopkg.in/yaml.v2"
 )
@@ -28,11 +28,6 @@ type StatusStanza struct {
 	Path          string `yaml:"path,omitempty"`
 	Port          int    `yaml:"port,omitempty"`
 	LocalhostOnly bool   `yaml:"localhost_only,omitempty"`
-}
-
-type ResourceLimitsStanza struct {
-	CPUs   int            `yaml:"cpus,omitempty"`
-	Memory size.ByteCount `yaml:"memory,omitempty"`
 }
 
 type Builder interface {
@@ -72,8 +67,10 @@ type Manifest interface {
 	WriteConfig(out io.Writer) error
 	PlatformConfigFileName() (string, error)
 	WritePlatformConfig(out io.Writer) error
+	WriteResourceLimitsConfig(out io.Writer) error
 	GetLaunchableStanzas() map[launch.LaunchableID]launch.LaunchableStanza
-	GetResourceLimitsStanza() ResourceLimitsStanza
+	GetResourceLimits() ResourceLimitsStanza
+	ResourceLimitsConfigFileName() (string, error)
 	GetConfig() map[interface{}]interface{}
 	SHA() (string, error)
 	GetStatusHTTP() bool
@@ -89,6 +86,10 @@ type Manifest interface {
 
 // assert manifest implements Manifest and UnsignedManifest
 var _ Manifest = &manifest{}
+
+type ResourceLimitsStanza struct {
+	Cgroup *cgroups.Config `yaml:"cgroup,omitempty"`
+}
 
 type manifest struct {
 	Id                types.PodID                                     `yaml:"id"` // public for yaml marshaling access. Use ID() instead.
@@ -135,6 +136,10 @@ func (manifest *manifest) GetLaunchableStanzas() map[launch.LaunchableID]launch.
 
 func (manifest *manifest) SetLaunchables(launchableStanzas map[launch.LaunchableID]launch.LaunchableStanza) {
 	manifest.LaunchableStanzas = launchableStanzas
+}
+
+func (manifest *manifest) GetResourceLimits() ResourceLimitsStanza {
+	return manifest.ResourceLimits
 }
 
 func (manifest *manifest) GetConfig() map[interface{}]interface{} {
@@ -224,10 +229,6 @@ func (manifest *manifest) SetStatusLocalhostOnly(localhostOnly bool) {
 
 func (manifest *manifest) SetResourceLimits(limits ResourceLimitsStanza) {
 	manifest.ResourceLimits = limits
-}
-
-func (manifest *manifest) GetResourceLimitsStanza() ResourceLimitsStanza {
-	return manifest.ResourceLimits
 }
 
 func (manifest *manifest) RunAsUser() string {
@@ -366,12 +367,7 @@ func (manifest *manifest) WriteConfig(out io.Writer) error {
 }
 
 func (manifest *manifest) WritePlatformConfig(out io.Writer) error {
-	platConf := make(map[launch.LaunchableID]interface{})
-	for launchableID, stanza := range manifest.LaunchableStanzas {
-		platConf[launchableID] = map[launch.LaunchableID]interface{}{
-			"cgroup": stanza.CgroupConfig,
-		}
-	}
+	platConf := manifest.launchableResourceLimits()
 
 	bytes, err := yaml.Marshal(platConf)
 	if err != nil {
@@ -380,6 +376,41 @@ func (manifest *manifest) WritePlatformConfig(out io.Writer) error {
 	_, err = out.Write(bytes)
 	if err != nil {
 		return util.Errorf("Could not write config for %s: %s", manifest.ID(), err)
+	}
+	return nil
+}
+
+type ResourceLimitsConfigFileSchema struct {
+	PodLimits        map[types.PodID]cgroups.Config      `yaml:"pod"`
+	LaunchableLimits map[launch.LaunchableID]interface{} `yaml:"launchables"`
+}
+
+func (manifest *manifest) launchableResourceLimits() map[launch.LaunchableID]interface{} {
+	limits := make(map[launch.LaunchableID]interface{})
+	for launchableID, stanza := range manifest.LaunchableStanzas {
+		limits[launchableID] = map[launch.LaunchableID]interface{}{
+			"cgroup": stanza.CgroupConfig,
+		}
+	}
+	return limits
+}
+
+func (manifest *manifest) WriteResourceLimitsConfig(out io.Writer) error {
+	if manifest.ResourceLimits.Cgroup == nil { // ResourceLimits are optional for now, this is not an error
+		return nil
+	}
+	resourceLimitsConfigFile := ResourceLimitsConfigFileSchema{
+		PodLimits:        map[types.PodID]cgroups.Config{manifest.ID(): *manifest.ResourceLimits.Cgroup},
+		LaunchableLimits: manifest.launchableResourceLimits(),
+	}
+
+	bytes, err := yaml.Marshal(resourceLimitsConfigFile)
+	if err != nil {
+		return util.Errorf("Could not write resource limits for %s: %s", manifest.ID(), err)
+	}
+	_, err = out.Write(bytes)
+	if err != nil {
+		return util.Errorf("Could not write resource limits for %s: %s", manifest.ID(), err)
 	}
 	return nil
 }
@@ -408,7 +439,7 @@ func (manifest *manifest) ConfigFileName() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(manifest.Id) + "_" + sha + ".yaml", nil
+	return manifest.Id.String() + "_" + sha + ".yaml", nil
 }
 
 func (manifest *manifest) PlatformConfigFileName() (string, error) {
@@ -416,7 +447,15 @@ func (manifest *manifest) PlatformConfigFileName() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(manifest.Id) + "_" + sha + ".platform.yaml", nil
+	return manifest.Id.String() + "_" + sha + ".platform.yaml", nil
+}
+
+func (manifest *manifest) ResourceLimitsConfigFileName() (string, error) {
+	sha, err := manifest.SHA()
+	if err != nil {
+		return "", err
+	}
+	return manifest.Id.String() + "_" + sha + ".resource_limits.yaml", nil
 }
 
 // Returns readers needed to verify the signature on the

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -355,3 +355,32 @@ func TestSetConfigCopies(t *testing.T) {
 	config["foo"] = "baz"
 	Assert(t).AreEqual(manifestConfig["foo"], "bar", "Config values shouldn't have changed when mutating the original input due to deep copy")
 }
+
+func TestWriteResourceLimitsConfigWithResourceLimits(t *testing.T) {
+	builder := NewBuilder()
+	builder.SetResourceLimits(ResourceLimitsStanza{Cgroup: &cgroups.Config{CPUs: 1, Memory: 1024}})
+	manifest := builder.GetManifest()
+	buf := bytes.Buffer{}
+	err := manifest.WriteResourceLimitsConfig(&buf)
+	if err != nil {
+		t.Errorf("Unexpected error writing Resource Limits Config: %v", err)
+	}
+	if len(buf.Bytes()) == 0 {
+		t.Error("Expected some resource limits config to be written but it wasn't")
+	}
+
+}
+
+func TestWriteResourceLimitsConfigWithoutResourceLimits(t *testing.T) {
+	builder := NewBuilder()
+	manifest := builder.GetManifest()
+	buf := bytes.Buffer{}
+	err := manifest.WriteResourceLimitsConfig(&buf)
+	if err != nil {
+		t.Errorf("It should not have been an error to write ResourceLimits on a manifest without them, but: %v", err)
+	}
+	if len(buf.Bytes()) != 0 {
+		t.Error("Wrote some resource limits config file with nonsense contents (none provided in manifest)")
+	}
+
+}

--- a/pkg/p2exec/p2_exec.go
+++ b/pkg/p2exec/p2_exec.go
@@ -2,6 +2,8 @@ package p2exec
 
 import (
 	"fmt"
+
+	"github.com/square/p2/pkg/types"
 )
 
 // DefaultP2Exec is the path to the default p2-exec binary. Specified as a var so you
@@ -15,6 +17,7 @@ type P2ExecArgs struct {
 	EnvDirs          []string
 	ExtraEnv         map[string]string
 	NoLimits         bool
+	PodID            *types.PodID
 	CgroupName       string
 	CgroupConfigName string
 	Command          []string
@@ -59,6 +62,10 @@ func (args P2ExecArgs) CommandLine() []string {
 
 	if args.ClearEnv {
 		cmd = append(cmd, "--clearenv")
+	}
+
+	if args.PodID != nil {
+		cmd = append(cmd, "--podID", args.PodID.String())
 	}
 
 	if len(cmd) > 0 {

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -238,7 +238,6 @@ func (p *Preparer) handlePods(podChan <-chan ManifestPair, quit <-chan struct{})
 					}
 				}
 				pod.SetLogBridgeExec(effectiveLogBridgeExec)
-
 				pod.SetFinishExec(p.finishExec)
 
 				// podChan is being fed values gathered from a consul.Watch() in


### PR DESCRIPTION
This is maybe as nice as the commit history will get.

There's a lot here, so let me go over the strategy.

Cgroups for pods are optional, for now. If the manifest has a `resource_limits` key at the top level, the preparer shall parse the file and write the limits to $pod/config/resource_limits.yaml. This file will be referenced in the p2-exec command line so that the cgroup is created (possibly redundantly) when the app starts (or restarts). 

The cgroup directory structure is nested underneath a new top-level group (called "p2") and then under the hostname. This fixes a long-standing bug where we couldn't properly cgroup things that ran inside of containers. Launchable cgroups are underneath pod cgroups where you'd expect them to be.