### PR TITLE
Read only in pod manifest

### DIFF
--- a/bin/p2-bootstrap/bootstrap.go
+++ b/bin/p2-bootstrap/bootstrap.go
@@ -49,7 +49,7 @@ func main() {
 	log.Println("Installing and launching consul")
 
 	// TODO: configure a proper http client instead of using default for fetcher
-	podFactory := pods.NewFactory(*podRoot, nodeName, uri.DefaultFetcher, *requireFile)
+	podFactory := pods.NewFactory(*podRoot, nodeName, uri.DefaultFetcher, *requireFile, pods.NewReadOnlyPolicy(false, nil, nil))
 
 	var consulPod *pods.Pod
 	var consulManifest manifest.Manifest

--- a/bin/p2-launch/main.go
+++ b/bin/p2-launch/main.go
@@ -85,7 +85,7 @@ func main() {
 
 	fetcher := uri.BasicFetcher{Client: httpClient}
 
-	podFactory := pods.NewFactory(*podRoot, types.NodeName(*nodeName), fetcher, "")
+	podFactory := pods.NewFactory(*podRoot, types.NodeName(*nodeName), fetcher, "", pods.NewReadOnlyPolicy(false, nil, nil))
 	pod := podFactory.NewLegacyPod(manifest.ID())
 
 	err = pod.Install(manifest, auth.NopVerifier(), artifact.NewRegistry(*artifactRegistryURL, fetcher, osversion.DefaultDetector))

--- a/bin/p2-shutdown/main.go
+++ b/bin/p2-shutdown/main.go
@@ -61,7 +61,7 @@ func main() {
 	forceHalt := true
 
 	// TODO: configure a proper http client instead of using default fetcher
-	podFactory := pods.NewFactory(*podRoot, node, uri.DefaultFetcher, "")
+	podFactory := pods.NewFactory(*podRoot, node, uri.DefaultFetcher, "", pods.NewReadOnlyPolicy(false, nil, nil))
 	var haltWG sync.WaitGroup
 	for _, realityEntry := range reality {
 		pod := podFactory.NewLegacyPod(realityEntry.Manifest.ID())

--- a/pkg/hooks/hook_env.go
+++ b/pkg/hooks/hook_env.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/square/p2/pkg/config"
 	"github.com/square/p2/pkg/manifest"
@@ -79,7 +80,14 @@ func (h *HookEnv) PodFromDisk() (*pods.Pod, error) {
 
 // Initializes a pod based on the hooked pod manifest and the system pod root
 func (h *HookEnv) Pod() (*pods.Pod, error) {
-	factory := pods.NewFactory(os.Getenv(HookedSystemPodRootEnvVar), HookedNodeEnvVar, uri.DefaultFetcher, "", pods.NewReadOnlyPolicy(false, nil, nil))
+	readonly, err := strconv.ParseBool(os.Getenv(HookedPodReadOnly))
+	if err != nil {
+		// if we can't parse the boolean, it may just be unset; default
+		// to readonly being off
+		readonly = false
+	}
+
+	factory := pods.NewFactory(os.Getenv(HookedSystemPodRootEnvVar), HookedNodeEnvVar, uri.DefaultFetcher, "", pods.NewReadOnlyPolicy(readonly, nil, nil))
 
 	podID, err := h.PodID()
 	if err != nil {

--- a/pkg/hooks/hook_env.go
+++ b/pkg/hooks/hook_env.go
@@ -79,7 +79,7 @@ func (h *HookEnv) PodFromDisk() (*pods.Pod, error) {
 
 // Initializes a pod based on the hooked pod manifest and the system pod root
 func (h *HookEnv) Pod() (*pods.Pod, error) {
-	factory := pods.NewFactory(os.Getenv(HookedSystemPodRootEnvVar), HookedNodeEnvVar, uri.DefaultFetcher, "")
+	factory := pods.NewFactory(os.Getenv(HookedSystemPodRootEnvVar), HookedNodeEnvVar, uri.DefaultFetcher, "", pods.NewReadOnlyPolicy(false, nil, nil))
 
 	podID, err := h.PodID()
 	if err != nil {

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strconv"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -140,6 +141,8 @@ func (h *hookContext) runHooks(dirpath string, hType HookType, pod Pod, podManif
 		return err
 	}
 
+	podManifest.SetReadOnlyIfUnset(pod.ReadOnly())
+
 	hec := &HookExecutionEnvironment{
 		HookEnvVar:                path.Base(dirpath),
 		HookEventEnvVar:           hType.String(),
@@ -152,6 +155,7 @@ func (h *hookContext) runHooks(dirpath string, hType HookType, pod Pod, podManif
 		HookedConfigDirPathEnvVar: pod.ConfigDir(),
 		HookedSystemPodRootEnvVar: h.podRoot,
 		HookedPodUniqueKeyEnvVar:  pod.UniqueKey().String(),
+		HookedPodReadOnly:         strconv.FormatBool(podManifest.GetReadOnly()),
 	}
 	return h.runDirectory(hec, logger)
 }

--- a/pkg/hooks/types.go
+++ b/pkg/hooks/types.go
@@ -64,6 +64,7 @@ const (
 	HookedConfigDirPathEnvVar = "HOOKED_CONFIG_DIR_PATH"
 	HookedSystemPodRootEnvVar = "HOOKED_SYSTEM_POD_ROOT"
 	HookedPodUniqueKeyEnvVar  = "HOOKED_POD_UNIQUE_KEY"
+	HookedPodReadOnly         = "HOOKED_POD_READ_ONLY"
 
 	DefaultTimeout = 120 * time.Second
 )
@@ -75,6 +76,7 @@ type Pod interface {
 	Node() types.NodeName
 	Home() string
 	UniqueKey() types.PodUniqueKey
+	ReadOnly() bool
 }
 
 type hookContext struct {
@@ -97,7 +99,8 @@ type HookExecutionEnvironment struct {
 	HookedEnvPathEnvVar,
 	HookedConfigDirPathEnvVar,
 	HookedSystemPodRootEnvVar,
-	HookedPodUniqueKeyEnvVar string
+	HookedPodUniqueKeyEnvVar,
+	HookedPodReadOnly string
 }
 
 // The set of UNIX environment variables for the hook's execution
@@ -114,6 +117,7 @@ func (hee *HookExecutionEnvironment) Env() []string {
 		fmt.Sprintf("%s=%s", HookedConfigDirPathEnvVar, hee.HookedConfigDirPathEnvVar),
 		fmt.Sprintf("%s=%s", HookedSystemPodRootEnvVar, hee.HookedSystemPodRootEnvVar),
 		fmt.Sprintf("%s=%s", HookedPodUniqueKeyEnvVar, hee.HookedPodUniqueKeyEnvVar),
+		fmt.Sprintf("%s=%s", HookedPodReadOnly, hee.HookedPodReadOnly),
 	}
 }
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -266,7 +266,7 @@ func (manifest *manifest) RunAsUser() string {
 }
 
 func (manifest *manifest) UnpackAsUser() string {
-	if *manifest.ReadOnly {
+	if manifest.GetReadOnly() {
 		return "root"
 	}
 
@@ -283,7 +283,7 @@ func (manifest *manifest) GetReadOnly() bool {
 
 func (manifest *manifest) SetReadOnlyIfUnset(readonly bool) {
 	if manifest.ReadOnly == nil {
-		*manifest.ReadOnly = readonly
+		manifest.ReadOnly = &readonly
 	}
 }
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -82,6 +82,7 @@ type Manifest interface {
 	GetStatusLocalhostOnly() bool
 	GetStatusStanza() StatusStanza
 	GetReadOnly() bool
+	SetReadOnlyIfUnset(readonly bool)
 	Marshal() ([]byte, error)
 	SignatureData() (plaintext, signature []byte)
 
@@ -104,7 +105,7 @@ type manifest struct {
 	StatusHTTP          bool                                            `yaml:"status_http,omitempty"`
 	Status              StatusStanza                                    `yaml:"status,omitempty"`
 	ResourceLimits      ResourceLimitsStanza                            `yaml:"resource_limits,omitempty"`
-	ReadOnly            bool                                            `yaml:"readonly,omitempty"`
+	ReadOnly            *bool                                           `yaml:"readonly,omitempty"`
 	ArtifactRegistryURL string                                          `yaml:"artifact_registry,omitempty"`
 
 	// Used to track the original bytes so that we don't reorder them when
@@ -265,7 +266,7 @@ func (manifest *manifest) RunAsUser() string {
 }
 
 func (manifest *manifest) UnpackAsUser() string {
-	if manifest.ReadOnly {
+	if *manifest.ReadOnly {
 		return "root"
 	}
 
@@ -273,7 +274,17 @@ func (manifest *manifest) UnpackAsUser() string {
 }
 
 func (manifest *manifest) GetReadOnly() bool {
-	return manifest.ReadOnly
+	if manifest.ReadOnly != nil {
+		return *manifest.ReadOnly
+	}
+
+	return false
+}
+
+func (manifest *manifest) SetReadOnlyIfUnset(readonly bool) {
+	if manifest.ReadOnly == nil {
+		*manifest.ReadOnly = readonly
+	}
 }
 
 func (mb builder) SetRunAsUser(user string) {
@@ -281,7 +292,7 @@ func (mb builder) SetRunAsUser(user string) {
 }
 
 func (mb builder) SetReadonly(readonly bool) {
-	mb.manifest.ReadOnly = readonly
+	*mb.manifest.ReadOnly = readonly
 }
 
 // FromPath constructs a Manifest from a local file. This function is a helper for

--- a/pkg/pods/factory.go
+++ b/pkg/pods/factory.go
@@ -117,7 +117,7 @@ func (f *hookFactory) NewHookPod(id types.PodID) *Pod {
 	home := filepath.Join(f.hookRoot, id.String())
 
 	// Hooks can't have a UUID
-	return newPodWithHome(id, "", home, f.node, "", f.fetcher, f.osVersionDetector, true)
+	return newPodWithHome(id, "", home, f.node, "", f.fetcher, f.osVersionDetector, false)
 }
 
 func newPodWithHome(

--- a/pkg/pods/factory.go
+++ b/pkg/pods/factory.go
@@ -152,7 +152,7 @@ func newPodWithHome(
 		Fetcher:           fetcher,
 		RequireFile:       requireFile,
 		OSVersionDetector: osVersionDetector,
-		ReadOnly:          readOnly,
+		readOnly:          readOnly,
 	}
 }
 

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -82,7 +82,7 @@ type Pod struct {
 	subsystemer cgroups.Subsystemer
 
 	// whether or not this pod should be deployed ReadOnly by default
-	ReadOnly bool
+	readOnly bool
 }
 
 type ManifestFinder interface {
@@ -107,6 +107,10 @@ func (pod *Pod) Node() types.NodeName {
 
 func (pod *Pod) Home() string {
 	return pod.home
+}
+
+func (pod *Pod) ReadOnly() bool {
+	return pod.readOnly
 }
 
 // A unique name for a pod instance, useful for avoiding filename conflicts.
@@ -431,7 +435,7 @@ func (pod *Pod) SetSubsystemer(s cgroups.Subsystemer) {
 // machine and are set up to run. In the case of Hoist artifacts (which is the only format
 // supported currently, this will set up runit services.).
 func (pod *Pod) Install(manifest manifest.Manifest, verifier auth.ArtifactVerifier, artifactRegistry artifact.Registry) error {
-	manifest.SetReadOnlyIfUnset(pod.ReadOnly)
+	manifest.SetReadOnlyIfUnset(pod.readOnly)
 
 	podHome := pod.home
 	uid, gid, err := user.IDs(manifest.UnpackAsUser())

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -80,6 +80,9 @@ type Pod struct {
 
 	// subsystemer is a tool for this pod to find its cgroup subsystem controller and metadata. Optionally nil, overridden in test
 	subsystemer cgroups.Subsystemer
+
+	// whether or not this pod should be deployed ReadOnly by default
+	ReadOnly bool
 }
 
 type ManifestFinder interface {
@@ -428,6 +431,8 @@ func (pod *Pod) SetSubsystemer(s cgroups.Subsystemer) {
 // machine and are set up to run. In the case of Hoist artifacts (which is the only format
 // supported currently, this will set up runit services.).
 func (pod *Pod) Install(manifest manifest.Manifest, verifier auth.ArtifactVerifier, artifactRegistry artifact.Registry) error {
+	manifest.SetReadOnlyIfUnset(pod.ReadOnly)
+
 	podHome := pod.home
 	uid, gid, err := user.IDs(manifest.UnpackAsUser())
 	if err != nil {

--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -30,7 +30,8 @@ import (
 )
 
 func getTestPod() *Pod {
-	podFactory := NewFactory("/data/pods", "testNode", uri.DefaultFetcher, "")
+	readOnlyPolicy := NewReadOnlyPolicy(false, nil, nil)
+	podFactory := NewFactory("/data/pods", "testNode", uri.DefaultFetcher, "", readOnlyPolicy)
 	pod := podFactory.NewLegacyPod("hello")
 	pod.subsystemer = &FakeSubsystemer{}
 	pod.CurrentManifest()
@@ -149,7 +150,8 @@ config:
 
 	podTemp, _ := ioutil.TempDir("", "pod")
 
-	podFactory := NewFactory(podTemp, "testNode", uri.DefaultFetcher, "")
+	readOnlyPolicy := NewReadOnlyPolicy(false, nil, nil)
+	podFactory := NewFactory(podTemp, "testNode", uri.DefaultFetcher, "", readOnlyPolicy)
 	pod := podFactory.NewLegacyPod(manifest.ID())
 	pod.subsystemer = &FakeSubsystemer{}
 
@@ -222,7 +224,8 @@ func TestLogLaunchableError(t *testing.T) {
 	testManifest := getTestPodManifest(t)
 	testErr := util.Errorf("Unable to do something")
 	message := "Test error occurred"
-	factory := NewFactory(DefaultPath, "testNode", uri.DefaultFetcher, "")
+	readOnlyPolicy := NewReadOnlyPolicy(false, nil, nil)
+	factory := NewFactory(DefaultPath, "testNode", uri.DefaultFetcher, "", readOnlyPolicy)
 	pod := factory.NewLegacyPod(testManifest.ID())
 	pod.logLaunchableError(testLaunchable.ServiceId, testErr, message)
 
@@ -241,7 +244,8 @@ func TestLogError(t *testing.T) {
 	testManifest := getTestPodManifest(t)
 	testErr := util.Errorf("Unable to do something")
 	message := "Test error occurred"
-	factory := NewFactory(DefaultPath, "testNode", uri.DefaultFetcher, "")
+	readOnlyPolicy := NewReadOnlyPolicy(false, nil, nil)
+	factory := NewFactory(DefaultPath, "testNode", uri.DefaultFetcher, "", readOnlyPolicy)
 	pod := factory.NewLegacyPod(testManifest.ID())
 	pod.logError(testErr, message)
 
@@ -257,7 +261,8 @@ func TestLogInfo(t *testing.T) {
 	Log.SetLogOut(&out)
 
 	testManifest := getTestPodManifest(t)
-	factory := NewFactory(DefaultPath, "testNode", uri.DefaultFetcher, "")
+	readOnlyPolicy := NewReadOnlyPolicy(false, nil, nil)
+	factory := NewFactory(DefaultPath, "testNode", uri.DefaultFetcher, "", readOnlyPolicy)
 	pod := factory.NewLegacyPod(testManifest.ID())
 	message := "Pod did something good"
 	pod.logInfo(message)
@@ -275,7 +280,7 @@ func TestWriteManifestWillReturnOldManifestTempPath(t *testing.T) {
 
 	poddir, err := ioutil.TempDir("", "poddir")
 	Assert(t).IsNil(err, "couldn't create tempdir")
-	pod := newPodWithHome("testPod", "", poddir, "testNode", "", nil, osversion.DefaultDetector)
+	pod := newPodWithHome("testPod", "", poddir, "testNode", "", nil, osversion.DefaultDetector, false)
 
 	// set the RunAs user to the user running the test, because when we
 	// write files we need an owner.

--- a/pkg/pods/read_only_policy.go
+++ b/pkg/pods/read_only_policy.go
@@ -1,0 +1,33 @@
+package pods
+
+import "github.com/square/p2/pkg/types"
+
+type ReadOnlyPolicy struct {
+	defaultReadOnly bool
+	whitelist       []types.PodID
+	blacklist       []types.PodID
+}
+
+func NewReadOnlyPolicy(defaultReadOnly bool, whitelist []types.PodID, blacklist []types.PodID) ReadOnlyPolicy {
+	return ReadOnlyPolicy{
+		defaultReadOnly: defaultReadOnly,
+		whitelist:       whitelist,
+		blacklist:       blacklist,
+	}
+}
+
+func (p *ReadOnlyPolicy) IsReadOnly(pod types.PodID) bool {
+	for _, v := range p.blacklist {
+		if v == pod {
+			return false
+		}
+	}
+
+	for _, v := range p.whitelist {
+		if v == pod {
+			return true
+		}
+	}
+
+	return p.defaultReadOnly
+}

--- a/pkg/preparer/orchestrate_test.go
+++ b/pkg/preparer/orchestrate_test.go
@@ -95,6 +95,10 @@ func (t *TestPod) UniqueKey() types.PodUniqueKey {
 	return ""
 }
 
+func (t *TestPod) ReadOnly() bool {
+	return false
+}
+
 type fakeHooks struct {
 	beforeInstallErr, beforeUninstallErr, afterInstallErr, afterLaunchErr, afterAuthFailErr, beforeLaunchErr error
 	ranBeforeInstall, ranBeforeUninstall, ranAfterLaunch, ranAfterInstall, ranAfterAuthFail, ranBeforeLaunch bool


### PR DESCRIPTION
To be honest, I'm a little out of my depth here.

That said, I'm attempting to have p2-preparer be configurable to set default readonly policy for deployed pods. Pods will be able to override this policy by setting the `ReadOnly` flag in their manifest (as they currently do today). To allow for a graceful changeover, the preparer manifest will supported a flag for whether or not readonly deploys should be the default, a list of PodIDs that should be deployed readonly by default, and a list of PodIDs that should not be deployed readonly by default.

We'll start out by having ReadOnly default to false, and manually deploying the preparer with a whitelist of readonly-clean pods. This list will grow over time. In the event of an error on our part, pod owners can explicitly deploy with ReadOnly set to false to override this, so they don't have to wait on a preparer deploy.

As we gradually roll out more apps ReadOnly, we'll build up a list of apps that *cannot* currently be deployed this way and add them to the blacklist. For now this won't do anything, as the default policy is false anyway. However, once we have an authoritative list of non-readonly apps, we can flip the default policy from false to true. Once this is done, we can remove apps from the whitelist until it's empty, then delete most of the code in this PR (and have the known-incompatible apps simply maintain that fact in their manifest).

We export a `HOOKED_POD_READ_ONLY` flag so that hooks can act upon this information even if the on-disk manifest doesn't have the information necessary to know if the pod is readonly or not (since it now depends upon the state of the pod manifest *and* the preparer manifest).