### PR TITLE
Ensure session cleanup is done consistently

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,7 @@ end
 
 desc 'Test all projects (short only)'
 task :test => [:build] do
-  e "go test -ldflags -s -short -timeout 20s ./..."
+  e "go test -ldflags -s -short -timeout 30s ./..."
 end
 
 desc 'Test all projects'

--- a/integration/hello/hello.go
+++ b/integration/hello/hello.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 var port = flag.String("port", "", "port that hello should listen on")
@@ -72,7 +72,7 @@ func main() {
 	} else {
 		*port = ":" + *port
 	}
-	fmt.Printf("Hello is listening at %q", port)
+	fmt.Printf("Hello is listening at %q", *port)
 	http.HandleFunc("/", SayHello)
 	http.HandleFunc("/exit/", Exit)
 	s := &http.Server{

--- a/pkg/store/consul/consultest/fake_session.go
+++ b/pkg/store/consul/consultest/fake_session.go
@@ -62,6 +62,10 @@ func (u *fakeUnlocker) Key() string {
 	return u.key
 }
 
+func (u fakeUnlocker) DestroySession() error {
+	return u.session.Destroy()
+}
+
 func (f *fakeSession) Lock(key string) (consul.Unlocker, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/pkg/store/consul/session.go
+++ b/pkg/store/consul/session.go
@@ -212,6 +212,10 @@ func (u unlocker) Key() string {
 	return u.key
 }
 
+func (u unlocker) DestroySession() error {
+	return u.session.Destroy()
+}
+
 func (s session) continuallyRenew() {
 	defer close(s.renewalErrCh)
 	for {
@@ -236,6 +240,7 @@ func (s session) continuallyRenew() {
 type Unlocker interface {
 	Unlock() error
 	Key() string
+	DestroySession() error
 }
 
 type unlocker struct {


### PR DESCRIPTION
There were 2 session leaks found:
* When locking to do a node transfer, we were not cleaning up the session if we failed to get the lock.
* After returning to `attemptNodeTransfer()` from `canNodeTransfer()`, we were only unlocking the lock once complete and doing nothing with the underlying session object.

Also had to make a couple changes to improve tests:
* Increase the timeout for go tests as we were consistently exceeding the 20s timeout with the `pkg/rc/*.go` tests.
* Fix up the hello integration in the repo so `go test` would succeed.
* Modify test setup order in TestNodeTransferNoopIfLockHeld to remove surprise errors from the logs when that test does fail.