### PR TITLE
add feature to mark platform hooks as required in preparer config

### DIFF
--- a/bin/p2-run-hooks/main.go
+++ b/bin/p2-run-hooks/main.go
@@ -71,8 +71,10 @@ func main() {
 		}
 	}
 
+	hooksRequired := []string{}
+
 	log.Printf("About to run %s hooks for pod %s\n", hookType, pod.Home())
-	err = dir.RunHookType(hookType, pod, podManifest)
+	err = dir.RunHookType(hookType, pod, podManifest, hooksRequired)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -52,6 +52,10 @@ status:
 `
 }
 
+func testRequiredHooksList() []string {
+	return []string{"req-hook", "some-other-req-hook"}
+}
+
 func testPodOldStatus() string {
 	return `id: thepod
 launchables:

--- a/pkg/preparer/setup.go
+++ b/pkg/preparer/setup.go
@@ -107,6 +107,9 @@ type Preparer struct {
 	// The directory that will actually be executed by the HookDir
 	hooksExecDir string
 
+	// List of required hooks
+	hooksRequired []string
+
 	// base64 encoding of docker authConfig needed for ImagePull
 	containerRegistryAuthStr string
 
@@ -188,6 +191,9 @@ type PreparerConfig struct {
 	// The pod manifest to use for hooks. If no hooks are desired, use the
 	// NoHooksSentinelValue constant to indicate that there aren't any
 	HooksManifest string `yaml:"hooks_manifest,omitempty"`
+
+	// List of required hooks. Otherwise a deploy should retry.
+	HooksRequired []string `yaml:"hooks_required"`
 
 	// Configures reporting the exit status of processes started by a pod to Consul
 	PodProcessReporterConfig podprocess.ReporterConfig `yaml:"process_result_reporter_config"`
@@ -677,6 +683,7 @@ func New(preparerConfig *PreparerConfig, logger logging.Logger) (*Preparer, erro
 		hooksManifest:                 hooksManifest,
 		hooksPod:                      hooksPod,
 		hooksExecDir:                  preparerConfig.HooksDirectory,
+		hooksRequired:                 preparerConfig.HooksRequired,
 		fetcher:                       fetcher,
 	}, nil
 }

--- a/pkg/preparer/setup_test.go
+++ b/pkg/preparer/setup_test.go
@@ -39,6 +39,7 @@ func TestLoadConfigWillMarshalYaml(t *testing.T) {
 	Assert(t).AreEqual("/etc/p2/hooks", preparerConfig.HooksDirectory, "did not read the hooks directory correctly")
 	Assert(t).AreEqual("/etc/p2.keyring", preparerConfig.Auth["keyring"], "did not read the keyring path correctly")
 	Assert(t).AreEqual(1, len(preparerConfig.ExtraLogDestinations), "should have picked up 1 log destination")
+	Assert(t).AreEqual(1, len(preparerConfig.HooksRequired), "should have picked up 1 required hook")
 
 	destination := preparerConfig.ExtraLogDestinations[0]
 	Assert(t).AreEqual(logging.OutSocket, destination.Type, "should have been the socket type")

--- a/pkg/preparer/test_preparer_config.yaml
+++ b/pkg/preparer/test_preparer_config.yaml
@@ -17,3 +17,5 @@ preparer:
     - touch
     - /tmp/process_did_finish
   require_file: /dev/shm/p2-may-run
+  hooks_required:
+  - basename__req-hook


### PR DESCRIPTION
Adding a feature to add a required list of p2-preparer hooks. The executed hook will be checked against `hooks_required: []` if it fails to see if the `err` should be returned. If the p2-preparer hook is not listed it should retain the previous functionality to log a warning and continue.

Simple preparer config:
```
id: hooks
launchables:
  req-hook:
  opt-hook:
config:
  hooks_required:
  - req-hook
```
This will result in failures to `req-hook` returning an err and `opt-hook` logging but continuing.