### PR TITLE
added customizable termination grace period for disable scritps

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"time"
 
 	"github.com/square/p2/pkg/artifact"
 	"github.com/square/p2/pkg/cgroups"
@@ -43,6 +44,7 @@ type Builder interface {
 	SetLaunchables(launchableStanzas map[launch.LaunchableID]launch.LaunchableStanza)
 	SetResourceLimits(limits ResourceLimitsStanza)
 	SetNodeRequirements(map[string]string)
+	SetTerminationGracePeriod(seconds int)
 }
 
 var _ Builder = builder{}
@@ -88,6 +90,7 @@ type Manifest interface {
 	Marshal() ([]byte, error)
 	SignatureData() (plaintext, signature []byte)
 	GetNodeRequirements() map[string]string
+	GetTerminationGracePeriod() time.Duration
 
 	GetBuilder() Builder
 }
@@ -100,18 +103,19 @@ type ResourceLimitsStanza struct {
 }
 
 type manifest struct {
-	Id                  types.PodID                                     `yaml:"id"` // public for yaml marshaling access. Use ID() instead.
-	RunAs               string                                          `yaml:"run_as,omitempty"`
-	LaunchableStanzas   map[launch.LaunchableID]launch.LaunchableStanza `yaml:"launchables"`
-	Config              map[interface{}]interface{}                     `yaml:"config"`
-	StatusPort          int                                             `yaml:"status_port,omitempty"`
-	StatusHTTP          bool                                            `yaml:"status_http,omitempty"`
-	Status              StatusStanza                                    `yaml:"status,omitempty"`
-	ResourceLimits      ResourceLimitsStanza                            `yaml:"resource_limits,omitempty"`
-	ReadOnly            *bool                                           `yaml:"readonly,omitempty"`
-	ArtifactRegistryURL string                                          `yaml:"artifact_registry,omitempty"`
-	NodeRequirements    map[string]string                               `yaml:"node_requirements,omitempty"`
-	MinHealthPercentage int                                             `yaml:"min_health_percentage,omitempty"`
+	Id                     types.PodID                                     `yaml:"id"` // public for yaml marshaling access. Use ID() instead.
+	RunAs                  string                                          `yaml:"run_as,omitempty"`
+	LaunchableStanzas      map[launch.LaunchableID]launch.LaunchableStanza `yaml:"launchables"`
+	Config                 map[interface{}]interface{}                     `yaml:"config"`
+	StatusPort             int                                             `yaml:"status_port,omitempty"`
+	StatusHTTP             bool                                            `yaml:"status_http,omitempty"`
+	Status                 StatusStanza                                    `yaml:"status,omitempty"`
+	ResourceLimits         ResourceLimitsStanza                            `yaml:"resource_limits,omitempty"`
+	ReadOnly               *bool                                           `yaml:"readonly,omitempty"`
+	ArtifactRegistryURL    string                                          `yaml:"artifact_registry,omitempty"`
+	NodeRequirements       map[string]string                               `yaml:"node_requirements,omitempty"`
+	MinHealthPercentage    int                                             `yaml:"min_health_percentage,omitempty"`
+	TerminationGracePeriod int                                             `yaml:"termination_grace_period,omitempty"`
 
 	// Used to track the original bytes so that we don't reorder them when
 	// doing a yaml.Unmarshal and a yaml.Marshal in succession
@@ -168,6 +172,10 @@ func (manifest *manifest) SetLaunchables(launchableStanzas map[launch.Launchable
 
 func (manifest *manifest) SetNodeRequirements(nodeRequirements map[string]string) {
 	manifest.NodeRequirements = nodeRequirements
+}
+
+func (manifest *manifest) SetTerminationGracePeriod(seconds int) {
+	manifest.TerminationGracePeriod = seconds
 }
 
 func (manifest *manifest) GetResourceLimits() ResourceLimitsStanza {
@@ -519,6 +527,10 @@ func (m manifest) SignatureData() (plaintext, signature []byte) {
 
 func (m manifest) GetNodeRequirements() map[string]string {
 	return m.NodeRequirements
+}
+
+func (m manifest) GetTerminationGracePeriod() time.Duration {
+	return time.Second * time.Duration(m.TerminationGracePeriod)
 }
 
 // ValidManifest checks the internal consistency of a manifest. Returns an error if the

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/square/p2/pkg/cgroups"
 	"github.com/square/p2/pkg/launch"
@@ -404,5 +405,16 @@ func TestSetNodeRequirements(t *testing.T) {
 	}
 	if val != "val1" {
 		t.Errorf("expected node requirement req1 to have value val1 but was %sa", val)
+	}
+}
+
+func TestSetTerminationGracePeriod(t *testing.T) {
+	b := NewBuilder()
+	b.SetID("foo")
+	b.SetTerminationGracePeriod(30)
+	man := b.GetManifest()
+	duration := man.GetTerminationGracePeriod()
+	if duration != 30*time.Second {
+		t.Errorf("expected termination grace period to be equal to 30 minutes, but was %v", duration)
 	}
 }


### PR DESCRIPTION
Sometime disable scripts run for 2h blocking p2-preparer to proceed. We should add termination grace period and kill the disabling process when too long time consumed. Default set to 1 hour considering not affect current process, and added `termination_grace_period` field in pod manifest to enable customization.