### PR TITLE
Add log lines when daemon set handling goroutine exits

### DIFF
--- a/pkg/ds/daemon_set.go
+++ b/pkg/ds/daemon_set.go
@@ -361,6 +361,7 @@ func (ds *daemonSet) WatchDesires(
 					// so that the timer would be stopped after
 					err = nil
 				case <-ctx.Done():
+					ds.logger.Warnln("goroutine exiting because ")
 					return
 				}
 			} else {
@@ -380,6 +381,7 @@ func (ds *daemonSet) WatchDesires(
 			case newDS, ok := <-updatedCh:
 				if !ok {
 					// channel closed
+					ds.logger.Warnln("goroutine exiting because updatedCh has closed")
 					return
 				}
 				if ds.ID() != newDS.ID {
@@ -462,6 +464,7 @@ func (ds *daemonSet) WatchDesires(
 
 			case deleteDS, ok := <-deletedCh:
 				if !ok {
+					ds.logger.Warnln("goroutine exiting because deletedCh has closed")
 					return
 				}
 				// Deleting a daemon sets has no effect
@@ -471,6 +474,7 @@ func (ds *daemonSet) WatchDesires(
 			case _, ok := <-nodesChangedCh:
 				if !ok {
 					// channel closed
+					ds.logger.Warnln("goroutine exiting because nodesChangedCh has closed")
 					return
 				}
 				if reportErr := ds.reportEligible(); reportErr != nil {
@@ -530,6 +534,7 @@ func (ds *daemonSet) WatchDesires(
 				nodesToAdd <- addedNodes
 
 			case <-ctx.Done():
+				ds.logger.Warnln("goroutine exiting because context was canceled")
 				return
 			}
 		}


### PR DESCRIPTION
Occasionally we see problems in the DS farm where the main control loop
gets blocked sending updates to daemon set handlers via channels. This
is likely because the handler goroutines are exiting, but logs don't
currently reveal the cause. This commit adds logs to all of the places
where these goroutines might exit which should shed light on the issue