### PR TITLE
Return early if RU fails to create audit details

### DIFF
--- a/pkg/roll/run_update.go
+++ b/pkg/roll/run_update.go
@@ -367,6 +367,7 @@ func (u *update) Run(ctx context.Context) (ret bool) {
 				"ru-deletion-txn"+u.ID().String(),
 				err,
 			)
+			return false
 		}
 
 		err = u.auditLogStore.Create(cleanupCtx, audit.RUCompletionEvent, details)


### PR DESCRIPTION
This change returns early from the RU Run() function if the call to
NewRUCompletionEventDetails() returns an error. Previously the function
did not return, and nil details could be passed to a subsequent function
call.

Returning early is chosen behavior now because that is what was
done in error cases from the subsequent auditlogStore.Create() function
call anyway and because when Run() returns false, the RU is not deleted
giving another RU farm the chance to pick it up and perform the cleanup.