### PR TITLE
Spliting Launch function

### DIFF
--- a/pkg/pods/pod_test.go
+++ b/pkg/pods/pod_test.go
@@ -331,7 +331,7 @@ func TestBuildRunitServices(t *testing.T) {
 
 	testManifest := manifest.NewBuilder()
 	testLaunchable := hl.If()
-	pod.buildRunitServices([]launch.Launchable{testLaunchable}, testManifest.GetManifest())
+	pod.BuildRunitServices([]launch.Launchable{testLaunchable}, testManifest.GetManifest())
 
 	bytes, err := ioutil.ReadFile(outFilePath)
 	if err != nil {


### PR DESCRIPTION
We need a case to just install pods but not start it.

I have split pod.Launch into 2 more functions.
1. PostActivate runs post activate for all launchables.
2. StartLaunchables starts up all launchables.
3. Made BuildRunitServices public