### PR TITLE
Fix docker installation in vagrant integration test

### DIFF
--- a/integration/common-provision.sh
+++ b/integration/common-provision.sh
@@ -65,8 +65,14 @@ pushd /tmp
 mkdir -p opencontainer-hello_def456/rootfs
 cp /usr/local/share/go/src/github.com/square/p2/integration/hello/config.json opencontainer-hello_def456/
 
-# get a suitable root filesystem for centos from docker
-sudo yum install docker -y
+# install docker using instructions from
+# https://docs.docker.com/install/linux/docker-ce/centos/#set-up-the-repository
+sudo yum install -y yum-utils device-mapper-persistent-data lvm2
+sudo yum-config-manager \
+    --add-repo \
+    https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum install -y docker-ce
+
 sudo systemctl start docker
 sudo docker pull centos
 container_id=$(sudo docker create centos:latest)


### PR DESCRIPTION
Previously starting docker under systemd was failing, the error seems to
go away if we use the docker installation instructions from
https://docs.docker.com/install/linux/docker-ce/centos/#install-docker-ce-1
which also gets us a more recent version