### PR TITLE
Always use cpu.cfs_period_us of 1,000,000

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -49,8 +49,6 @@ func (subsys Subsystems) SetCPU(name CgroupID, cpus int) error {
 	period := 1000000 // one million microseconds
 	quota := cpus * period
 	if cpus == 0 {
-		// one hundred thousand microseconds is the default, -1 will return EINVAL
-		period = 100000
 		// setting -1 here will unrestrict the cgroup, so the period won't matter
 		quota = -1
 	}


### PR DESCRIPTION
It is possible to have a pod with cpu restrictions and an
unrestricted launchable. When that happens, the pod has a cgroup
cpu.cfs_period_us of 1,000,000. Then, for the launchable's unrestricted cpu limit, we
switch to the default period of 100,000. Having a period of 100,000
nested within a cgroup that has a period of 1,000,000 is invalid.

This change switches to always using a period of 1,000,000 for
consistency and to prevent failed writes. Those failed writes would block pod
installation.