### PR TITLE
Retry node transfers on health check timeout

### DIFF
--- a/pkg/rc/replication_controller.go
+++ b/pkg/rc/replication_controller.go
@@ -993,13 +993,15 @@ func (rc *replicationController) doBackgroundNodeTransfer(rcFields fields.RC, lo
 		if alertErr != nil {
 			logger.WithError(alertErr).Errorln("Unable to send alert")
 		}
-
-		rc.nodeTransferMu.Lock()
-		rc.nodeTransfer = nodeTransfer{}
-		rc.nodeTransferMu.Unlock()
 	} else {
 		logger.Infof("Node transfer was canceled: %s.", rollbackReason)
+		// We'll retry the node transfer on the next call of meetDesires using
+		// the same old and new nodes because they have been written to the
+		// status tree
 	}
+	rc.nodeTransferMu.Lock()
+	rc.nodeTransfer = nodeTransfer{}
+	rc.nodeTransferMu.Unlock()
 }
 
 func (rc *replicationController) watchHealth(rcFields fields.RC, logger logging.Logger) (bool, audit.RollbackReason) {


### PR DESCRIPTION
When the watchHealth go routine times out waiting for a new node to come
up healthy, the routine ends. In this case, we want the node transfer to
be retried with the same old and new nodes, and that is possible because
they have been persisted in the Consul replication controller status
tree. However, because the local rc.nodeTransfer struct would have a
non-nil quit channel, the replication controller did not retry because
it thought the watch health go routine was still operating in the
background. By setting the rc.nodeTransfer struct to the empty struct,
the node transfer will be correctly retried.