### PR TITLE
Get better logging from composite verifier process

### DIFF
--- a/pkg/auth/artifact_verifier.go
+++ b/pkg/auth/artifact_verifier.go
@@ -85,7 +85,7 @@ func (b *CompositeVerifier) VerifyHoistArtifact(localCopy *os.File, verification
 		err = b.buildVerifier.VerifyHoistArtifact(localCopy, verificationData)
 		if err != nil {
 			errstrings = append(errstrings, err.Error())
-			return util.Errorf("Could not verify hoist artifact: %v", errstrings)
+			return util.Errorf("Failed to verify hoist artifact: %v", errstrings)
 		}
 	}
 	return nil

--- a/pkg/auth/artifact_verifier.go
+++ b/pkg/auth/artifact_verifier.go
@@ -83,7 +83,11 @@ func (b *CompositeVerifier) VerifyHoistArtifact(localCopy *os.File, verification
 			return util.Errorf("Could not rewind localCopy %v back to start of file: %v", localCopy.Name(), err)
 		}
 		err = b.buildVerifier.VerifyHoistArtifact(localCopy, verificationData)
-		errstrings = append(errstrings, err.Error())
+		if err != nil {
+			errstrings = append(errstrings, err.Error())
+		} else {
+			return nil
+		}
 	}
 
 	if len(errstrings) > 0 {

--- a/pkg/auth/artifact_verifier.go
+++ b/pkg/auth/artifact_verifier.go
@@ -74,10 +74,10 @@ func NewCompositeVerifier(keyringPath string, fetcher uri.Fetcher, logger *loggi
 
 // Attempt manifest verification. If it fails, fallback to the build verifier.
 func (b *CompositeVerifier) VerifyHoistArtifact(localCopy *os.File, verificationData VerificationData) error {
-	var errstrings []string
 	err := b.manVerifier.VerifyHoistArtifact(localCopy, verificationData)
-	errstrings = append(errstrings, err.Error())
-	if len(errstrings) > 0 {
+	if err != nil {
+		var errstrings []string
+		errstrings = append(errstrings, err.Error())
 		_, err = localCopy.Seek(0, os.SEEK_SET)
 		if err != nil {
 			return util.Errorf("Could not rewind localCopy %v back to start of file: %v", localCopy.Name(), err)
@@ -85,13 +85,8 @@ func (b *CompositeVerifier) VerifyHoistArtifact(localCopy *os.File, verification
 		err = b.buildVerifier.VerifyHoistArtifact(localCopy, verificationData)
 		if err != nil {
 			errstrings = append(errstrings, err.Error())
-		} else {
-			return nil
+			return util.Errorf("Could not verify hoist artifact: %v", errstrings)
 		}
-	}
-
-	if len(errstrings) > 0 {
-		return util.Errorf("Could not verify hoist artifact: %v", errstrings)
 	}
 	return nil
 }


### PR DESCRIPTION
Before, we failed to see the error message that triggers the fallback to the build verifier. By saving all the error strings, we are able to better inspect why we end up in the fallback.