### PR TITLE
Set IdleConnTimeout on http transport

### DIFF
--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -184,6 +184,9 @@ type PreparerConfig struct {
 	// clients, e.g. consul client vs artifact downloader
 	HTTPTimeout time.Duration `yaml:"http_timeout"`
 
+	// IdleConnTimeout will be set on the preparer's HTTP client transport.
+	IdleConnTimeout time.Duration `yaml:"idle_conn_timeout"`
+
 	// Use a single Store so that all requests go through the same HTTP client.
 	consulClientMux sync.Mutex
 	consulClient    consulutil.ConsulClient
@@ -337,6 +340,12 @@ func (c *PreparerConfig) getClient(
 		cxnTimeout = 30 * time.Second
 	}
 
+	idleConnTimeout := c.IdleConnTimeout
+	if idleConnTimeout == time.Duration(0*time.Second) {
+		// Not set in manifest
+		idleConnTimeout = time.Duration(90 * time.Second)
+	}
+
 	tlsConfig.InsecureSkipVerify = insecureSkipVerify
 	transport := &http.Transport{
 		TLSClientConfig: tlsConfig,
@@ -345,6 +354,7 @@ func (c *PreparerConfig) getClient(
 			Timeout:   cxnTimeout,
 			KeepAlive: cxnTimeout,
 		}).Dial,
+		IdleConnTimeout: idleConnTimeout,
 	}
 	if c.HTTP2 {
 		if err = http2.ConfigureTransport(transport); err != nil {


### PR DESCRIPTION
We can also use this PR to discuss setting other fields like `MaxIdleConns` that people see as helpful to reduce the number of connections the preparer keeps open to Consul.