### PR TITLE
Ignore ineligible nodes during in rolling updates

### DIFF
--- a/bin/p2-rctl/main.go
+++ b/bin/p2-rctl/main.go
@@ -470,7 +470,6 @@ func (r rctlParams) RollingUpdate(oldID, newID string, want, need int) {
 			session,
 			watchDelay,
 			alerting.NewNop(),
-			nil,   // note: this will cause a panic if one of the RCs is dynamic
 			false, // no audit logging
 			auditlogstore.ConsulStore{}, // no audit logging
 		).Run(ctx)

--- a/pkg/roll/farm.go
+++ b/pkg/roll/farm.go
@@ -12,7 +12,6 @@ import (
 	hclient "github.com/square/p2/pkg/health/client"
 	"github.com/square/p2/pkg/labels"
 	"github.com/square/p2/pkg/logging"
-	"github.com/square/p2/pkg/manifest"
 	p2metrics "github.com/square/p2/pkg/metrics"
 	"github.com/square/p2/pkg/rc"
 	"github.com/square/p2/pkg/rc/fields"
@@ -23,7 +22,6 @@ import (
 	"github.com/square/p2/pkg/store/consul/rcstore"
 	"github.com/square/p2/pkg/store/consul/rollstore"
 	"github.com/square/p2/pkg/store/consul/transaction"
-	"github.com/square/p2/pkg/types"
 	"github.com/square/p2/pkg/util"
 
 	"github.com/Sirupsen/logrus"
@@ -34,10 +32,6 @@ import (
 
 type Factory interface {
 	New(roll_fields.Update, logging.Logger, consul.Session) Update
-}
-
-type RCScheduler interface {
-	EligibleNodes(man manifest.Manifest, nodeSelector klabels.Selector) ([]types.NodeName, error)
 }
 
 type UpdateFactory struct {
@@ -53,8 +47,6 @@ type UpdateFactory struct {
 	Labeler             labeler
 	WatchDelay          time.Duration
 	Alerter             alerting.Alerter
-
-	scheduler RCScheduler
 
 	ShouldCreateAuditLogRecords bool
 	AuditLogStore               auditlogstore.ConsulStore
@@ -78,7 +70,6 @@ func NewUpdateFactory(
 	labeler labeler,
 	watchDelay time.Duration,
 	alerter alerting.Alerter,
-	scheduler RCScheduler,
 	auditLogStore auditlogstore.ConsulStore,
 	shouldCreateAuditLogRecords bool,
 ) UpdateFactory {
@@ -95,7 +86,6 @@ func NewUpdateFactory(
 		Labeler:                     labeler,
 		WatchDelay:                  watchDelay,
 		Alerter:                     alerter,
-		scheduler:                   scheduler,
 		AuditLogStore:               auditLogStore,
 		ShouldCreateAuditLogRecords: shouldCreateAuditLogRecords,
 	}
@@ -118,7 +108,6 @@ func (f UpdateFactory) New(u roll_fields.Update, l logging.Logger, session consu
 		session,
 		f.WatchDelay,
 		f.Alerter,
-		f.scheduler,
 		f.ShouldCreateAuditLogRecords,
 		f.AuditLogStore,
 	)

--- a/pkg/roll/integration_test.go
+++ b/pkg/roll/integration_test.go
@@ -304,7 +304,6 @@ func TestLockRCs(t *testing.T) {
 		session,
 		0,
 		nil,
-		nil,
 		false,
 		auditlogstore.ConsulStore{},
 	).(*update)


### PR DESCRIPTION
Because rolling updates and node transfers can no longer occur at the
same time, marking a node as ineligible during a rolling update can
cause a "deadlock" where the roll cannot move forward because an
ineligible does not count as healthy.