### PR TITLE
Add a helper to the hook env struct to get a pod's unique name

### DIFF
--- a/pkg/hooks/hook_env.go
+++ b/pkg/hooks/hook_env.go
@@ -129,3 +129,25 @@ func (h *HookEnv) ExitUnlessEvent(types ...HookType) HookType {
 	os.Exit(0)
 	return HookType("") // never reached
 }
+
+func (h *HookEnv) PodUniqueKey() (types.PodUniqueKey, error) {
+	podUniqueKey := os.Getenv(HookedPodUniqueKeyEnvVar)
+	if podUniqueKey == "" {
+		return "", util.Errorf("%s environment variable is not set", HookedPodUniqueKeyEnvVar)
+	}
+	return types.PodUniqueKey(podUniqueKey), nil
+}
+
+func (h *HookEnv) PodUniqueName() (string, error) {
+	podUniqueKey, err := h.PodUniqueKey()
+	if err != nil {
+		return "", err
+	}
+
+	podID, err := h.PodID()
+	if err != nil {
+		return "", err
+	}
+
+	return pods.ComputeUniqueName(podID, podUniqueKey), nil
+}

--- a/pkg/pods/factory.go
+++ b/pkg/pods/factory.go
@@ -88,7 +88,7 @@ func NewHookFactory(hookRoot string, node types.NodeName, fetcher uri.Fetcher) H
 	}
 }
 
-func computeUniqueName(id types.PodID, uniqueKey types.PodUniqueKey) string {
+func ComputeUniqueName(id types.PodID, uniqueKey types.PodUniqueKey) string {
 	name := id.String()
 	if uniqueKey != "" {
 		// If the pod was scheduled with a UUID, we want to namespace its pod home
@@ -104,7 +104,7 @@ func (f *factory) NewUUIDPod(id types.PodID, uniqueKey types.PodUniqueKey) (*Pod
 	if uniqueKey == "" {
 		return nil, util.Errorf("uniqueKey cannot be empty")
 	}
-	home := filepath.Join(f.podRoot, computeUniqueName(id, uniqueKey))
+	home := filepath.Join(f.podRoot, ComputeUniqueName(id, uniqueKey))
 	return newPodWithHome(id, uniqueKey, home, f.node, f.requireFile, f.fetcher, f.osVersionDetector, f.readOnlyPolicy.IsReadOnly(id)), nil
 }
 
@@ -128,7 +128,7 @@ func newPodWithHome(
 	requireFile string,
 	fetcher uri.Fetcher,
 	osVersionDetector osversion.Detector,
-    readOnly bool,
+	readOnly bool,
 ) *Pod {
 	var logger logging.Logger
 	logger = Log.SubLogger(logrus.Fields{"pod": id, "uuid": uniqueKey})

--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -120,7 +120,7 @@ func (pod *Pod) ReadOnly() bool {
 // This is exported because being able to generate a unique deterministic
 // string for pods is useful in hooks for example.
 func (pod *Pod) UniqueName() string {
-	return computeUniqueName(pod.Id, pod.uniqueKey)
+	return ComputeUniqueName(pod.Id, pod.uniqueKey)
 }
 
 func (pod *Pod) UniqueKey() types.PodUniqueKey {


### PR DESCRIPTION
This is useful for hooks that want to maintain per-pod state on disk and
helps them to do the right thing. The pod unique name is the correct
uniquie identifier to use because it combines pod ID and pod unique key
if set.