### PR TITLE
Remove out-of-place code snippet in the pod cluster store.

### DIFF
--- a/pkg/store/consul/pcstore/consul_store.go
+++ b/pkg/store/consul/pcstore/consul_store.go
@@ -297,16 +297,6 @@ func (s *ConsulStore) MutatePC(
 		return fields.PodCluster{}, util.Errorf("Could not set pod cluster at path '%s'", pcp)
 	}
 
-	err = s.setLabelsForPC(pc)
-	if err != nil {
-		// TODO: what if this delete fails?
-		deleteErr := s.Delete(pc.ID)
-		if deleteErr != nil {
-			err = util.Errorf("%s\n%s", err, deleteErr)
-		}
-		return fields.PodCluster{}, err
-	}
-
 	return pc, nil
 }
 


### PR DESCRIPTION
There was logic in the MutatePC function where it would write labels for
the pod after doing a mutation, and if the label write fails it would
delete the pod cluster. It doesn't make sense to be touching labels at
all here, and it certainly doesn't make sense to delete the pod cluster
unless that's what the caller wanted. Looks like this was a bad
copy/paste from the Create() function, where it does make sense to
delete a pod cluster for which a label write failed.