### PR TITLE
increase TestHookRunWithTimeout from 1 msec to 1 sec

### DIFF
--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -97,11 +97,11 @@ func testManifest() manifest.Manifest {
 }
 
 func TestHookRunWithTimeout(t *testing.T) {
-	timeout := 1 * time.Millisecond
-	sleep := "1" // 1 second sleep to be executed by the script
+	timeout := 1 * time.Second
+	sleep := "5" // Wait longer than hook timeout to trigger failure
 
 	// build an executable file to feed to Hook
-	contents := []byte("#!/bin/bash\nsleep " + sleep)
+	contents := []byte("#!/usr/bin/env sh\nsleep " + sleep)
 
 	tmpFile, err := tempFileWithContents("test-hook-run-with-timeout.", contents)
 	if err != nil {


### PR DESCRIPTION
- Fix issue when timeout is 1 ms. This results in the file being cleaned up before it is fsync() to the filesystem resulting in the temp script missing and thus can't be executed.
- Ensure hook script executes longer than 1 sec.
- Use `/usr/bin/env sh` for the hook script. Using `env` is the standard why of calling environments and platform agnostic. Switching to `sh` because we don't need a full bash environment.