### PR TITLE
modified the way to terminate disable script with commandContext

### DIFF
--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/square/p2/pkg/artifact"
 	"github.com/square/p2/pkg/auth"
 	"github.com/square/p2/pkg/cgroups"
@@ -100,7 +102,7 @@ func (hl *Launchable) IsOneoff() bool {
 	return hl.IsUUIDPod
 }
 
-func (hl *Launchable) Disable() error {
+func (hl *Launchable) Disable(gracePeriod time.Duration) error {
 	if hl.IsOneoff() {
 		// oneoff pods have nothing to disable/enable, they only run once and there's
 		// no server component
@@ -110,7 +112,7 @@ func (hl *Launchable) Disable() error {
 	// the error return from os/exec.Run is almost always meaningless
 	// ("exit status 1")
 	// since the output is more useful to the user, that's what we'll preserve
-	out, err := hl.disable()
+	out, err := hl.disable(gracePeriod)
 	if err != nil {
 		return launch.DisableError{Inner: util.Errorf("%s", out)}
 	}
@@ -166,7 +168,7 @@ func (hl *Launchable) Launch(serviceBuilder *runit.ServiceBuilder, sv runit.SV) 
 
 func (hl *Launchable) PostActivate() (string, error) {
 	// TODO: unexport this method (requires integrating BuildRunitServices into this API)
-	output, err := hl.InvokeBinScript("post-activate")
+	output, err := hl.InvokeBinScriptWithContext(context.Background(), "post-activate")
 
 	// providing a post-activate script is optional, ignore those errors
 	if err != nil && !os.IsNotExist(err) {
@@ -176,8 +178,10 @@ func (hl *Launchable) PostActivate() (string, error) {
 	return output, nil
 }
 
-func (hl *Launchable) disable() (string, error) {
-	output, err := hl.InvokeBinScript("disable")
+func (hl *Launchable) disable(gracePeriod time.Duration) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), gracePeriod)
+	defer cancel()
+	output, err := hl.InvokeBinScriptWithContext(ctx, "disable")
 
 	// providing a disable script is optional, ignore those errors
 	if err != nil && !os.IsNotExist(err) {
@@ -194,7 +198,7 @@ func (hl *Launchable) enable() (string, error) {
 		return "", nil
 	}
 
-	output, err := hl.InvokeBinScript("enable")
+	output, err := hl.InvokeBinScriptWithContext(context.Background(), "enable")
 
 	// providing an enable script is optional, ignore those errors
 	if err != nil && !os.IsNotExist(err) {
@@ -204,7 +208,15 @@ func (hl *Launchable) enable() (string, error) {
 	return output, nil
 }
 
+func (hl *Launchable) InvokeBinScriptWithContext(ctx context.Context, script string) (string, error) {
+	return hl.invokeBinScript(ctx, script)
+}
+
 func (hl *Launchable) InvokeBinScript(script string) (string, error) {
+	return hl.invokeBinScript(context.Background(), script)
+}
+
+func (hl *Launchable) invokeBinScript(ctx context.Context, script string) (string, error) {
 	cmdPath := filepath.Join(hl.InstallDir(), "bin", script)
 	_, err := os.Stat(cmdPath)
 	if err != nil {
@@ -225,7 +237,7 @@ func (hl *Launchable) InvokeBinScript(script string) (string, error) {
 		RequireFile:      hl.RequireFile,
 		ClearEnv:         true,
 	}
-	cmd := exec.Command(hl.P2Exec, p2ExecArgs.CommandLine()...)
+	cmd := exec.CommandContext(ctx, hl.P2Exec, p2ExecArgs.CommandLine()...)
 	buffer := bytes.Buffer{}
 	cmd.Stdout = &buffer
 	cmd.Stderr = &buffer

--- a/pkg/hoist/hoist_launchable.go
+++ b/pkg/hoist/hoist_launchable.go
@@ -168,7 +168,7 @@ func (hl *Launchable) Launch(serviceBuilder *runit.ServiceBuilder, sv runit.SV) 
 
 func (hl *Launchable) PostActivate() (string, error) {
 	// TODO: unexport this method (requires integrating BuildRunitServices into this API)
-	output, err := hl.InvokeBinScriptWithContext(context.Background(), "post-activate")
+	output, err := hl.InvokeBinScript("post-activate")
 
 	// providing a post-activate script is optional, ignore those errors
 	if err != nil && !os.IsNotExist(err) {
@@ -198,7 +198,7 @@ func (hl *Launchable) enable() (string, error) {
 		return "", nil
 	}
 
-	output, err := hl.InvokeBinScriptWithContext(context.Background(), "enable")
+	output, err := hl.InvokeBinScript("enable")
 
 	// providing an enable script is optional, ignore those errors
 	if err != nil && !os.IsNotExist(err) {

--- a/pkg/hoist/hoist_launchable_test.go
+++ b/pkg/hoist/hoist_launchable_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/anthonybishopric/gotcha"
 )
 
-var terminationGracePeriod = 1 * time.Hour
+var terminationGracePeriod = 1 * time.Minute
 
 func TestInstallDir(t *testing.T) {
 	tempDir := os.TempDir()
@@ -272,6 +272,15 @@ func TestNonexistentDisable(t *testing.T) {
 	expectedDisableOutput := ""
 
 	Assert(t).AreEqual(disableOutput, expectedDisableOutput, "Did not get expected output from test disable script")
+}
+
+func TestDisableWithLimitedTerminationGracePeriod(t *testing.T) {
+	// This test's behavior is not dependent on whether the pod is a legacy or uuid pod
+	hl, sb := FakeHoistLaunchableForDirLegacyPod("successful_scripts_test_hoist_launchable")
+	defer CleanupFakeLaunchable(hl, sb)
+
+	_, err := hl.disable(1 * time.Millisecond)
+	Assert(t).IsNotNil(err, "Expected disable to fail for this test, as the termination grace period is met")
 }
 
 func TestEnable(t *testing.T) {

--- a/pkg/hoist/hoist_launchable_test.go
+++ b/pkg/hoist/hoist_launchable_test.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/square/p2/pkg/launch"
 	"github.com/square/p2/pkg/runit"
@@ -13,6 +14,8 @@ import (
 
 	. "github.com/anthonybishopric/gotcha"
 )
+
+var terminationGracePeriod = 1 * time.Hour
 
 func TestInstallDir(t *testing.T) {
 	tempDir := os.TempDir()
@@ -232,7 +235,7 @@ func TestDisable(t *testing.T) {
 	hl, sb := FakeHoistLaunchableForDirLegacyPod("successful_scripts_test_hoist_launchable")
 	defer CleanupFakeLaunchable(hl, sb)
 
-	disableOutput, err := hl.disable()
+	disableOutput, err := hl.disable(terminationGracePeriod)
 	Assert(t).IsNil(err, "Got an unexpected error when calling disable on the test hoist launchable")
 
 	expectedDisableOutput := "disable invoked"
@@ -247,7 +250,7 @@ func TestFailingDisable(t *testing.T) {
 	hl, sb := FakeHoistLaunchableForDirLegacyPod("failing_scripts_test_hoist_launchable")
 	defer CleanupFakeLaunchable(hl, sb)
 
-	disableOutput, err := hl.disable()
+	disableOutput, err := hl.disable(terminationGracePeriod)
 	Assert(t).IsNotNil(err, "Expected disable to fail for this test, but it didn't")
 
 	expectedDisableOutput := "Error: this script failed"
@@ -263,7 +266,7 @@ func TestNonexistentDisable(t *testing.T) {
 	hl, sb := FakeHoistLaunchableForDirLegacyPod("nonexistent_scripts_test_hoist_launchable")
 	defer CleanupFakeLaunchable(hl, sb)
 
-	disableOutput, err := hl.disable()
+	disableOutput, err := hl.disable(terminationGracePeriod)
 	Assert(t).IsNil(err, "Got an unexpected error when calling disable on the test hoist launchable")
 
 	expectedDisableOutput := ""
@@ -410,7 +413,7 @@ func TestNoDisableForUUIDPods(t *testing.T) {
 
 	// If disable actually gets run, we'll get an error because we chose the launchable
 	// with failing scripts
-	err := hl.Disable()
+	err := hl.Disable(terminationGracePeriod)
 	if err != nil {
 		t.Error("disable script shouldn't have run for a uuid pod")
 	}
@@ -419,7 +422,7 @@ func TestNoDisableForUUIDPods(t *testing.T) {
 func TestDisableWithFailingDisable(t *testing.T) {
 	// This test's behavior is not dependent on whether the pod is a legacy or uuid pod
 	hl, _ := FakeHoistLaunchableForDirLegacyPod("failing_scripts_test_hoist_launchable")
-	err := hl.Disable()
+	err := hl.Disable(terminationGracePeriod)
 	Assert(t).IsNotNil(err, "Expected error while disabling")
 	_, ok := err.(launch.DisableError)
 	Assert(t).IsTrue(ok, "Expected disable error to be returned")
@@ -428,7 +431,7 @@ func TestDisableWithFailingDisable(t *testing.T) {
 func TestDisableWithPassingDisable(t *testing.T) {
 	// This test's behavior is not dependent on whether the pod is a legacy or uuid pod
 	hl, _ := FakeHoistLaunchableForDirLegacyPod("successful_scripts_test_hoist_launchable")
-	err := hl.Disable()
+	err := hl.Disable(terminationGracePeriod)
 	Assert(t).IsNil(err, "Expected disable to succeed")
 }
 

--- a/pkg/hoist/successful_scripts_test_hoist_launchable/installs/testLaunchable_abc123/bin/disable
+++ b/pkg/hoist/successful_scripts_test_hoist_launchable/installs/testLaunchable_abc123/bin/disable
@@ -1,2 +1,4 @@
 #!/bin/bash
+echo "sleeping for 2 second to test termination grace period"
+sleep 0.005
 echo "disable invoked"

--- a/pkg/hoist/successful_scripts_test_hoist_launchable/installs/testLaunchable_abc123/bin/disable
+++ b/pkg/hoist/successful_scripts_test_hoist_launchable/installs/testLaunchable_abc123/bin/disable
@@ -1,4 +1,4 @@
 #!/bin/bash
-echo "sleeping for 2 second to test termination grace period"
+echo "sleeping for 5 milliseconds to test termination grace period"
 sleep 0.005
 echo "disable invoked"

--- a/pkg/launch/launchable.go
+++ b/pkg/launch/launchable.go
@@ -217,7 +217,7 @@ type Launchable interface {
 	// Launch begins execution.
 	Launch(serviceBuilder *runit.ServiceBuilder, sv runit.SV) error
 	// Disable allows a launchable to stop work and do cleanup prior to Stop
-	Disable() error
+	Disable(gracePeriod time.Duration) error
 	// Stop stops execution.
 	Stop(serviceBuilder *runit.ServiceBuilder, sv runit.SV, force bool) error
 	// MakeCurrent adjusts a "current" symlink for this launchable name to point to this

--- a/pkg/opencontainer/containers.go
+++ b/pkg/opencontainer/containers.go
@@ -368,7 +368,7 @@ func (l *Launchable) stop(serviceBuilder *runit.ServiceBuilder, sv runit.SV) err
 	return nil
 }
 
-func (l *Launchable) Disable() error {
+func (l *Launchable) Disable(gracePeriod time.Duration) error {
 	// "disable" script not supported for containers
 	return nil
 }


### PR DESCRIPTION
For hosit launchable, terminate the disable script when grace period is met;
for docker launchable, we do not need to terminate the disable process, just unblock the p2-preparer waiting for the disable script, and proceed killing the container.

Also not only for disable script, this commit enables p2 to have termination grace period on any step.