### PR TITLE
Add --require-file flag to p2-launch

### DIFF
--- a/bin/p2-launch/main.go
+++ b/bin/p2-launch/main.go
@@ -36,6 +36,7 @@ var (
 	).Short('d').ExistingFile()
 	caFile              = kingpin.Flag("tls-ca-file", "File containing the x509 PEM-encoded CA ").ExistingFile()
 	artifactRegistryURL = kingpin.Flag("artifact-registry-url", "the artifact registry to fetch artifacts from").Short('r').URL()
+	requireFile         = kingpin.Flag("require-file", "If set, the p2-exec invocation(s) written for the pod will not execute until the file exists on the system").String()
 )
 
 func main() {
@@ -85,7 +86,7 @@ func main() {
 
 	fetcher := uri.BasicFetcher{Client: httpClient}
 
-	podFactory := pods.NewFactory(*podRoot, types.NodeName(*nodeName), fetcher, "", pods.NewReadOnlyPolicy(false, nil, nil))
+	podFactory := pods.NewFactory(*podRoot, types.NodeName(*nodeName), fetcher, *requireFile, pods.NewReadOnlyPolicy(false, nil, nil))
 	pod := podFactory.NewLegacyPod(manifest.ID())
 
 	err = pod.Install(manifest, auth.NopVerifier(), artifact.NewRegistry(*artifactRegistryURL, fetcher, osversion.DefaultDetector))


### PR DESCRIPTION
This will support bootstrapping a service in a way that it will not
actually be able to execute until a particular file is on disk.
p2-preparer already supports writing runit services this way, but it
couldn't be done by p2-launch.