### PR TITLE
Health service into rolling update fixes

### DIFF
--- a/bin/p2-rctl-server/main.go
+++ b/bin/p2-rctl-server/main.go
@@ -83,7 +83,7 @@ func main() {
 
 	rollStore := rollstore.NewConsul(client, labeler, nil)
 	healthChecker := checker.NewHealthChecker(client)
-	shadowTrafficHealthChecker := checker.NewShadowTrafficHealthChecker(nil, nil, client, nil, nil, false)
+	shadowTrafficHealthChecker := checker.NewShadowTrafficHealthChecker(nil, nil, client, nil, nil, false, false)
 	sched := scheduler.NewApplicatorScheduler(labeler)
 
 	// Start acquiring sessions

--- a/bin/p2-rctl/main.go
+++ b/bin/p2-rctl/main.go
@@ -167,7 +167,7 @@ func main() {
 		rls:               rollstore.NewConsul(client, rollLabeler, nil),
 		consuls:           consul.NewConsulStore(client),
 		labeler:           labeler,
-		hcheck:            checker.NewShadowTrafficHealthChecker(nil, nil, client, nil, nil, false),
+		hcheck:            checker.NewShadowTrafficHealthChecker(nil, nil, client, nil, nil, false, false),
 		hclient:           nil,
 		logger:            logger,
 	}

--- a/pkg/health/checker/test/fake_checker.go
+++ b/pkg/health/checker/test/fake_checker.go
@@ -28,6 +28,8 @@ func NewSingleServiceShadow(service string, health map[types.NodeName]health.Res
 func (s singleServiceShadowChecker) WatchService(
 	ctx context.Context,
 	serviceID string,
+	nodeIDs []types.NodeName,
+	nodeIDsCh <-chan []types.NodeName,
 	resultCh chan<- map[types.NodeName]health.Result,
 	errCh chan<- error,
 	watchDelay time.Duration,
@@ -38,7 +40,12 @@ func (s singleServiceShadowChecker) WatchService(
 	panic("WatchService not implemented")
 }
 
-func (s singleServiceShadowChecker) Service(serviceID string, useHealthService bool, status manifest.StatusStanza) (map[types.NodeName]health.Result, error) {
+func (s singleServiceShadowChecker) Service(
+	serviceID string,
+	nodeIDs []types.NodeName,
+	useHealthService bool,
+	status manifest.StatusStanza,
+) (map[types.NodeName]health.Result, error) {
 	if serviceID != s.service {
 		return nil, fmt.Errorf("Wrong service %s given, I only have health for %s", serviceID, s.service)
 	}


### PR DESCRIPTION
Fix up logic in WatchService of checker.go
Add refresh logic in run_update.go for the case of node transfer or other reason causing the current pods in an RU to change.