### PR TITLE
Add function to manifest builder to set node requirements

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -42,6 +42,7 @@ type Builder interface {
 	SetStatusPort(port int)
 	SetLaunchables(launchableStanzas map[launch.LaunchableID]launch.LaunchableStanza)
 	SetResourceLimits(limits ResourceLimitsStanza)
+	SetNodeRequirements(map[string]string)
 }
 
 var _ Builder = builder{}
@@ -157,6 +158,10 @@ func (manifest *manifest) GetLaunchableStanzas() map[launch.LaunchableID]launch.
 
 func (manifest *manifest) SetLaunchables(launchableStanzas map[launch.LaunchableID]launch.LaunchableStanza) {
 	manifest.LaunchableStanzas = launchableStanzas
+}
+
+func (manifest *manifest) SetNodeRequirements(nodeRequirements map[string]string) {
+	manifest.NodeRequirements = nodeRequirements
 }
 
 func (manifest *manifest) GetResourceLimits() ResourceLimitsStanza {

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -386,3 +386,19 @@ func TestArtifactRegistryOverride(t *testing.T) {
 		t.Error("Expected registry override to occur, but didn't find one")
 	}
 }
+
+func TestSetNodeRequirements(t *testing.T) {
+	b := NewBuilder()
+	b.SetID("foo")
+	b.SetNodeRequirements(map[string]string{
+		"req1": "val1",
+	})
+	man := b.GetManifest()
+	val, ok := man.GetNodeRequirements()["req1"]
+	if !ok {
+		t.Fatal("expected a node requirement for req1")
+	}
+	if val != "val1" {
+		t.Errorf("expected node requirement req1 to have value val1 but was %sa", val)
+	}
+}


### PR DESCRIPTION
This is useful for programmatically building a manifest that has node
requirements