### PR TITLE
Add no_halt_on_update launchable option to launchable stanza spec

### DIFF
--- a/bin/p2-restart/main.go
+++ b/bin/p2-restart/main.go
@@ -102,7 +102,9 @@ func main() {
 
 	logger.NoFields().Infoln("Halting pod")
 
-	ok, err := pod.Halt(manifest)
+	// let the pod manifest decide which launchables to actually stop
+	force := false
+	ok, err := pod.Halt(manifest, force)
 	if err != nil {
 		logger.WithError(err).Fatalln("Could not halt pod")
 	} else if !ok {

--- a/bin/p2-shutdown/main.go
+++ b/bin/p2-shutdown/main.go
@@ -56,6 +56,10 @@ func main() {
 		podsToShutdown = append(podsToShutdown, types.PodID(pod))
 	}
 
+	// An operator is taking the machine out of service, force all services
+	// to shut down regardless of manifest settings
+	forceHalt := true
+
 	// TODO: configure a proper http client instead of using default fetcher
 	podFactory := pods.NewFactory(*podRoot, node, uri.DefaultFetcher, "")
 	var haltWG sync.WaitGroup
@@ -74,7 +78,7 @@ func main() {
 		// Halt in the background because Halt() waits for lifecycle scripts
 		go func(man manifest.Manifest, podID types.PodID) {
 			defer haltWG.Done()
-			success, err := pod.Halt(man)
+			success, err := pod.Halt(man, forceHalt)
 			if !success {
 				log.Printf("[ERROR]: at least one launchable of %s did not halt successfully.", podID)
 			}

--- a/bin/p2-stop/main.go
+++ b/bin/p2-stop/main.go
@@ -119,7 +119,9 @@ func main() {
 
 	logger.NoFields().Infoln("Halting pod")
 
-	ok, err := pod.Halt(manifest)
+	// An operator is stopping the pod, don't allow the manifest to decide not to stop a launchable
+	forceHalt := true
+	ok, err := pod.Halt(manifest, forceHalt)
 	if err != nil {
 		logger.WithError(err).Fatalln("Could not halt pod")
 	} else if !ok {

--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -261,7 +261,12 @@ func (hl *Launchable) start(serviceBuilder *runit.ServiceBuilder, sv runit.SV) e
 	for _, executable := range executables {
 		var err error
 		if hl.RestartPolicy_ == runit.RestartPolicyAlways {
-			_, err = sv.Restart(&executable.Service, hl.RestartTimeout)
+			// TODO: can we use start always?
+			if hl.NoHaltOnUpdate_ {
+				_, err = sv.Start(&executable.Service)
+			} else {
+				_, err = sv.Restart(&executable.Service, hl.RestartTimeout)
+			}
 		} else {
 			_, err = sv.Once(&executable.Service)
 		}

--- a/pkg/launch/launchable.go
+++ b/pkg/launch/launchable.go
@@ -49,6 +49,16 @@ type LaunchableStanza struct {
 	// "always".
 	RestartPolicy_ runit.RestartPolicy `yaml:"restart_policy,omitempty"`
 
+	// NoHaltOnUpdate instructs the preparer to skip stopping the
+	// launchable's processes when it is being updated. This is useful for
+	// processes that are designed to be updated via binary overwrite and
+	// SIGHUP for example.
+	// NOTE: under certain circumstances the process still might be
+	// stopped, for example if a host operator calls p2-shutdown
+	// NOTE: P2 does not arrange for signals to your app to signify update,
+	// that should be implemented by the pod itself via bin/post-activate
+	NoHaltOnUpdate bool `yaml:"no_halt_on_update,omitempty"`
+
 	// Specifies which files or directories (relative to launchable root)
 	// should be launched under runit. Only launchables of type "hoist"
 	// make use of this field, and if empty, a default of ["bin/launch"]
@@ -149,7 +159,7 @@ type Launchable interface {
 	// Disable allows a launchable to stop work and do cleanup prior to Stop
 	Disable() error
 	// Stop stops execution.
-	Stop(serviceBuilder *runit.ServiceBuilder, sv runit.SV) error
+	Stop(serviceBuilder *runit.ServiceBuilder, sv runit.SV, force bool) error
 	// MakeCurrent adjusts a "current" symlink for this launchable name to point to this
 	// launchable's version.
 	MakeCurrent() error

--- a/pkg/opencontainer/containers.go
+++ b/pkg/opencontainer/containers.go
@@ -291,7 +291,7 @@ func (l *Launchable) Disable() error {
 }
 
 // Halt causes the launchable to halt execution if it is running.
-func (l *Launchable) Stop(serviceBuilder *runit.ServiceBuilder, sv runit.SV) error {
+func (l *Launchable) Stop(serviceBuilder *runit.ServiceBuilder, sv runit.SV, _ bool) error {
 	err := l.stop(serviceBuilder, sv)
 	if err != nil {
 		return launch.StopError{Inner: err}


### PR DESCRIPTION
When set, this option instructs P2 to skip the "sv stop" portion of the
normal manifest update process. This is useful for processes that are
designed to gracefully reload without service interruption. However, P2
does not arrange for a signal to be sent to the process, pods that need
this functionality should implement their own signal handling in
bin/post-activate.

There are certain circumstances in which the no_halt_on_update setting
will be ignored, for instance if an operator is shutting down all pods
on the host or if a pod is being uninstalled (manifest deleted from the
intent tree).