### PR TITLE
Allow resource_limits of 0 in pod manifests

### DIFF
--- a/bin/p2-exec/main.go
+++ b/bin/p2-exec/main.go
@@ -339,12 +339,6 @@ func createPodCgroup(resourceLimitsPath string, podID types.PodID, hostname type
 	if !ok {
 		return util.Errorf("Did not find any pod limits in file at: %s, instead found %+v", resourceLimitsPath, podLimits)
 	}
-	if podLimits.CPUs == 0 {
-		return util.Errorf("Expected cgroup config to contain a non-zero value for CPU. %+v", podLimits)
-	}
-	if podLimits.Memory == 0 {
-		return util.Errorf("Expected cgroup config to contain a non-zero value for CPU. %+v", podLimits)
-	}
 
 	err = cgroups.CreatePodCgroup(podID, hostname, podLimits, cgroups.DefaultSubsystemer)
 	if err != nil {


### PR DESCRIPTION
Right now, a cgroup limit of 0 for either CPUs or memory in the manifest
(or the omission of the cgroup limit) translates to an actual cgroup
limit of -1, i.e. unrestricted. To facilitate an automated adoption of
reosurce_limits based on existing launchable limits, we should allow
manifest limits of 0 (at least for now). Otherwise we will have to
impose new limits that did not previously exist and that will slow down
the migration to pod resource_limits.