### PR TITLE
Check service discovery synced before node swap

### DIFF
--- a/bin/p2-rctl-server/main.go
+++ b/bin/p2-rctl-server/main.go
@@ -134,6 +134,7 @@ func main() {
 		alerter,
 		1*time.Second,
 		artifactRegistry,
+		nil,
 	).Start(nil)
 	roll.NewFarm(
 		roll.UpdateFactory{

--- a/pkg/rc/farm.go
+++ b/pkg/rc/farm.go
@@ -103,6 +103,7 @@ type Farm struct {
 	rcWatchPauseTime time.Duration
 
 	artifactRegistry artifact.Registry
+	sdChecker        ServiceDiscoveryChecker
 }
 
 type childRC struct {
@@ -129,6 +130,7 @@ func NewFarm(
 	alerter alerting.Alerter,
 	rcWatchPauseTime time.Duration,
 	artifactRegistry artifact.Registry,
+	sdChecker ServiceDiscoveryChecker,
 ) *Farm {
 	if alerter == nil {
 		alerter = alerting.NewNop()
@@ -153,6 +155,7 @@ func NewFarm(
 		rcSelector:       rcSelector,
 		rcWatchPauseTime: rcWatchPauseTime,
 		artifactRegistry: artifactRegistry,
+		sdChecker:        sdChecker,
 	}
 }
 
@@ -282,6 +285,7 @@ START_LOOP:
 					rcf.alerter,
 					rcf.healthChecker,
 					rcf.artifactRegistry,
+					rcf.sdChecker,
 				)
 				childQuit := make(chan struct{})
 				rcf.children[rcKey.ID] = childRC{


### PR DESCRIPTION
Systems that have a delay between changes to P2 pod cluster membership
and changes to the membership of their service discovery and load
balancing systems should not let those two diverge further through node
transfers.

The RC Farm now accepts the ServiceDiscoveryChecker interface, and RC's
will call its IsSyncedToCluster() function to ensure that the service
discovery system is synced enough to support a transfer.