### PR TITLE
Add extra Consul headers config

### DIFF
--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -170,6 +170,10 @@ type PreparerConfig struct {
 	// requests when the preparer is configured to dial a unix socket for
 	// communication with Consul
 	ConsulHost string `yaml:"consul_host_header,omitempty"`
+	// AdditionalConsulHeaders will all be set as headers for Consul requests
+	// when the preparer is configured to dial a unix socket for Consul
+	// communication
+	AdditionalConsulHeaders map[string]string `yaml:"additional_consul_headers"`
 
 	// Directories that are allowed to be launched by this preparer
 	DockerImageDirectoryWhitelist []string     `yaml:"docker_image_directory_whitelist,omitempty"`
@@ -319,7 +323,7 @@ func (c *PreparerConfig) getOpts() (consul.Options, error) {
 		if err != nil {
 			return consul.Options{}, err
 		}
-		client = socket.NewHTTPClient(socketPath, c.ConsulHost)
+		client = socket.NewHTTPClient(socketPath, c.ConsulHost, c.AdditionalConsulHeaders)
 	} else if c.ConsulHttps {
 		client, err = c.GetClient(30 * time.Second) // 30 seconds is the net/http default
 		if err != nil {

--- a/pkg/util/net/socket/http_client_test.go
+++ b/pkg/util/net/socket/http_client_test.go
@@ -47,7 +47,7 @@ func TestClient(t *testing.T) {
 
 	socketPath := filepath.Join(tempDir, "test_http.sock")
 
-	client := NewHTTPClient(socketPath, "consul-production")
+	client := NewHTTPClient(socketPath, "consul-production", nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 


### PR DESCRIPTION
When the preparer is communicating with Consul through a unix socket,
there is now an additional manifest config that will allow the preparer
to add any additional headers to all requests to Consul.