### PR TITLE
Unregister metrics when stopping monitoring them

### DIFF
--- a/pkg/ds/farm.go
+++ b/pkg/ds/farm.go
@@ -580,6 +580,18 @@ func (dsf *Farm) spawnDaemonSet(
 			for {
 				select {
 				case <-ctx.Done():
+					for _, name := range ds.MetricNames("healthy") {
+						p2metrics.Registry.Unregister(name)
+					}
+					for _, name := range ds.MetricNames("critical") {
+						p2metrics.Registry.Unregister(name)
+					}
+					for _, name := range ds.MetricNames("unknown") {
+						p2metrics.Registry.Unregister(name)
+					}
+					for _, name := range ds.MetricNames("warning") {
+						p2metrics.Registry.Unregister(name)
+					}
 					return
 				case <-ticks.C:
 					eligible, err := ds.EligibleNodes()


### PR DESCRIPTION
I've noticed that multiple P2-master nodes emit these metrics, but only one is correct.

I think calling Unregister will stop them from being reported.