### PR TITLE
Modify p2-preparer to read pod whitelist from pod_whitelist_file

### DIFF
--- a/bin/p2-bootstrap/bootstrap.go
+++ b/bin/p2-bootstrap/bootstrap.go
@@ -44,7 +44,7 @@ func main() {
 	nodeName := types.NodeName(hostname)
 	agentManifest, err := manifest.FromPath(*agentManifestPath)
 	if err != nil {
-		log.Fatalln("Could not get agent manifest: %s", err)
+		log.Fatalf("Could not get agent manifest: %s", err)
 	}
 	log.Println("Installing and launching consul")
 

--- a/bin/p2-preparer/main.go
+++ b/bin/p2-preparer/main.go
@@ -85,7 +85,7 @@ func main() {
 		logger.WithError(err).Fatalf("Could not do initial build reality at launch: %s", err)
 	}
 
-	podWhiteList, err := prep.CheckPodWhitelist(preparerConfig)
+	podWhiteList, err := prep.ProceedPodWhitelist(preparerConfig)
 	if err != nil {
 		logger.WithError(err).Fatalf("Error occurs when checking pod whitelist %+v", podWhiteList)
 	}

--- a/bin/p2-preparer/main.go
+++ b/bin/p2-preparer/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"io/ioutil"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -11,6 +13,7 @@ import (
 
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/preparer"
+	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util/param"
 	"github.com/square/p2/pkg/version"
 	"github.com/square/p2/pkg/watch"
@@ -44,6 +47,7 @@ func main() {
 		defer statusServer.Close()
 	}
 
+	requiredPods := make(map[types.PodID]bool)
 	if preparerConfig.RequireFile != "" {
 		_, err := os.Stat(preparerConfig.RequireFile)
 		if os.IsNotExist(err) {
@@ -51,6 +55,14 @@ func main() {
 		}
 		if err != nil {
 			logger.WithError(err).Fatalln("Could not check for require file's existence")
+		}
+
+		required, err := loadTokens(preparerConfig.RequireFile)
+		if err != nil {
+			logger.WithError(err).WithField("path", preparerConfig.RequireFile).Fatalln("Could not read required file")
+		}
+		for pod := range required {
+			requiredPods[types.PodID(pod)] = true
 		}
 	}
 
@@ -83,6 +95,14 @@ func main() {
 	err = prep.BuildRealityAtLaunch()
 	if err != nil {
 		logger.WithError(err).Fatalf("Could not do initial build reality at launch: %s", err)
+	}
+
+	// check if any podID existing in require file(p2-may-run), if so, install them first
+	if len(requiredPods) == 0 {
+		err = prep.InstallRequiredPods(requiredPods, preparerConfig)
+		if err != nil {
+			logger.WithError(err).Fatalln("Could not install required pods")
+		}
 	}
 
 	go prep.WatchForPodManifestsForNode(quitMainUpdate)
@@ -123,4 +143,13 @@ func waitForTermination(logger logging.Logger, quitMainUpdate chan struct{}, qui
 	}
 	quitMainUpdate <- struct{}{}
 	<-quitMainUpdate // acknowledgement
+}
+
+func loadTokens(path string) ([]string, error) {
+	tokens, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return strings.Split(string(tokens), " "), nil
 }

--- a/integration/single-node-slug-deploy/check.go
+++ b/integration/single-node-slug-deploy/check.go
@@ -101,7 +101,7 @@ func main() {
 
 	requireFile, err := createRequireFile(tempdir)
 	if err != nil {
-		log.Fatalln("Could not create temp require file, bailing: %s", err)
+		log.Fatalf("Could not create temp require file, bailing: %s", err)
 	}
 
 	userHookManifest, err := userCreationHookManifest(tempdir, noAddUser)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,12 +1,15 @@
 package constants
 
 import (
+	"time"
+
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util/param"
 )
 
 const (
-	PreparerPodID = types.PodID("p2-preparer")
+	PreparerPodID            = types.PodID("p2-preparer")
+	P2WhitelistCheckInterval = 10 * time.Second
 )
 
 // Maximum allowed time for a single health check, in seconds

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -2,8 +2,12 @@ package constants
 
 import (
 	"github.com/square/p2/pkg/types"
+	"github.com/square/p2/pkg/util/param"
 )
 
 const (
 	PreparerPodID = types.PodID("p2-preparer")
 )
+
+// Maximum allowed time for a single health check, in seconds
+var HEALTHCHECK_TIMEOUT = param.Int64("healthcheck_timeout", 5)

--- a/pkg/pods/factory.go
+++ b/pkg/pods/factory.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/Sirupsen/logrus"
+	dockerclient "github.com/docker/docker/client"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/osversion"
 	"github.com/square/p2/pkg/p2exec"
@@ -12,9 +14,6 @@ import (
 	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/uri"
 	"github.com/square/p2/pkg/util"
-
-	"github.com/Sirupsen/logrus"
-	dockerclient "github.com/docker/docker/client"
 )
 
 const DefaultPath = "/data/pods"
@@ -112,7 +111,7 @@ func (f *factory) NewUUIDPod(id types.PodID, uniqueKey types.PodUniqueKey) (*Pod
 		return nil, util.Errorf("uniqueKey cannot be empty")
 	}
 	home := filepath.Join(f.podRoot, ComputeUniqueName(id, uniqueKey))
-  return newPodWithHome(id, uniqueKey, home, f.node, f.requireFile, f.fetcher, f.osVersionDetector, f.readOnlyPolicy.IsReadOnly(id), &f.dockerClient), nil
+	return newPodWithHome(id, uniqueKey, home, f.node, f.requireFile, f.fetcher, f.osVersionDetector, f.readOnlyPolicy.IsReadOnly(id), &f.dockerClient), nil
 
 }
 

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -3,9 +3,8 @@ package preparer
 import (
 	"context"
 	"fmt"
-	"time"
-
 	"os"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/square/p2/pkg/artifact"
@@ -81,10 +80,10 @@ func (p podWorkerID) String() string {
 	return fmt.Sprintf("%s-%s", p.podID.String(), p.podUniqueKey)
 }
 
-func (p *Preparer) CheckPodWhitelist(preparerConfig *PreparerConfig) (map[types.PodID]bool, error) {
+func (p *Preparer) ProceedPodWhitelist(preparerConfig *PreparerConfig) (map[types.PodID]bool, error) {
 	whiteListPods := make(map[types.PodID]bool)
 	if preparerConfig.PodWhitelistFile != "" {
-		// Keep loopinng the white list of pods in pod whitelist file, and install the non existing pods
+		// Keep looping the white list of pods in pod whitelist file, and install the non existing pods
 		// exit while the white list is empty
 		for {
 			_, err := os.Stat(preparerConfig.PodWhitelistFile)
@@ -193,7 +192,10 @@ func (p *Preparer) handleWhiteListPod(pair *ManifestPair, errorChan chan<- error
 	}
 	ok := p.resolvePair(*pair, pod, manifestLogger)
 	if !ok {
-		errorChan <- util.Errorf("failed to install pod: %s", pair.Intent.ID())
+		errorChan <- util.PodIntallationError{
+			Inner: util.Errorf("failed to install pod: %s", pair.Intent.ID()),
+			PodID: pair.Intent.ID(),
+		}
 		return
 	}
 	p.Logger.WithField("podManifest", pair).Println("Finished installation of the whitelist pod")

--- a/pkg/preparer/orchestrate.go
+++ b/pkg/preparer/orchestrate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/square/p2/pkg/artifact"
 	"github.com/square/p2/pkg/auth"
 	"github.com/square/p2/pkg/constants"
+	"github.com/square/p2/pkg/health"
 	"github.com/square/p2/pkg/hooks"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/manifest"
@@ -77,6 +78,101 @@ func (p podWorkerID) String() string {
 	}
 
 	return fmt.Sprintf("%s-%s", p.podID.String(), p.podUniqueKey)
+}
+
+func (p *Preparer) InstallRequiredPods(requiredPods map[types.PodID]bool, preparerConfig *PreparerConfig) error {
+	intentResults, _, err := p.store.ListPods(consul.INTENT_TREE, p.node)
+	var intentRequired []consul.ManifestResult
+	if err != nil {
+		p.Logger.WithError(err).Errorln("could not check intent")
+	}
+	errorChan := make(chan error)
+	quit := make(chan struct{})
+
+	for _, intentResult := range intentResults {
+		if _, ok := requiredPods[intentResult.Manifest.ID()]; ok {
+			// check pod health here, to prevent reinstall. This is useful when
+			// the required pod is already running, and the p2-prepare restarted
+			if p.checkPodHealth(intentResult, preparerConfig) {
+				continue
+			}
+			intentRequired = append(intentRequired, intentResult)
+		}
+	}
+
+	for _, intentManifest := range intentRequired {
+		intentManifest := &ManifestPair{
+			Intent:       intentManifest.Manifest,
+			ID:           intentManifest.Manifest.ID(),
+			PodUniqueKey: intentManifest.PodUniqueKey,
+		}
+
+		go p.handleRequiredPod(intentManifest, errorChan, quit)
+	}
+	for i := 0; i < len(intentRequired); i++ {
+		select {
+		case <-quit:
+		case err := <-errorChan:
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *Preparer) handleRequiredPod(intentManifest *ManifestPair, errorChan chan<- error, quit chan<- struct{}) {
+	var pod *pods.Pod
+	var err error
+	var manifestLogger logging.Logger
+	sha, _ := intentManifest.Intent.SHA()
+
+	manifestLogger = p.Logger.SubLogger(logrus.Fields{
+		"pod":            intentManifest.ID,
+		"sha":            sha,
+		"pod_unique_key": intentManifest.PodUniqueKey,
+	})
+	manifestLogger.NoFields().Debugln("processing required pod manifest")
+
+	if intentManifest.PodUniqueKey == "" {
+		pod = p.podFactory.NewLegacyPod(intentManifest.ID)
+	} else {
+		pod, err = p.podFactory.NewUUIDPod(intentManifest.ID, intentManifest.PodUniqueKey)
+		if err != nil {
+			manifestLogger.WithError(err).Errorln("Could not initialize pod")
+			errorChan <- util.Errorf("failed to initialize pod: %s, error: %v", intentManifest.Intent.ID(), err)
+		}
+	}
+
+	ok, err := p.preparePod(*intentManifest, pod, manifestLogger)
+	if !ok || err != nil {
+		errorChan <- util.Errorf("failed to install pod: %s, error: %v", intentManifest.Intent.ID(), err)
+		return
+	}
+	ok = p.resolvePair(*intentManifest, pod, manifestLogger)
+	if !ok {
+		errorChan <- util.Errorf("failed to install pod: %s", intentManifest.Intent.ID())
+		return
+	}
+	quit <- struct{}{}
+}
+
+func (p *Preparer) checkPodHealth(man consul.ManifestResult, config *PreparerConfig) bool {
+	client, err := config.GetClient(time.Duration(*constants.HEALTHCHECK_TIMEOUT) * time.Second)
+	if err != nil {
+		p.Logger.WithError(err).Errorln("failed to get http client for this preparer")
+		return false
+	}
+	url := fmt.Sprintf("http://%s:%d%s", p.node, man.Manifest.GetStatusPort(), man.Manifest.GetStatusPath())
+
+	resp, err := client.Head(url)
+	if err != nil {
+		p.Logger.WithError(err).Errorln("health check failed")
+		return false
+	}
+
+	if health.HealthState(resp.Status) == health.Passing {
+		return true
+	}
+	return false
 }
 
 func (p *Preparer) WatchForPodManifestsForNode(quitAndAck chan struct{}) {
@@ -222,83 +318,14 @@ func (p *Preparer) handlePods(podChan <-chan ManifestPair, quit <-chan struct{})
 						break
 					}
 				}
-
-				// TODO better solution: force the preparer to have a 0s default timeout, prevent KILLs
-				if pod.Id == constants.PreparerPodID {
-					pod.DefaultTimeout = time.Duration(0)
+				ok, err := p.preparePod(nextLaunch, pod, manifestLogger)
+				if !ok || err != nil {
+					break
 				}
-
-				effectiveLogBridgeExec := p.logExec
-				// pods that are in the blacklist for this preparer shall not use the
-				// preparer's log exec. Instead, they will use the default svlogd logexec.
-				for _, podID := range p.logBridgeBlacklist {
-					if pod.Id.String() == podID {
-						effectiveLogBridgeExec = svlogdExec
-						break
-					}
-				}
-				pod.SetLogBridgeExec(effectiveLogBridgeExec)
-				pod.SetFinishExec(p.finishExec)
-
-				// podChan is being fed values gathered from a consul.Watch() in
-				// WatchForPodManifestsForNode(). If the watch returns a new pair of
-				// intent/reality values before the previous change has finished
-				// processing in resolvePair(), the reality value will be stale. This
-				// leads to a bug where the preparer will appear to update a package
-				// and when that is finished, "update" it again.
-				//
-				// Example ordering of bad events:
-				// 1) update to /intent for pod A comes in, /reality is read and
-				// resolvePair() handles it
-				// 2) before resolvePair() finishes, another /intent update comes in,
-				// and /reality is read but hasn't been changed. This update cannot
-				// be processed until the previous resolvePair() call finishes, and
-				// updates /reality. Now the reality value used here is stale. We
-				// want to refresh our /reality read so we don't restart the pod if
-				// intent didn't change between updates.
-				//
-				// The correct solution probably involves watching reality and intent
-				// and feeding updated pairs to a control loop.
-				//
-				// This is a quick fix to ensure that the reality value being used is
-				// up-to-date. The de-bouncing logic in this method should ensure that the
-				// intent value is fresh (to the extent that Consul is timely). Fetching
-				// the reality value again ensures its freshness too.
-				if nextLaunch.PodUniqueKey == "" {
-					// legacy pod, get reality manifest from reality tree
-					reality, _, err := p.store.Pod(consul.REALITY_TREE, p.node, nextLaunch.ID)
-					if err == pods.NoCurrentManifest {
-						nextLaunch.Reality = nil
-					} else if err != nil {
-						manifestLogger.WithError(err).Errorln("Error getting reality manifest")
-						break
-					} else {
-						nextLaunch.Reality = reality
-					}
-				} else {
-					// uuid pod, get reality manifest from pod status
-					status, _, err := p.podStatusStore.Get(nextLaunch.PodUniqueKey)
-					switch {
-					case err != nil && !statusstore.IsNoStatus(err):
-						manifestLogger.WithError(err).Errorln("Error getting reality manifest from pod status")
-						break
-					case statusstore.IsNoStatus(err):
-						nextLaunch.Reality = nil
-					default:
-						manifest, err := manifest.FromBytes([]byte(status.Manifest))
-						if err != nil {
-							manifestLogger.WithError(err).Errorln("Error parsing reality manifest from pod status")
-							break
-						}
-						nextLaunch.Reality = manifest
-					}
-				}
-
-				ok := p.resolvePair(nextLaunch, pod, manifestLogger)
+				ok = p.resolvePair(nextLaunch, pod, manifestLogger)
 				if ok {
 					nextLaunch = ManifestPair{}
 					working = false
-
 					// Reset the backoff time
 					backoffTime = minimumBackoffTime
 				} else {
@@ -311,6 +338,80 @@ func (p *Preparer) handlePods(podChan <-chan ManifestPair, quit <-chan struct{})
 			}
 		}
 	}
+}
+
+func (p *Preparer) preparePod(nextLaunch ManifestPair, pod *pods.Pod, manifestLogger logging.Logger) (bool, error) {
+	// TODO better solution: force the preparer to have a 0s default timeout, prevent KILLs
+	if pod.Id == constants.PreparerPodID {
+		pod.DefaultTimeout = time.Duration(0)
+	}
+
+	effectiveLogBridgeExec := p.logExec
+	// pods that are in the blacklist for this preparer shall not use the
+	// preparer's log exec. Instead, they will use the default svlogd logexec.
+	for _, podID := range p.logBridgeBlacklist {
+		if pod.Id.String() == podID {
+			effectiveLogBridgeExec = svlogdExec
+			return false, nil
+		}
+	}
+	pod.SetLogBridgeExec(effectiveLogBridgeExec)
+	pod.SetFinishExec(p.finishExec)
+
+	// podChan is being fed values gathered from a consul.Watch() in
+	// WatchForPodManifestsForNode(). If the watch returns a new pair of
+	// intent/reality values before the previous change has finished
+	// processing in resolvePair(), the reality value will be stale. This
+	// leads to a bug where the preparer will appear to update a package
+	// and when that is finished, "update" it again.
+	//
+	// Example ordering of bad events:
+	// 1) update to /intent for pod A comes in, /reality is read and
+	// resolvePair() handles it
+	// 2) before resolvePair() finishes, another /intent update comes in,
+	// and /reality is read but hasn't been changed. This update cannot
+	// be processed until the previous resolvePair() call finishes, and
+	// updates /reality. Now the reality value used here is stale. We
+	// want to refresh our /reality read so we don't restart the pod if
+	// intent didn't change between updates.
+	//
+	// The correct solution probably involves watching reality and intent
+	// and feeding updated pairs to a control loop.
+	//
+	// This is a quick fix to ensure that the reality value being used is
+	// up-to-date. The de-bouncing logic in this method should ensure that the
+	// intent value is fresh (to the extent that Consul is timely). Fetching
+	// the reality value again ensures its freshness too.
+	if nextLaunch.PodUniqueKey == "" {
+		// legacy pod, get reality manifest from reality tree
+		reality, _, err := p.store.Pod(consul.REALITY_TREE, p.node, nextLaunch.ID)
+		if err == pods.NoCurrentManifest {
+			nextLaunch.Reality = nil
+		} else if err != nil {
+			manifestLogger.WithError(err).Errorln("Error getting reality manifest")
+			return false, err
+		} else {
+			nextLaunch.Reality = reality
+		}
+	} else {
+		// uuid pod, get reality manifest from pod status
+		status, _, err := p.podStatusStore.Get(nextLaunch.PodUniqueKey)
+		switch {
+		case err != nil && !statusstore.IsNoStatus(err):
+			manifestLogger.WithError(err).Errorln("Error getting reality manifest from pod status")
+			return false, err
+		case statusstore.IsNoStatus(err):
+			nextLaunch.Reality = nil
+		default:
+			manifest, err := manifest.FromBytes([]byte(status.Manifest))
+			if err != nil {
+				manifestLogger.WithError(err).Errorln("Error parsing reality manifest from pod status")
+				return false, err
+			}
+			nextLaunch.Reality = manifest
+		}
+	}
+	return true, nil
 }
 
 // check if a manifest satisfies the authorization requirement of this preparer

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -143,6 +143,7 @@ type PreparerConfig struct {
 	KeyFile                      string                 `yaml:"key_file,omitempty"`
 	PodRoot                      string                 `yaml:"pod_root,omitempty"`
 	RequireFile                  string                 `yaml:"require_file,omitempty"`
+	PodWhitelistFile             string                 `yaml:"pod_whitelist_file,omitempty"`
 	StatusPort                   int                    `yaml:"status_port"`
 	StatusSocket                 string                 `yaml:"status_socket"`
 	Auth                         map[string]interface{} `yaml:"auth,omitempty"`

--- a/pkg/util/PodError.go
+++ b/pkg/util/PodError.go
@@ -1,0 +1,17 @@
+package util
+
+import "github.com/square/p2/pkg/types"
+
+type PodIntallationError struct {
+	Inner error
+	PodID types.PodID
+}
+
+func (r PodIntallationError) Error() string {
+	return r.Inner.Error()
+}
+
+func IsPodIntallationError(err error) bool {
+	_, ok := err.(PodIntallationError)
+	return ok
+}

--- a/pkg/util/readfile.go
+++ b/pkg/util/readfile.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"io/ioutil"
+	"strings"
+)
+
+func LoadTokens(path string) ([]string, error) {
+	tokens, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return strings.Split(string(tokens), "\n"), nil
+}

--- a/pkg/watch/health.go
+++ b/pkg/watch/health.go
@@ -5,13 +5,13 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/square/p2/pkg/constants"
 	"github.com/square/p2/pkg/health"
 	"github.com/square/p2/pkg/logging"
 	"github.com/square/p2/pkg/manifest"
 	"github.com/square/p2/pkg/preparer"
 	"github.com/square/p2/pkg/store/consul"
 	"github.com/square/p2/pkg/types"
-	"github.com/square/p2/pkg/util/param"
 )
 
 // These constants should probably all be something the p2 user can set
@@ -19,9 +19,6 @@ import (
 
 // Duration between health checks
 const HEALTHCHECK_INTERVAL = 1 * time.Second
-
-// Maximum allowed time for a single check, in seconds
-var HEALTHCHECK_TIMEOUT = param.Int64("healthcheck_timeout", 5)
 
 // Contains method for watching the consul reality store to
 // track services running on a node. A manager method:
@@ -85,12 +82,12 @@ func MonitorPodHealth(config *preparer.PreparerConfig, logger *logging.Logger, s
 
 	// if GetClient fails it means the certfile/keyfile/cafile were
 	// invalid or did not exist. It makes sense to throw a fatal error
-	secureClient, err := config.GetClient(time.Duration(*HEALTHCHECK_TIMEOUT) * time.Second)
+	secureClient, err := config.GetClient(time.Duration(*constants.HEALTHCHECK_TIMEOUT) * time.Second)
 	if err != nil {
 		logger.WithError(err).Fatalln("failed to get http client for this preparer")
 	}
 
-	insecureClient, err := config.GetInsecureClient(time.Duration(*HEALTHCHECK_TIMEOUT) * time.Second)
+	insecureClient, err := config.GetInsecureClient(time.Duration(*constants.HEALTHCHECK_TIMEOUT) * time.Second)
 	if err != nil {
 		logger.WithError(err).Fatalln("failed to get http client for this preparer")
 	}


### PR DESCRIPTION
Introducing pod whitelist file, which contains a list of while list pods. Particular uses case is after an host is re imaged, there may still be some sticky apps' manifest remain in node's intent store,  previously, once p2-prepare boosts, it starts to watch intent store immediately and download and install the app binaries, even without other fundamentals of the host are ready. 
So here we introduces pod whitelist file, when p2-prepare is initialized, and before start normally working, we force p2-prepare to keep checking pod whitelist file, install all the pods in the whitelist, keep checking for update, until the pod whiltelist file is empty, which services as a signal that p2-prepare can proceed to play with it's full functionality. 