### PR TITLE
use new health service with rolling updates

### DIFF
--- a/bin/p2-ds-farm/main.go
+++ b/bin/p2-ds-farm/main.go
@@ -46,7 +46,7 @@ func main() {
 	logger := logging.NewLogger(logrus.Fields{})
 	dsStore := dsstore.NewConsul(client, 3, &logger)
 	consulStore := consul.NewConsulStore(client)
-	healthChecker := checker.NewConsulHealthChecker(client)
+	healthChecker := checker.NewHealthChecker(client)
 
 	rawStatusStore := statusstore.NewConsul(client)
 	statusStore := daemonsetstatus.NewConsul(rawStatusStore, ds_farm.DaemonSetStatusNamespace)

--- a/bin/p2-inspect/main.go
+++ b/bin/p2-inspect/main.go
@@ -78,7 +78,7 @@ func main() {
 		}
 	}
 
-	hchecker := checker.NewConsulHealthChecker(client)
+	hchecker := checker.NewHealthChecker(client)
 	for podID := range statusMap {
 		resultMap, err := hchecker.Service(podID.String())
 		if err != nil {

--- a/bin/p2-rctl-server/main.go
+++ b/bin/p2-rctl-server/main.go
@@ -82,7 +82,8 @@ func main() {
 	rcStatusStore := rcstatus.NewConsul(statusStoreClient, consul.RCStatusNamespace)
 
 	rollStore := rollstore.NewConsul(client, labeler, nil)
-	healthChecker := checker.NewConsulHealthChecker(client)
+	healthChecker := checker.NewHealthChecker(client)
+	shadowTrafficHealthChecker := checker.NewShadowTrafficHealthChecker(nil, nil, client, nil, nil, false)
 	sched := scheduler.NewApplicatorScheduler(labeler)
 
 	// Start acquiring sessions
@@ -138,7 +139,7 @@ func main() {
 		roll.UpdateFactory{
 			Store:         consulStore,
 			RCStore:       rcStore,
-			HealthChecker: healthChecker,
+			HealthChecker: shadowTrafficHealthChecker,
 			Labeler:       labeler,
 		},
 		consulStore,

--- a/bin/p2-rctl/main.go
+++ b/bin/p2-rctl/main.go
@@ -167,7 +167,7 @@ func main() {
 		rls:               rollstore.NewConsul(client, rollLabeler, nil),
 		consuls:           consul.NewConsulStore(client),
 		labeler:           labeler,
-		hcheck:            checker.NewConsulHealthChecker(client),
+		hcheck:            checker.NewShadowTrafficHealthChecker(nil, nil, client, nil, nil, false),
 		hclient:           nil,
 		logger:            logger,
 	}
@@ -271,7 +271,7 @@ type rctlParams struct {
 	rls               RollingUpdateStore
 	labeler           labels.ApplicatorWithoutWatches
 	consuls           Store
-	hcheck            checker.ConsulHealthChecker
+	hcheck            checker.ShadowTrafficHealthChecker
 	hclient           hclient.HealthServiceClient
 	logger            logging.Logger
 }
@@ -444,6 +444,7 @@ func (r rctlParams) RollingUpdate(oldID, newID string, want, need int) {
 	session := r.consuls.NewUnmanagedSession(sessionID, "")
 
 	result := make(chan bool, 1)
+
 	go func() {
 		ctx, cancel := transaction.New(context.Background())
 		defer cancel()

--- a/bin/p2-replicate/main.go
+++ b/bin/p2-replicate/main.go
@@ -50,7 +50,7 @@ func main() {
 	_, opts, labeler := flags.ParseWithConsulOptions()
 	client := consul.NewConsulClient(opts)
 	store := consul.NewConsulStore(client)
-	healthChecker := checker.NewConsulHealthChecker(client)
+	healthChecker := checker.NewHealthChecker(client)
 
 	manifest, err := manifest.FromURI(*manifestURI)
 	if err != nil {

--- a/pkg/ds/daemon_set.go
+++ b/pkg/ds/daemon_set.go
@@ -139,7 +139,7 @@ type daemonSet struct {
 	txner                 transaction.Txner
 	applicator            Labeler
 	watcher               LabelWatcher
-	healthChecker         *checker.ConsulHealthChecker
+	healthChecker         *checker.HealthChecker
 	healthWatchDelay      time.Duration
 	statusWritingInterval time.Duration
 
@@ -180,7 +180,7 @@ func New(
 	watcher LabelWatcher,
 	labelsAggregationRate time.Duration,
 	logger logging.Logger,
-	healthChecker *checker.ConsulHealthChecker,
+	healthChecker *checker.HealthChecker,
 	rateLimitInterval time.Duration,
 	cachedPodMatch bool,
 	healthWatchDelay time.Duration,

--- a/pkg/ds/farm.go
+++ b/pkg/ds/farm.go
@@ -74,7 +74,7 @@ type Farm struct {
 	logger  logging.Logger
 	alerter alerting.Alerter
 
-	healthChecker    *checker.ConsulHealthChecker
+	healthChecker    *checker.HealthChecker
 	healthWatchDelay time.Duration
 
 	monitorHealth         bool
@@ -120,7 +120,7 @@ func NewFarm(
 	sessions <-chan string,
 	logger logging.Logger,
 	alerter alerting.Alerter,
-	healthChecker *checker.ConsulHealthChecker,
+	healthChecker *checker.HealthChecker,
 	rateLimitInterval time.Duration,
 	monitorHealth bool,
 	cachedPodMatch bool,

--- a/pkg/health/checker/checker_test.go
+++ b/pkg/health/checker/checker_test.go
@@ -34,11 +34,11 @@ func TestService(t *testing.T) {
 	fakeStore := fakeConsulStore{
 		results: map[string]consul.WatchResult{"node1": result1},
 	}
-	consulHC := consulHealthChecker{
+	hc := healthChecker{
 		consulStore: fakeStore,
 	}
 
-	results, err := consulHC.Service("some_service")
+	results, err := hc.Service("some_service")
 	Assert(t).IsNil(err, "Unexpected error calling Service()")
 
 	expected := health.Result{

--- a/pkg/health/checker/test/fake_checker.go
+++ b/pkg/health/checker/test/fake_checker.go
@@ -1,15 +1,48 @@
 package test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/square/p2/pkg/health"
 	"github.com/square/p2/pkg/health/checker"
+	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/types"
 )
 
 // TODO: replication/common_setup_test.go has some things that could be moved here
+
+type singleServiceShadowChecker struct {
+	service string
+	health  map[types.NodeName]health.Result
+}
+
+func NewSingleServiceShadow(service string, health map[types.NodeName]health.Result) checker.ShadowTrafficHealthChecker {
+	return &singleServiceShadowChecker{
+		service: service,
+		health:  health,
+	}
+}
+
+func (s singleServiceShadowChecker) WatchService(
+	ctx context.Context,
+	serviceID string,
+	resultCh chan<- map[types.NodeName]health.Result,
+	errCh chan<- error,
+	watchDelay time.Duration,
+	useHealthService bool,
+	status manifest.StatusStanza,
+) {
+	panic("WatchService not implemented")
+}
+
+func (s singleServiceShadowChecker) Service(serviceID string, useHealthService bool, status manifest.StatusStanza) (map[types.NodeName]health.Result, error) {
+	if serviceID != s.service {
+		return nil, fmt.Errorf("Wrong service %s given, I only have health for %s", serviceID, s.service)
+	}
+	return s.health, nil
+}
 
 type singleServiceChecker struct {
 	service string
@@ -17,7 +50,7 @@ type singleServiceChecker struct {
 }
 
 // NewSingleService reports a fixed health result for a single service only
-func NewSingleService(service string, health map[types.NodeName]health.Result) checker.ConsulHealthChecker {
+func NewSingleService(service string, health map[types.NodeName]health.Result) checker.HealthChecker {
 	return &singleServiceChecker{
 		service: service,
 		health:  health,
@@ -38,7 +71,13 @@ func (s singleServiceChecker) WatchPodOnNode(nodename types.NodeName, podID type
 	return resultCh, nil
 }
 
-func (s singleServiceChecker) WatchService(serviceID string, resultCh chan<- map[types.NodeName]health.Result, errCh chan<- error, quitCh <-chan struct{}, watchDelay time.Duration) {
+func (s singleServiceChecker) WatchService(
+	ctx context.Context,
+	serviceID string,
+	resultCh chan<- map[types.NodeName]health.Result,
+	errCh chan<- error,
+	watchDelay time.Duration,
+) {
 	panic("WatchService not implemented")
 
 }
@@ -58,9 +97,9 @@ type AlwaysHappyHealthChecker struct {
 	allNodes []types.NodeName
 }
 
-// creates an implementation of checker.ConsulHealthChecker that always reports
+// creates an implementation of checker.HealthChecker that always reports
 // satisfied health checks for testing purposes
-func HappyHealthChecker(nodes []types.NodeName) checker.ConsulHealthChecker {
+func HappyHealthChecker(nodes []types.NodeName) checker.HealthChecker {
 	return AlwaysHappyHealthChecker{nodes}
 }
 
@@ -101,10 +140,10 @@ func (h AlwaysHappyHealthChecker) Service(serviceID string) (map[types.NodeName]
 }
 
 func (h AlwaysHappyHealthChecker) WatchService(
+	ctx context.Context,
 	serviceID string,
 	resultCh chan<- map[types.NodeName]health.Result,
 	errCh chan<- error,
-	quitCh <-chan struct{},
 	watchDelay time.Duration,
 ) {
 	allHappy := make(map[types.NodeName]health.Result)
@@ -116,7 +155,7 @@ func (h AlwaysHappyHealthChecker) WatchService(
 	}
 	for {
 		select {
-		case <-quitCh:
+		case <-ctx.Done():
 			return
 		case resultCh <- allHappy:
 		}

--- a/pkg/health/client/client.go
+++ b/pkg/health/client/client.go
@@ -17,7 +17,18 @@ type HealthResponse struct {
 	Error  error
 }
 
+type HealthEndpointsRequest struct {
+	Endpoints []string
+	Protocol  string
+}
+
+type HealthEndpointsResponse struct {
+	HealthResponses map[string]HealthResponse
+}
+
 type HealthServiceClient interface {
 	HealthCheck(ctx context.Context, req *HealthRequest) (health.HealthState, error)
 	HealthMonitor(ctx context.Context, req *HealthRequest, resultChan chan *HealthResponse) error
+	HealthCheckEndpoints(ctx context.Context, req *HealthEndpointsRequest) (map[string]health.HealthState, error)
+	HealthMonitorEndpoints(ctx context.Context, req *HealthEndpointsRequest, resultChan chan *HealthResponse) error
 }

--- a/pkg/health/store/store.go
+++ b/pkg/health/store/store.go
@@ -21,14 +21,14 @@ type HealthStore interface {
 
 type healthStore struct {
 	cachedHealth  map[cacheKey]*health.Result
-	healthChecker checker.ConsulHealthChecker
+	healthChecker checker.HealthChecker
 	lock          sync.RWMutex
 	logger        logging.Logger
 }
 
 var _ HealthStore = &healthStore{}
 
-func NewHealthStore(healthChecker checker.ConsulHealthChecker) HealthStore {
+func NewHealthStore(healthChecker checker.HealthChecker) HealthStore {
 	return &healthStore{
 		healthChecker: healthChecker,
 		lock:          sync.RWMutex{},

--- a/pkg/health/store/store_test.go
+++ b/pkg/health/store/store_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -18,10 +19,10 @@ func (hc *FakeHealthChecker) WatchPodOnNode(nodename types.NodeName, podID types
 }
 
 func (hc *FakeHealthChecker) WatchService(
+	ctx context.Context,
 	serviceID string,
 	resultCh chan<- map[types.NodeName]health.Result,
 	errCh chan<- error,
-	quitCh <-chan struct{},
 	watchDelay time.Duration,
 ) {
 	panic("not implemented")

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -80,6 +80,7 @@ type Manifest interface {
 	GetStatusPath() string
 	GetStatusPort() int
 	GetStatusLocalhostOnly() bool
+	GetStatusStanza() StatusStanza
 	GetReadOnly() bool
 	Marshal() ([]byte, error)
 	SignatureData() (plaintext, signature []byte)
@@ -214,8 +215,12 @@ func (manifest *manifest) SetStatusHTTP(statusHTTP bool) {
 }
 
 func (manifest *manifest) GetStatusPath() string {
-	if manifest.Status.Path != "" {
-		return path.Join("/", manifest.Status.Path)
+	return manifest.Status.GetPath()
+}
+
+func (status StatusStanza) GetPath() string {
+	if status.Path != "" {
+		return path.Join("/", status.Path)
 	}
 	return "/_status"
 }
@@ -242,6 +247,10 @@ func (manifest *manifest) GetStatusLocalhostOnly() bool {
 
 func (manifest *manifest) SetStatusLocalhostOnly(localhostOnly bool) {
 	manifest.Status.LocalhostOnly = localhostOnly
+}
+
+func (manifest *manifest) GetStatusStanza() StatusStanza {
+	return manifest.Status
 }
 
 func (manifest *manifest) SetResourceLimits(limits ResourceLimitsStanza) {

--- a/pkg/rc/farm.go
+++ b/pkg/rc/farm.go
@@ -83,7 +83,7 @@ type Farm struct {
 	scheduler     Scheduler
 	labeler       Labeler
 	txner         transaction.Txner
-	healthChecker checker.ConsulHealthChecker
+	healthChecker checker.HealthChecker
 
 	// session stream for the rcs locked by this farm
 	sessions <-chan string
@@ -120,7 +120,7 @@ func NewFarm(
 	rcLocker ReplicationControllerLocker,
 	rcWatcher ReplicationControllerWatcher,
 	txner transaction.Txner,
-	healthChecker checker.ConsulHealthChecker,
+	healthChecker checker.HealthChecker,
 	scheduler Scheduler,
 	labeler Labeler,
 	sessions <-chan string,

--- a/pkg/rc/replication_controller.go
+++ b/pkg/rc/replication_controller.go
@@ -140,7 +140,7 @@ type replicationController struct {
 	scheduler     Scheduler
 	podApplicator Labeler
 	alerter       alerting.Alerter
-	healthChecker checker.ConsulHealthChecker
+	healthChecker checker.HealthChecker
 
 	nodeTransfer nodeTransfer
 
@@ -168,7 +168,7 @@ func New(
 	podApplicator Labeler,
 	logger logging.Logger,
 	alerter alerting.Alerter,
-	healthChecker checker.ConsulHealthChecker,
+	healthChecker checker.HealthChecker,
 	artifactRegistry artifact.Registry,
 ) ReplicationController {
 	if alerter == nil {

--- a/pkg/replication/replication.go
+++ b/pkg/replication/replication.go
@@ -105,7 +105,7 @@ type replication struct {
 	labeler        Labeler
 	manifest       manifest.Manifest
 	mu             sync.RWMutex
-	health         checker.ConsulHealthChecker
+	health         checker.HealthChecker
 	threshold      health.HealthState // minimum state to treat as "healthy"
 	logger         logging.Logger
 
@@ -169,7 +169,7 @@ func newReplication(
 	labeler Labeler,
 	podLabels map[string]string,
 	manifest manifest.Manifest,
-	health checker.ConsulHealthChecker,
+	health checker.HealthChecker,
 	threshold health.HealthState,
 	logger logging.Logger,
 	rateLimiter *time.Ticker,

--- a/pkg/replication/replicator.go
+++ b/pkg/replication/replicator.go
@@ -60,7 +60,7 @@ type replicator struct {
 	store            Store
 	txner            transaction.Txner
 	labeler          Labeler
-	health           checker.ConsulHealthChecker
+	health           checker.HealthChecker
 	threshold        health.HealthState // minimum state to treat as "healthy"
 	healthWatchDelay time.Duration      // interval of time between initiating health watches
 
@@ -78,7 +78,7 @@ func NewReplicator(
 	store Store,
 	txner transaction.Txner,
 	labeler Labeler,
-	health checker.ConsulHealthChecker,
+	health checker.HealthChecker,
 	threshold health.HealthState,
 	lockMessage string,
 	timeout time.Duration,

--- a/pkg/roll/farm.go
+++ b/pkg/roll/farm.go
@@ -49,7 +49,7 @@ type UpdateFactory struct {
 	RCStatusStore       RCStatusStore
 	RollStore           RollingUpdateStore
 	HealthServiceClient hclient.HealthServiceClient
-	HealthChecker       checker.ConsulHealthChecker
+	HealthChecker       checker.ShadowTrafficHealthChecker
 	Labeler             labeler
 	WatchDelay          time.Duration
 	Alerter             alerting.Alerter
@@ -73,7 +73,7 @@ func NewUpdateFactory(
 	rcStore ReplicationControllerStore,
 	rcStatusStore RCStatusStore,
 	rollStore RollingUpdateStore,
-	healthChecker checker.ConsulHealthChecker,
+	healthChecker checker.ShadowTrafficHealthChecker,
 	healthServiceClient hclient.HealthServiceClient,
 	labeler labeler,
 	watchDelay time.Duration,

--- a/pkg/roll/update_test.go
+++ b/pkg/roll/update_test.go
@@ -530,7 +530,7 @@ func updateWithHealth(t *testing.T,
 		consulClient:                fixture.Client,
 		rcStore:                     rcs,
 		rcLocker:                    rcs,
-		hcheck:                      checkertest.NewSingleService(podID, checks),
+		hcheck:                      checkertest.NewSingleServiceShadow(podID, checks),
 		labeler:                     applicator,
 		logger:                      logger,
 		Update:                      ru,
@@ -667,7 +667,7 @@ func TestCountHealthyLooksAtEligibleForDynamicRCs(t *testing.T) {
 }
 
 func (u *update) uniformShouldRollAfterDelay(t *testing.T, podID types.PodID) (int, error) {
-	remove, add, err := u.shouldRollAfterDelay(podID)
+	remove, add, err := u.shouldRollAfterDelay(podID, false, manifest.StatusStanza{})
 	Assert(t).AreEqual(remove, add, "expected nodes removed and nodes added to be equal")
 	return add, err
 }
@@ -708,7 +708,7 @@ func TestShouldRollInitialMigrationFromZero(t *testing.T) {
 	upd.DesiredReplicas = 3
 	upd.MinimumReplicas = 2
 
-	remove, add, err := upd.shouldRollAfterDelay(manifest.ID())
+	remove, add, err := upd.shouldRollAfterDelay(manifest.ID(), false, manifest.GetStatusStanza())
 	Assert(t).IsNil(err, "expected no error determining nodes to roll")
 	Assert(t).AreEqual(remove, 0, "expected to remove no nodes")
 	Assert(t).AreEqual(add, 1, "expected to add one node")
@@ -760,7 +760,7 @@ func TestShouldRollMidwayUnhealthyMigrationFromZero(t *testing.T) {
 	upd.DesiredReplicas = 3
 	upd.MinimumReplicas = 2
 
-	remove, add, _ := upd.shouldRollAfterDelay(manifest.ID())
+	remove, add, _ := upd.shouldRollAfterDelay(manifest.ID(), false, manifest.GetStatusStanza())
 	Assert(t).AreEqual(remove, 0, "expected to remove no nodes")
 	Assert(t).AreEqual(add, 0, "expected to add no nodes")
 }
@@ -892,7 +892,7 @@ func TestShouldRollMidwayHealthyMigrationFromZero(t *testing.T) {
 	upd.DesiredReplicas = 3
 	upd.MinimumReplicas = 2
 
-	remove, add, err := upd.shouldRollAfterDelay(manifest.ID())
+	remove, add, err := upd.shouldRollAfterDelay(manifest.ID(), false, manifest.GetStatusStanza())
 	Assert(t).IsNil(err, "expected no error determining nodes to roll")
 	Assert(t).AreEqual(remove, 0, "expected to remove no nodes")
 	Assert(t).AreEqual(add, 1, "expected to add one node")
@@ -911,7 +911,7 @@ func TestShouldRollMidwayHealthyMigrationFromZeroWhenNewSatisfies(t *testing.T) 
 	upd.DesiredReplicas = 3
 	upd.MinimumReplicas = 2
 
-	remove, add, err := upd.shouldRollAfterDelay(manifest.ID())
+	remove, add, err := upd.shouldRollAfterDelay(manifest.ID(), false, manifest.GetStatusStanza())
 	Assert(t).IsNil(err, "expected no error determining nodes to roll")
 	Assert(t).AreEqual(remove, 0, "expected to remove no nodes")
 	Assert(t).AreEqual(add, 1, "expected to add one node")
@@ -985,27 +985,29 @@ type cannedWatchServiceChecker struct {
 }
 
 func (c cannedWatchServiceChecker) WatchService(
+	ctx context.Context,
 	serviceID string,
 	resultCh chan<- map[types.NodeName]health.Result,
 	errCh chan<- error,
-	quitCh <-chan struct{},
 	watchDelay time.Duration,
+	useHealthService bool,
+	status manifest.StatusStanza,
 ) {
 	for {
 		select {
-		case <-quitCh:
+		case <-ctx.Done():
 			return
 		case val := <-c.watchServiceCh:
 			select {
 			case resultCh <- val:
-			case <-quitCh:
+			case <-ctx.Done():
 				return
 			}
 		}
 	}
 }
 
-func (c cannedWatchServiceChecker) Service(serviceID string) (map[types.NodeName]health.Result, error) {
+func (c cannedWatchServiceChecker) Service(serviceID string, useHealthService bool, status manifest.StatusStanza) (map[types.NodeName]health.Result, error) {
 	return c.serviceResult, nil
 }
 
@@ -1258,7 +1260,7 @@ func TestRollLoopMigrateFromZero(t *testing.T) {
 	rollLoopResult := make(chan bool)
 
 	go func() {
-		rollLoopResult <- upd.rollLoop(ctx, manifest.ID(), healths, nil)
+		rollLoopResult <- upd.rollLoop(ctx, manifest.ID(), healths, nil, false, manifest.GetStatusStanza())
 		close(rollLoopResult)
 	}()
 
@@ -1324,7 +1326,7 @@ func TestRollLoopStallsIfUnhealthy(t *testing.T) {
 	rollLoopResult := make(chan bool)
 
 	go func() {
-		rollLoopResult <- upd.rollLoop(ctx, manifest.ID(), healths, nil)
+		rollLoopResult <- upd.rollLoop(ctx, manifest.ID(), healths, nil, false, manifest.GetStatusStanza())
 		close(rollLoopResult)
 	}()
 


### PR DESCRIPTION
Changes required for rolling updates to use the health service client for health checks while still using the consul health tree in parallel. These changes will test reliability of health service client.
- Created a separate healthChecker type in checker.go called ShadowTrafficHealthChecker that will utilize both the health service client and old consul tree checking code
- Old health checker was renamed from ConsulHealthChecker to HealthChecker so that in the future when the health service client is deemed reliable we can rename ShadowTrafficHealthChecker to HealthChecker
- WatchService and Service functions defined for new HealthChecker to be used by rolling updates
- WatchService uses both health service client and consul health tree
- Service uses either consul or health service client