### PR TITLE
Fix nil manifest dereference bug

### DIFF
--- a/pkg/pods/pod.go
+++ b/pkg/pods/pod.go
@@ -421,6 +421,10 @@ func (pod *Pod) Uninstall() error {
 		return err
 	}
 
+	if currentManifest == nil {
+		return nil
+	}
+
 	// only do this step if this pod has a docker launchable
 	dockerLaunchableFound := false
 	for _, launchableStanza := range currentManifest.GetLaunchableStanzas() {


### PR DESCRIPTION
The `currentManifest.GetLaunchableStanzas()` just below will cause a nil dereference panic if the current manifest is nil. There is nothing else this function needs to do if the manifest is nil, so we can return here.