### PR TITLE
Revert vendor change in docker pkg container_exec.go

### DIFF
--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -128,8 +128,8 @@ func (l *Launchable) Disable() error {
 	}
 
 	// TODO: check if we need to set anything in this
-	execStartCheck := dockertypes.ExecStartCheck{}
-	hijackedResp, err := l.DockerClient.ContainerExecAttach(ctx, resp.ID, execStartCheck)
+	execConfig = dockertypes.ExecConfig{}
+	hijackedResp, err := l.DockerClient.ContainerExecAttach(ctx, resp.ID, execConfig)
 	if err != nil {
 		return util.Errorf("could not start PreStop exec process for container %s: %s", containerName, err)
 	}
@@ -294,8 +294,8 @@ func (l *Launchable) Launch(_ *runit.ServiceBuilder, _ runit.SV) error {
 		}
 
 		// TODO: check if we need to set anything in this
-		execStartCheck := dockertypes.ExecStartCheck{}
-		hijackedResp, err := l.DockerClient.ContainerExecAttach(ctx, resp.ID, execStartCheck)
+		execConfig = dockertypes.ExecConfig{}
+		hijackedResp, err := l.DockerClient.ContainerExecAttach(ctx, resp.ID, execConfig)
 		if err != nil {
 			return util.Errorf("could not start PostStart exec process for container %s: %s", containerName, err)
 		}

--- a/vendor/github.com/docker/docker/client/container_exec.go
+++ b/vendor/github.com/docker/docker/client/container_exec.go
@@ -35,7 +35,7 @@ func (cli *Client) ContainerExecStart(ctx context.Context, execID string, config
 // It returns a types.HijackedConnection with the hijacked connection
 // and the a reader to get output. It's up to the called to close
 // the hijacked connection by calling types.HijackedResponse.Close.
-func (cli *Client) ContainerExecAttach(ctx context.Context, execID string, config types.ExecStartCheck) (types.HijackedResponse, error) {
+func (cli *Client) ContainerExecAttach(ctx context.Context, execID string, config types.ExecConfig) (types.HijackedResponse, error) {
 	headers := map[string][]string{"Content-Type": {"application/json"}}
 	return cli.postHijacked(ctx, "/exec/"+execID+"/start", nil, config, headers)
 }

--- a/vendor/github.com/docker/docker/client/interface.go
+++ b/vendor/github.com/docker/docker/client/interface.go
@@ -39,7 +39,7 @@ type ContainerAPIClient interface {
 	ContainerCommit(ctx context.Context, container string, options types.ContainerCommitOptions) (types.IDResponse, error)
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (container.ContainerCreateCreatedBody, error)
 	ContainerDiff(ctx context.Context, container string) ([]container.ContainerChangeResponseItem, error)
-	ContainerExecAttach(ctx context.Context, execID string, config types.ExecStartCheck) (types.HijackedResponse, error)
+	ContainerExecAttach(ctx context.Context, execID string, config types.ExecConfig) (types.HijackedResponse, error)
 	ContainerExecCreate(ctx context.Context, container string, config types.ExecConfig) (types.IDResponse, error)
 	ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error)
 	ContainerExecResize(ctx context.Context, execID string, options types.ResizeOptions) error


### PR DESCRIPTION
- ContainerExecAttach takes wrong type but it doesn't matter for us since we pass an empty struct