### PR TITLE
cgroup: decrease cpu period duration

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	CPUPeriod = 1000000 // one million microseconds
+	CPUPeriod = 100000 // one hundred thousand microseconds
 )
 
 // maps cgroup subsystems to their respective paths


### PR DESCRIPTION
When processes hit their CPU quota, they are throttled
for the remainder of the time in the configured period.
Pausing pods or launchables for up to 1 second is too
high and could lead to throughput drops.