### PR TITLE
Support unix socket http client in p2-preparer

### DIFF
--- a/pkg/util/net/socket/http_client.go
+++ b/pkg/util/net/socket/http_client.go
@@ -1,0 +1,74 @@
+package socket
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/square/p2/pkg/util"
+)
+
+// UnixSocketTransport provides an http.RoundTripper that wraps around another
+// RoundTripper, adding needed metadata to each request
+type UnixSocketTransport struct {
+	// Transport does the actual work of sending the HTTP requests after
+	// UnixSocketTransport rewrites certain request metadata
+	*http.Transport
+
+	// The name of Consul added as the request host header
+	ConsulHost string
+}
+
+// RoundTrip implements the http.RoundTripper interface. It modifies the HTTP
+// request to inject the necessary request metadata for the request to be
+// route the request to the right place. The modified HTTP request is then
+// passed to the wrapped *http.Transport (also an implementation of
+// RoundTripper).
+func (t UnixSocketTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	// Set the scheme to "http" because we're talking to a unix socket protected
+	// with filesystem permissions, so we don't need or want TLS
+	r.URL.Scheme = "http"
+
+	// Encode Consul name in the host header for the request to be routed on
+	r.Host = t.ConsulHost
+
+	// Perform the actual HTTP request
+	return t.Transport.RoundTrip(r)
+}
+
+// NewHTTPClient returns an *http.Client which will send all HTTP requests to the unix socket at socketPath,
+// and will encode the proper request metadata to make all requests route to Consul
+func NewHTTPClient(socketPath, consulHost string) *http.Client {
+	return &http.Client{
+		Transport: NewTransport(socketPath, consulHost),
+		// 6 minutes is slightly higher than the wait time we use on consul watches of
+		// 5 minutes. We expect that a response might not come back for up to 5
+		// minutes, but we shouldn't wait much longer than that
+		Timeout: 6 * time.Minute,
+	}
+}
+
+func NewTransport(socketPath, consulHost string) http.RoundTripper {
+	return UnixSocketTransport{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network string, addr string) (net.Conn, error) {
+				return net.DialUnix("unix", nil, &net.UnixAddr{
+					Net:  "unix",
+					Name: socketPath,
+				})
+			},
+		},
+		ConsulHost: consulHost,
+	}
+}
+
+func Path(pathEnvVar string) (string, error) {
+	path := os.Getenv(pathEnvVar)
+	if path == "" {
+		return "", util.Errorf("%s is not set", pathEnvVar)
+	}
+
+	return path, nil
+}

--- a/pkg/util/net/socket/http_client_test.go
+++ b/pkg/util/net/socket/http_client_test.go
@@ -1,0 +1,112 @@
+package socket
+
+import (
+	"context"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/square/p2/pkg/util"
+)
+
+func startUnixHTTPServer(ctx context.Context, socketPath string, handlerFunc http.HandlerFunc) error {
+	ln, err := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		<-ctx.Done()
+		ln.Close()
+	}()
+
+	return http.Serve(ln, handler{handlerFunc: handlerFunc})
+}
+
+type handler struct {
+	handlerFunc http.HandlerFunc
+}
+
+func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.handlerFunc(w, r)
+}
+
+func TestClient(t *testing.T) {
+	// Need to use /tmp because TMPDIR ends up giving us a socket path that is
+	// greater than the max socket path length
+	tempDir, err := ioutil.TempDir("/tmp", "test_http_client")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	socketPath := filepath.Join(tempDir, "test_http.sock")
+
+	client := NewHTTPClient(socketPath, "consul-production")
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	reqCh := make(chan http.Request)
+	defer close(reqCh)
+	serverErrCh := make(chan error)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer close(serverErrCh)
+		defer wg.Done()
+		err := startUnixHTTPServer(ctx, socketPath, func(w http.ResponseWriter, r *http.Request) {
+			reqCh <- *r
+		})
+		if err != nil {
+			serverErrCh <- err
+		}
+	}()
+
+	clientErrCh := make(chan error)
+	defer close(clientErrCh)
+
+	wg.Add(1)
+	go func() {
+		// sigh, give the server some time to start
+		time.Sleep(1 * time.Millisecond)
+
+		defer wg.Done()
+		resp, err := client.Get("http://whatever/foo/bar")
+		if err != nil {
+			clientErrCh <- util.Errorf("HTTP request via socket client unexpectedly failed: %s", err)
+			return
+		}
+		defer resp.Body.Close()
+	}()
+
+	var req http.Request
+	select {
+	case req = <-reqCh:
+		t.Log("got a request!")
+	case err := <-serverErrCh:
+		t.Fatalf("got unexpected error running HTTP server: %s", err)
+	case err := <-clientErrCh:
+		t.Fatalf("got unexpected error making HTTP request: %s", err)
+	}
+	cancel()
+
+	expectedHost := "consul-production"
+	if req.Host != expectedHost {
+		t.Errorf("expected request's Host field to be rewritten to %q but was %q", expectedHost, req.Host)
+	}
+	if req.URL.Path != "/foo/bar" {
+		t.Errorf("the request's path was rewritten to %q", req.URL.Path)
+	}
+
+	// drain server error channel (we expect it to error when we close the listener)
+	for range serverErrCh {
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
~~This is an initial, MVP for deploying an Envoy sidecar launchable
alongside p2-preparer to handle HTTP traffic between preparers and
Consul. It works by using a custom Transport that sends requests to
the Envoy unix socket along with other request metadata Envoy needs to
route the request to Consul.~~

This is largely shamelessly stolen from @mpuncel's prior work in configuring an Envoy-compatibile Go HTTP client internally at Square.

This commit adds new http client sends requests to a unix socket
specified by an environment variable in the preparer's pod manifest.
When the environment variable is set in the manifest, outbound requests
to Consul will be sent to the socket.