### PR TITLE
we are not interested in RCs that don't have any replicas

### DIFF
--- a/pkg/rc/replication_controller.go
+++ b/pkg/rc/replication_controller.go
@@ -1173,6 +1173,9 @@ func (rc *replicationController) checkEligibleForUnused(podID types.PodID, eligi
 }
 
 func (rc *replicationController) checkMissingArtifacts(rcFields fields.RC) {
+	if rcFields.ReplicasDesired == 0 {
+		return
+	}
 	podID := rcFields.Manifest.ID()
 	launchableStanzas := rcFields.Manifest.GetLaunchableStanzas()
 	for launchableID, launchableStanza := range launchableStanzas {


### PR DESCRIPTION
We have observed some RCs "get away" from their rolling updates and sit around with 0 replicas. This sort of check is only interesting when we're looking at apps that are managing nodes. This change should greatly reduce the false positive rate for this alert.