### PR TITLE
Allow some node transfers during rolling updates

### DIFF
--- a/pkg/rc/replication_controller.go
+++ b/pkg/rc/replication_controller.go
@@ -792,7 +792,7 @@ func (rc *replicationController) retryAllocate(rcFields fields.RC, attempts int)
 		time.Sleep(backoff)
 		nodes, err := rc.scheduler.AllocateNodes(rcFields.Manifest, rcFields.NodeSelector, 1, true)
 		if err != nil {
-			rc.logger.WithError(err).Errorln("node transfer allocate attempt %d failed", i+1)
+			rc.logger.WithError(err).Errorf("node transfer allocate attempt %d failed", i+1)
 			continue
 		} else if len(nodes) < 1 {
 			rc.logger.Errorln("node transfer allocate attempt %d allocated no nodes", i+1)
@@ -812,7 +812,7 @@ func (rc *replicationController) retryDeallocate(rcFields fields.RC, ineligible 
 		time.Sleep(backoff)
 		err := rc.scheduler.DeallocateNodes(rcFields.NodeSelector, []types.NodeName{ineligible})
 		if err != nil {
-			rc.logger.WithError(err).Errorln("node transfer deallocate attempt %d failed", i+1)
+			rc.logger.WithError(err).Errorf("node transfer deallocate attempt %d failed", i+1)
 			continue
 		}
 		return nil

--- a/pkg/rc/replication_controller_test.go
+++ b/pkg/rc/replication_controller_test.go
@@ -1125,7 +1125,7 @@ func TestNodeTransferNoopIfLockHeld(t *testing.T) {
 	}
 	rc.healthChecker = fake_checker.NewSingleService("some_pod", healthMap)
 
-	ok, err := rc.attemptNodeTransfer(rcFields, current, "node2", 1)
+	ok, err := rc.attemptNodeTransfer(rcFields, current, []types.NodeName{"node2"}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1199,7 +1199,7 @@ func TestNodeTransferNoopIfPodsUnhealthy(t *testing.T) {
 	}
 	rc.healthChecker = fake_checker.NewSingleService("some_pod", healthMap)
 
-	ok, err := rc.attemptNodeTransfer(rcFields, current, "node2", 1)
+	ok, err := rc.attemptNodeTransfer(rcFields, current, []types.NodeName{"node2"}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1343,7 +1343,7 @@ func TestNodeTransferAlertsIfAllocationsFail(t *testing.T) {
 	}
 	rc.healthChecker = fake_checker.NewSingleService("some_pod", healthMap)
 
-	_, err = rc.attemptNodeTransfer(rcFields, current, "node2", 1)
+	_, err = rc.attemptNodeTransfer(rcFields, current, []types.NodeName{"node2"}, 1)
 	if err == nil {
 		t.Fatal("expected allocation error")
 	}


### PR DESCRIPTION
Specifically, when the old RC has only ineligible nodes and replicas that it does not desire.